### PR TITLE
[WEB-4272] Add Pricing block

### DIFF
--- a/nextjs-app/app/components/BlockHeaderSection.tsx
+++ b/nextjs-app/app/components/BlockHeaderSection.tsx
@@ -26,7 +26,7 @@ interface BlockHeaderSectionProps {
     }
   }
   backgroundColor?: BackgroundTheme
-  headerAlignment?: Alignment.CENTER | Alignment.LEFT
+  headerAlignment?: Alignment.CENTER | Alignment.LEFT | Alignment.RIGHT
   className?: string
 }
 
@@ -38,11 +38,24 @@ export const BlockHeaderSection: React.FC<BlockHeaderSectionProps> = ({
 }) => {
   const textColor = TEXT_COLOR_MAP[backgroundColor]
   const isLeftAligned = headerAlignment === Alignment.LEFT
+  const isRightAligned = headerAlignment === Alignment.RIGHT
 
   const alignmentClasses = {
-    container: isLeftAligned ? 'items-start' : 'items-center',
-    text: isLeftAligned ? 'text-left' : 'text-center',
-    buttons: isLeftAligned ? 'justify-start' : 'justify-center',
+    container: isLeftAligned
+      ? 'items-start'
+      : isRightAligned
+        ? 'items-end'
+        : 'items-center',
+    text: isLeftAligned
+      ? 'text-left'
+      : isRightAligned
+        ? 'text-right'
+        : 'text-center',
+    buttons: isLeftAligned
+      ? 'justify-start'
+      : isRightAligned
+        ? 'justify-end'
+        : 'justify-center',
   }
 
   const primaryButton = header.primaryButton
@@ -52,7 +65,11 @@ export const BlockHeaderSection: React.FC<BlockHeaderSectionProps> = ({
   const hasDarkBackground = backgroundColor === BackgroundTheme.DARK
 
   const buttonMobileBase = 'w-full flex sm:w-auto'
-  const buttonMobileJustify = isLeftAligned ? 'justify-start' : 'justify-center'
+  const buttonMobileJustify = isLeftAligned
+    ? 'justify-start'
+    : isRightAligned
+      ? 'justify-end'
+      : 'justify-center'
 
   return (
     <div className={`w-full ${className}`}>

--- a/nextjs-app/app/components/BlockRenderer.tsx
+++ b/nextjs-app/app/components/BlockRenderer.tsx
@@ -11,6 +11,7 @@ import CTACardBlock from '@/app/components/CTACardBlock'
 import FAQBlock from '@/app/components/FAQBlock'
 import StepperBlock from '@/app/components/StepperBlock'
 import PricingBlock from '@/app/components/pricing/PricingBlock'
+import HeroBlock from '@/app/components/hero/HeroBlock'
 
 type BlocksType = {
   [key: string]: React.FC<any>
@@ -39,6 +40,7 @@ const Blocks: BlocksType = {
   faqBlock: FAQBlock,
   stepperBlock: StepperBlock,
   pricingBlock: PricingBlock,
+  heroBlock: HeroBlock,
 }
 
 /**

--- a/nextjs-app/app/components/BlockRenderer.tsx
+++ b/nextjs-app/app/components/BlockRenderer.tsx
@@ -10,6 +10,7 @@ import FeatureModules from '@/app/components/FeatureModules'
 import CTACardBlock from '@/app/components/CTACardBlock'
 import FAQBlock from '@/app/components/FAQBlock'
 import StepperBlock from '@/app/components/StepperBlock'
+import PricingBlock from '@/app/components/pricing/PricingBlock'
 
 type BlocksType = {
   [key: string]: React.FC<any>
@@ -37,6 +38,7 @@ const Blocks: BlocksType = {
   ctaCardBlock: CTACardBlock,
   faqBlock: FAQBlock,
   stepperBlock: StepperBlock,
+  pricingBlock: PricingBlock,
 }
 
 /**

--- a/nextjs-app/app/components/LinkButton.tsx
+++ b/nextjs-app/app/components/LinkButton.tsx
@@ -28,7 +28,11 @@ export const LinkButton: React.FC<LinkButtonProps> = ({
 
   return (
     <Link href={url} target={target} className={`inline-block ${className}`}>
-      <Button iconPosition={iconPosition} variant={variant}>
+      <Button
+        iconPosition={iconPosition}
+        variant={variant}
+        className={className}
+      >
         {ButtonIcon && <ButtonIcon className="mr-2 h-4 w-4" />}
         {label}
       </Button>

--- a/nextjs-app/app/components/LinkButton.tsx
+++ b/nextjs-app/app/components/LinkButton.tsx
@@ -13,6 +13,7 @@ interface LinkButtonProps {
   iconPosition?: IconPosition
   target?: LinkTarget
   className?: string
+  buttonClassName?: string
 }
 
 export const LinkButton: React.FC<LinkButtonProps> = ({
@@ -23,6 +24,7 @@ export const LinkButton: React.FC<LinkButtonProps> = ({
   iconPosition = IconPosition.LEFT,
   target = LinkTarget.BLANK,
   className = '',
+  buttonClassName = '',
 }) => {
   const ButtonIcon = icon ? getLucideIcon(icon) : null
 
@@ -31,7 +33,7 @@ export const LinkButton: React.FC<LinkButtonProps> = ({
       <Button
         iconPosition={iconPosition}
         variant={variant}
-        className={className}
+        className={buttonClassName}
       >
         {ButtonIcon && <ButtonIcon className="mr-2 h-4 w-4" />}
         {label}

--- a/nextjs-app/app/components/ValuePropDefaultColumn.tsx
+++ b/nextjs-app/app/components/ValuePropDefaultColumn.tsx
@@ -16,31 +16,33 @@ export const ValuePropDefaultColumn: React.FC<ValuePropDefaultColumnProps> = ({
 }) => {
   return (
     <div
-      className={`flex-1 basis-1/2 rounded-3xl p-5 sm:p-8 xl:p-12 ${className}`}
+      className={`flex-1 basis-1/2 rounded-3xl p-5 sm:p-8 xl:p-12 flex flex-col ${className}`}
       style={{ backgroundColor: column.backgroundColor }}
     >
-      <h3 className="text-[40px] font-semibold text-gray-900 mb-8 leading-tight">
-        {column.title}
-      </h3>
+      <div className="flex-grow">
+        <h3 className="text-[40px] font-semibold text-gray-900 mb-8 leading-tight">
+          {column.title}
+        </h3>
 
-      <div className="space-y-6 mb-8">
-        {column.items.map((item, itemIndex) => {
-          const ItemIcon = getLucideIcon(item.icon)
+        <div className="space-y-6 mb-8">
+          {column.items.map((item, itemIndex) => {
+            const ItemIcon = getLucideIcon(item.icon)
 
-          return (
-            <div key={itemIndex} className="flex items-start gap-4">
-              <div className="flex-shrink-0 w-12 h-12 bg-white rounded-full flex items-center justify-center">
-                <ItemIcon className="w-5 h-5 text-gray-700" />
+            return (
+              <div key={itemIndex} className="flex items-start gap-4">
+                <div className="flex-shrink-0 w-12 h-12 bg-white rounded-full flex items-center justify-center">
+                  <ItemIcon className="w-5 h-5 text-gray-700" />
+                </div>
+
+                <div className="flex-1 pt-1">
+                  <p className="text-lead text-[20px] text-gray-900 leading-relaxed">
+                    {item.text}
+                  </p>
+                </div>
               </div>
-
-              <div className="flex-1 pt-1">
-                <p className="text-lead text-[20px] text-gray-900 leading-relaxed">
-                  {item.text}
-                </p>
-              </div>
-            </div>
-          )
-        })}
+            )
+          })}
+        </div>
       </div>
 
       {column.button && column.button.label && column.button.url && (

--- a/nextjs-app/app/components/hero/HeroBlock.tsx
+++ b/nextjs-app/app/components/hero/HeroBlock.tsx
@@ -1,0 +1,112 @@
+import React from 'react'
+import {
+  BACKGROUND_COLOR_MAP,
+  BackgroundTheme,
+  ButtonVariant,
+} from '../../types/design-tokens'
+import { HeroLayout, Alignment } from '../../types/ui'
+import { HeroBlockProps, TransformedHeader } from '../../types/sanity'
+import { OverlayHero } from './OverlayHero'
+import { StandardHero } from './StandardHero'
+
+export const HeroBlock: React.FC<HeroBlockProps> = ({ block }) => {
+  const {
+    header,
+    headerAlignment = Alignment.CENTER,
+    backgroundTheme = BackgroundTheme.WHITE,
+    layout = HeroLayout.HEADER_ONLY,
+    image,
+    imageContained = false,
+  } = block
+
+  const alignmentEnum = headerAlignment as Alignment
+  const backgroundEnum = backgroundTheme as BackgroundTheme
+  const layoutEnum = layout as HeroLayout
+
+  const backgroundColor = BACKGROUND_COLOR_MAP[backgroundEnum]
+  const hasImage = Boolean(layoutEnum !== HeroLayout.HEADER_ONLY && image)
+
+  // TODO: Implement proper link resolution for url props, and unify block header props with other blocks to use SanityLink type
+  // JIRA: https://goodparty.atlassian.net/browse/WEB-4279
+  const transformedHeader: TransformedHeader = React.useMemo(
+    () => ({
+      overline: header.overline,
+      heading: header.heading,
+      subhead: header.subhead,
+      primaryButton: header.primaryButton
+        ? {
+            label: header.primaryButton.label,
+            url: '#', // TODO: Replace with resolveUrl(header.primaryButton) when WEB-4279 is implemented
+            icon: header.primaryButton.icon,
+            variant: header.primaryButton.variant as ButtonVariant,
+          }
+        : undefined,
+      secondaryButton: header.secondaryButton
+        ? {
+            label: header.secondaryButton.label,
+            url: '#', // TODO: Replace with resolveUrl(header.secondaryButton) when WEB-4279 is implemented
+            icon: header.secondaryButton.icon,
+            variant: header.secondaryButton.variant as ButtonVariant,
+          }
+        : undefined,
+    }),
+    [header],
+  )
+
+  const isOverlay =
+    layoutEnum === HeroLayout.IMAGE_FULL_WIDTH ||
+    layoutEnum === HeroLayout.IMAGE_CONTAINED
+
+  const isTwoColumn =
+    layoutEnum === HeroLayout.TWO_COLUMN_IMAGE_LEFT ||
+    layoutEnum === HeroLayout.TWO_COLUMN_IMAGE_RIGHT
+
+  const standardPadding = isTwoColumn && !imageContained ? 'py-0' : 'py-20'
+
+  const layoutClasses = isTwoColumn
+    ? `flex flex-col ${imageContained ? 'gap-12' : 'gap-0'} lg:grid lg:grid-cols-2 lg:gap-20 lg:items-center`
+    : isOverlay
+      ? 'relative'
+      : ''
+
+  const horizontalPaddingClasses =
+    isTwoColumn && !imageContained
+      ? 'px-0'
+      : isTwoColumn && imageContained
+        ? 'px-5 sm:px-10 xl:px-20 2xl:px-20'
+        : 'px-5 sm:px-10 xl:px-20 2xl:px-[clamp(80px,4vw,160px)]'
+
+  const headerMargin = isTwoColumn
+    ? imageContained
+      ? 'mb-5 sm:mb-10'
+      : 'my-5 sm:my-10'
+    : ''
+
+  return (
+    <section style={{ backgroundColor }}>
+      {isOverlay && hasImage && image ? (
+        <OverlayHero
+          layoutEnum={layoutEnum}
+          image={image}
+          transformedHeader={transformedHeader}
+          alignmentEnum={alignmentEnum}
+        />
+      ) : (
+        <StandardHero
+          horizontalPaddingClasses={horizontalPaddingClasses}
+          standardPadding={standardPadding}
+          layoutClasses={layoutClasses}
+          layoutEnum={layoutEnum}
+          headerMargin={headerMargin}
+          transformedHeader={transformedHeader}
+          backgroundEnum={backgroundEnum}
+          alignmentEnum={alignmentEnum}
+          hasImage={hasImage}
+          image={image}
+        />
+      )}
+    </section>
+  )
+}
+
+export default HeroBlock

--- a/nextjs-app/app/components/hero/HeroImage.tsx
+++ b/nextjs-app/app/components/hero/HeroImage.tsx
@@ -1,0 +1,61 @@
+import React from 'react'
+import Image from 'next/image'
+import { urlForImage } from '../../../sanity/lib/utils'
+import { HeroLayout } from '../../types/ui'
+import { SanityImage } from '../../types/sanity'
+
+interface HeroImageProps {
+  image: SanityImage
+  layout: HeroLayout
+}
+
+const DEFAULT_HERO_WIDTH = 1376
+const DEFAULT_HERO_HEIGHT = 800
+
+export const HeroImage: React.FC<HeroImageProps> = ({ image, layout }) => {
+  const imageUrl = urlForImage(image)?.url()
+
+  const isPriority =
+    layout === HeroLayout.IMAGE_FULL_WIDTH ||
+    layout === HeroLayout.IMAGE_CONTAINED
+
+  const layoutConfig = {
+    [HeroLayout.HEADER_ONLY]: {
+      imageClasses: 'h-auto',
+      containerClasses: '',
+    },
+    [HeroLayout.TWO_COLUMN_IMAGE_LEFT]: {
+      imageClasses: 'h-auto object-cover',
+      containerClasses: '',
+    },
+    [HeroLayout.TWO_COLUMN_IMAGE_RIGHT]: {
+      imageClasses: 'h-auto object-cover',
+      containerClasses: '',
+    },
+    [HeroLayout.IMAGE_FULL_WIDTH]: {
+      imageClasses: 'h-full object-cover min-h-[500px]',
+      containerClasses: 'h-full',
+    },
+    [HeroLayout.IMAGE_CONTAINED]: {
+      imageClasses: 'h-full',
+      containerClasses: 'h-full',
+    },
+  }[layout]
+
+  return (
+    <>
+      {imageUrl && (
+        <div className={`w-full ${layoutConfig.containerClasses}`}>
+          <Image
+            src={imageUrl}
+            alt={image.alt || ''}
+            width={DEFAULT_HERO_WIDTH}
+            height={DEFAULT_HERO_HEIGHT}
+            className={`w-full ${layoutConfig.imageClasses}`}
+            priority={isPriority}
+          />
+        </div>
+      )}
+    </>
+  )
+}

--- a/nextjs-app/app/components/hero/OverlayHero.tsx
+++ b/nextjs-app/app/components/hero/OverlayHero.tsx
@@ -1,0 +1,38 @@
+import React from 'react'
+import { BlockHeaderSection } from '../BlockHeaderSection'
+import { HeroImage } from './HeroImage'
+import { BackgroundTheme } from '../../types/design-tokens'
+import { HeroLayout, Alignment } from '../../types/ui'
+import { SanityImage, TransformedHeader } from '../../types/sanity'
+
+export const OverlayHero: React.FC<{
+  layoutEnum: HeroLayout
+  image: SanityImage
+  transformedHeader: TransformedHeader
+  alignmentEnum: Alignment
+}> = ({ layoutEnum, image, transformedHeader, alignmentEnum }) => (
+  <div className="relative min-h-[500px]">
+    {layoutEnum === HeroLayout.IMAGE_FULL_WIDTH ? (
+      <div className="absolute inset-0">
+        <HeroImage image={image} layout={layoutEnum} />
+      </div>
+    ) : (
+      <div className="absolute inset-0 flex justify-center px-5 sm:px-10 md:px-20">
+        <div className="w-full max-w-[1376px] py-5 sm:py-10 md:py-20">
+          <HeroImage image={image} layout={layoutEnum} />
+        </div>
+      </div>
+    )}
+    <div className="relative z-10 flex items-center justify-center min-h-[500px] px-10 md:px-20 py-20">
+      <div
+        className={`w-full max-w-4xl ${layoutEnum === HeroLayout.IMAGE_CONTAINED ? 'max-[1100px]:px-5' : ''}`}
+      >
+        <BlockHeaderSection
+          header={transformedHeader}
+          backgroundColor={BackgroundTheme.DARK}
+          headerAlignment={alignmentEnum}
+        />
+      </div>
+    </div>
+  </div>
+)

--- a/nextjs-app/app/components/hero/StandardHero.tsx
+++ b/nextjs-app/app/components/hero/StandardHero.tsx
@@ -1,0 +1,53 @@
+import React from 'react'
+import { BlockHeaderSection } from '../BlockHeaderSection'
+import { HeroImage } from './HeroImage'
+import { BackgroundTheme } from '../../types/design-tokens'
+import { HeroLayout, Alignment } from '../../types/ui'
+import { SanityImage, TransformedHeader } from '../../types/sanity'
+
+export const StandardHero: React.FC<{
+  horizontalPaddingClasses: string
+  standardPadding: string
+  layoutClasses: string
+  layoutEnum: HeroLayout
+  headerMargin: string
+  transformedHeader: TransformedHeader
+  backgroundEnum: BackgroundTheme
+  alignmentEnum: Alignment
+  hasImage: boolean
+  image: SanityImage | undefined
+}> = ({
+  horizontalPaddingClasses,
+  standardPadding,
+  layoutClasses,
+  layoutEnum,
+  headerMargin,
+  transformedHeader,
+  backgroundEnum,
+  alignmentEnum,
+  hasImage,
+  image,
+}) => (
+  <div className={`${horizontalPaddingClasses} ${standardPadding}`}>
+    <div className="mx-auto w-full max-w-[1376px]">
+      <div className={`${layoutClasses}`}>
+        <div
+          className={`${layoutEnum === HeroLayout.TWO_COLUMN_IMAGE_RIGHT ? 'lg:order-2' : ''} ${headerMargin}`}
+        >
+          <BlockHeaderSection
+            header={transformedHeader}
+            backgroundColor={backgroundEnum}
+            headerAlignment={alignmentEnum}
+          />
+        </div>
+        {hasImage && image && (
+          <div
+            className={`${layoutEnum === HeroLayout.TWO_COLUMN_IMAGE_LEFT ? 'lg:order-1' : ''}`}
+          >
+            <HeroImage image={image} layout={layoutEnum} />
+          </div>
+        )}
+      </div>
+    </div>
+  </div>
+)

--- a/nextjs-app/app/components/pricing/PricingBlock.module.css
+++ b/nextjs-app/app/components/pricing/PricingBlock.module.css
@@ -1,0 +1,20 @@
+.pricingGrid {
+  display: grid;
+  place-items: center;
+  gap: 3rem; /* 48px - same as gap-12 */
+  grid-template-columns: 1fr; /* Single column by default */
+}
+
+@media (min-width: 954px) {
+  .pricingGrid.twoCards {
+    grid-template-columns: 405px 405px;
+    justify-content: center;
+  }
+}
+
+@media (min-width: 1406px) {
+  .pricingGrid.threeCards {
+    grid-template-columns: 405px 405px 405px;
+    justify-content: center;
+  }
+}

--- a/nextjs-app/app/components/pricing/PricingBlock.tsx
+++ b/nextjs-app/app/components/pricing/PricingBlock.tsx
@@ -1,0 +1,52 @@
+import React from 'react'
+import {
+  BackgroundTheme,
+  BACKGROUND_COLOR_MAP,
+} from '../../types/design-tokens'
+import { Alignment } from '../../types/ui'
+import { BlockHeaderSection } from '../BlockHeaderSection'
+import { PricingCard, type PricingCardPlan } from './PricingCard'
+import styles from './PricingBlock.module.css'
+
+interface PricingBlockProps {
+  block: {
+    header?: Parameters<typeof BlockHeaderSection>[0]['header']
+    layout: 'threeColumn' | 'twoColumn'
+    plans: PricingCardPlan[]
+    backgroundTheme?: BackgroundTheme
+  }
+  index: number
+}
+
+export default function PricingBlock({ block }: PricingBlockProps) {
+  const { header, plans } = block
+  const backgroundTheme = block.backgroundTheme || BackgroundTheme.DARK
+  const bgColor = BACKGROUND_COLOR_MAP[backgroundTheme]
+
+  return (
+    <section
+      className="py-20 px-5 sm:px-10 xl:px-20 2xl:px-[clamp(20px,4vw,160px)]"
+      style={{ backgroundColor: bgColor }}
+    >
+      <div className="mx-auto w-full max-w-[1376px]">
+        {header && (
+          <BlockHeaderSection
+            header={header}
+            backgroundColor={backgroundTheme}
+            headerAlignment={Alignment.CENTER}
+          />
+        )}
+
+        {plans && plans.length > 0 && (
+          <div
+            className={`${styles.pricingGrid} ${plans.length === 2 ? styles.twoCards : styles.threeCards} mt-12`}
+          >
+            {plans.map((plan) => (
+              <PricingCard key={plan.name} plan={plan} />
+            ))}
+          </div>
+        )}
+      </div>
+    </section>
+  )
+}

--- a/nextjs-app/app/components/pricing/PricingCard.tsx
+++ b/nextjs-app/app/components/pricing/PricingCard.tsx
@@ -1,0 +1,93 @@
+import React from 'react'
+import { LucideIcon } from 'lucide-react'
+import { ButtonVariant } from '../../types/design-tokens'
+import { IconPosition, LinkTarget } from '../../types/ui'
+import { LinkButton } from '../LinkButton'
+import { getLucideIcon } from '../../utils/icons'
+import {
+  PricingCardBackground,
+  PRICING_CARD_BG_MAP,
+} from '../../types/design-tokens'
+import { GoodPartyOrgLogo } from 'goodparty-styleguide'
+
+interface FeatureItem {
+  icon?: string
+  text: string
+}
+
+export interface PricingCardPlan {
+  name: string
+  price: number // USD per month
+  description?: string
+  features: FeatureItem[]
+  backgroundColor?: PricingCardBackground
+  ctaButton?: {
+    label: string
+    url: string
+    icon?: string
+    target?: LinkTarget
+  }
+}
+
+export const PricingCard: React.FC<{ plan: PricingCardPlan }> = ({ plan }) => {
+  const bgColor =
+    PRICING_CARD_BG_MAP[
+      plan.backgroundColor || PricingCardBackground.BRAND_SECONDARY
+    ]
+  const isDark =
+    (plan.backgroundColor || PricingCardBackground.BRAND_SECONDARY) ===
+    PricingCardBackground.BRAND_SECONDARY
+
+  return (
+    <div
+      className={`box-border rounded-[32px] shadow-sm p-8 flex flex-col w-full max-w-[405px] md:w-[405px] h-full relative ${isDark ? 'text-white border border-white/10' : 'text-brand-dark'}`}
+      style={{ backgroundColor: bgColor }}
+    >
+      {!isDark && (
+        <GoodPartyOrgLogo className="absolute top-8 right-8 h-7 w-7" />
+      )}
+
+      <div className="flex flex-col gap-4 items-start w-full text-left">
+        <div className="text-2xl font-semibold leading-tight">{plan.name}</div>
+        <div className="flex items-baseline gap-2">
+          <span className="text-6xl font-semibold">${plan.price}</span>
+          <span className="text-base">per month</span>
+        </div>
+      </div>
+
+      <hr
+        className={`my-6 border-t ${isDark ? 'border-white/10' : 'border-black/10'} w-full`}
+      />
+
+      <div className="text-left w-full flex-1">
+        <ul className="flex flex-col gap-2">
+          {plan.features?.map((item, idx) => {
+            const IconComp = getLucideIcon(item.icon || 'Check') as LucideIcon
+            return (
+              <li key={idx} className="flex gap-2 items-start">
+                <IconComp
+                  className={`mt-[2px] h-4 w-4 flex-none ${isDark ? 'text-white' : 'text-brand'}`}
+                />
+                <span className="text-base leading-normal">{item.text}</span>
+              </li>
+            )
+          })}
+        </ul>
+      </div>
+
+      {plan.ctaButton && plan.ctaButton.label && plan.ctaButton.url && (
+        <div className="pt-8 w-full">
+          <LinkButton
+            label={plan.ctaButton.label}
+            url={plan.ctaButton.url}
+            icon={plan.ctaButton.icon || 'ArrowRight'}
+            variant={ButtonVariant.SECONDARY}
+            iconPosition={IconPosition.RIGHT}
+            target={plan.ctaButton.target}
+            className="w-full"
+          />
+        </div>
+      )}
+    </div>
+  )
+}

--- a/nextjs-app/app/components/pricing/PricingCard.tsx
+++ b/nextjs-app/app/components/pricing/PricingCard.tsx
@@ -85,6 +85,7 @@ export const PricingCard: React.FC<{ plan: PricingCardPlan }> = ({ plan }) => {
             iconPosition={IconPosition.RIGHT}
             target={plan.ctaButton.target}
             className="w-full"
+            buttonClassName="w-full"
           />
         </div>
       )}

--- a/nextjs-app/app/types/design-tokens.ts
+++ b/nextjs-app/app/types/design-tokens.ts
@@ -139,3 +139,15 @@ export const LINK_TYPE_OPTIONS = [
   { title: 'Page', value: LinkType.PAGE },
   { title: 'Post', value: LinkType.POST },
 ] as const
+
+export enum PricingCardBackground {
+  BRAND_SECONDARY = 'brandSecondary',
+  LAVENDER_100 = 'lavender100',
+  BRIGHT_YELLOW_300 = 'brightYellow300',
+}
+
+export const PRICING_CARD_BG_MAP: Record<PricingCardBackground, string> = {
+  [PricingCardBackground.BRAND_SECONDARY]: DesignTokens.COLOR_BRAND_SECONDARY,
+  [PricingCardBackground.LAVENDER_100]: DesignTokens.COLOR_LAVENDER_100,
+  [PricingCardBackground.BRIGHT_YELLOW_300]: 'var(--color-bright-yellow-300)',
+}

--- a/nextjs-app/app/types/sanity.ts
+++ b/nextjs-app/app/types/sanity.ts
@@ -1,3 +1,5 @@
+import { ButtonVariant } from './design-tokens'
+
 export enum SanityType {
   REFERENCE = 'reference',
   DOCUMENT = 'document',
@@ -64,4 +66,54 @@ export interface SanityDocument {
   _createdAt: string
   _updatedAt: string
   _rev: string
+}
+
+// HeroBlock related interfaces
+export interface BlockHeader {
+  overline?: string
+  heading: string
+  subhead?: string
+  primaryButton?: {
+    label: string
+    url: SanityLink
+    icon?: string
+    variant?: string
+  }
+  secondaryButton?: {
+    label: string
+    url: SanityLink
+    icon?: string
+    variant?: string
+  }
+}
+
+export interface TransformedHeader {
+  overline?: string
+  heading: string
+  subhead?: string
+  primaryButton?: {
+    label: string
+    url: string
+    icon?: string
+    variant?: ButtonVariant
+  }
+  secondaryButton?: {
+    label: string
+    url: string
+    icon?: string
+    variant?: ButtonVariant
+  }
+}
+
+export interface HeroBlockProps {
+  block: {
+    _key: string
+    _type: 'heroBlock'
+    header: BlockHeader
+    headerAlignment: string
+    backgroundTheme: string
+    layout: string
+    image?: SanityImage
+    imageContained?: boolean
+  }
 }

--- a/nextjs-app/app/types/ui.ts
+++ b/nextjs-app/app/types/ui.ts
@@ -26,3 +26,22 @@ export enum FontWeight {
   MEDIUM = 'medium',
   SEMIBOLD = 'semibold',
 }
+
+export enum HeroLayout {
+  HEADER_ONLY = 'headerOnly',
+  TWO_COLUMN_IMAGE_LEFT = 'twoColumnImageLeft',
+  TWO_COLUMN_IMAGE_RIGHT = 'twoColumnImageRight',
+  IMAGE_FULL_WIDTH = 'imageFullWidth',
+  IMAGE_CONTAINED = 'imageContained',
+}
+
+export const HERO_LAYOUT_OPTIONS = [
+  { title: 'Header Only', value: HeroLayout.HEADER_ONLY },
+  { title: 'Two Column - Image Left', value: HeroLayout.TWO_COLUMN_IMAGE_LEFT },
+  {
+    title: 'Two Column - Image Right',
+    value: HeroLayout.TWO_COLUMN_IMAGE_RIGHT,
+  },
+  { title: 'Image Full Width', value: HeroLayout.IMAGE_FULL_WIDTH },
+  { title: 'Image Contained', value: HeroLayout.IMAGE_CONTAINED },
+] as const

--- a/package-lock.json
+++ b/package-lock.json
@@ -448,16 +448,18 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       }
     },
     "node_modules/@babel/helper-create-regexp-features-plugin": {
-      "version": "7.26.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.26.3.tgz",
-      "integrity": "sha512-G7ZRb40uUgdKOQqPLjfD12ZmGA54PzqDFUv2BKImnC9QIfGhIHKvVML0oN8IUiDq4iRqpq74ABpvOaerfWdong==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.27.1.tgz",
+      "integrity": "sha512-uVDC72XVf8UbrH5qQTc18Agb8emwjTiZrQE11Nv3CuBEZmVvTwwE9CBUEvHku06gQCAyYf8Nv6ja1IN+6LMbxQ==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.25.9",
+        "@babel/helper-annotate-as-pure": "^7.27.1",
         "regexpu-core": "^6.2.0",
         "semver": "^6.3.1"
       },
@@ -556,13 +558,14 @@
       }
     },
     "node_modules/@babel/helper-remap-async-to-generator": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.25.9.tgz",
-      "integrity": "sha512-IZtukuUeBbhgOcaW2s06OXTzVNJR0ybm4W5xC1opWFFJMZbwRj5LCk+ByYH7WdZPZTt8KnFwA8pvjN2yqcPlgw==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.27.1.tgz",
+      "integrity": "sha512-7fiA521aVw8lSPeI4ZOD3vRFkoqkJcS+z4hFo82bFSH/2tNd6eJ5qCVMS5OzDmZh/kaHQeBaeyxK6wljcPtveA==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.25.9",
-        "@babel/helper-wrap-function": "^7.25.9",
-        "@babel/traverse": "^7.25.9"
+        "@babel/helper-annotate-as-pure": "^7.27.1",
+        "@babel/helper-wrap-function": "^7.27.1",
+        "@babel/traverse": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -629,13 +632,14 @@
       }
     },
     "node_modules/@babel/helper-wrap-function": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.25.9.tgz",
-      "integrity": "sha512-ETzz9UTjQSTmw39GboatdymDq4XIQbR8ySgVrylRhPOFpsd+JrKHIuF0de7GCWmem+T4uC5z7EZguod7Wj4A4g==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.27.1.tgz",
+      "integrity": "sha512-NFJK2sHUvrjo8wAU/nQTWU890/zB2jj0qBcCbZbbf+005cAsv6tMjXz31fBign6M5ov1o0Bllu+9nbqkfsjjJQ==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.25.9",
-        "@babel/traverse": "^7.25.9",
-        "@babel/types": "^7.25.9"
+        "@babel/template": "^7.27.1",
+        "@babel/traverse": "^7.27.1",
+        "@babel/types": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -670,12 +674,13 @@
       }
     },
     "node_modules/@babel/plugin-bugfix-firefox-class-in-computed-class-key": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-firefox-class-in-computed-class-key/-/plugin-bugfix-firefox-class-in-computed-class-key-7.25.9.tgz",
-      "integrity": "sha512-ZkRyVkThtxQ/J6nv3JFYv1RYY+JT5BvU0y3k5bWrmuG4woXypRa4PXmm9RhOwodRkYFWqC0C0cqcJ4OqR7kW+g==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-firefox-class-in-computed-class-key/-/plugin-bugfix-firefox-class-in-computed-class-key-7.27.1.tgz",
+      "integrity": "sha512-QPG3C9cCVRQLxAVwmefEmwdTanECuUBMQZ/ym5kiw3XKCGA7qkuQLcjWWHcrD/GKbn/WmJwaezfuuAOcyKlRPA==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.9",
-        "@babel/traverse": "^7.25.9"
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/traverse": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -685,11 +690,12 @@
       }
     },
     "node_modules/@babel/plugin-bugfix-safari-class-field-initializer-scope": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-class-field-initializer-scope/-/plugin-bugfix-safari-class-field-initializer-scope-7.25.9.tgz",
-      "integrity": "sha512-MrGRLZxLD/Zjj0gdU15dfs+HH/OXvnw/U4jJD8vpcP2CJQapPEv1IWwjc/qMg7ItBlPwSv1hRBbb7LeuANdcnw==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-class-field-initializer-scope/-/plugin-bugfix-safari-class-field-initializer-scope-7.27.1.tgz",
+      "integrity": "sha512-qNeq3bCKnGgLkEXUuFry6dPlGfCdQNZbn7yUAPCInwAJHMU7THJfrBSozkcWq5sNM6RcF3S8XyQL2A52KNR9IA==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.9"
+        "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -699,11 +705,12 @@
       }
     },
     "node_modules/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.25.9.tgz",
-      "integrity": "sha512-2qUwwfAFpJLZqxd02YW9btUCZHl+RFvdDkNfZwaIJrvB8Tesjsk8pEQkTvGwZXLqXUx/2oyY3ySRhm6HOXuCug==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.27.1.tgz",
+      "integrity": "sha512-g4L7OYun04N1WyqMNjldFwlfPCLVkgB54A/YCXICZYBsvJJE3kByKv9c9+R/nAfmIfjl2rKYLNyMHboYbZaWaA==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.9"
+        "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -713,13 +720,14 @@
       }
     },
     "node_modules/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.25.9.tgz",
-      "integrity": "sha512-6xWgLZTJXwilVjlnV7ospI3xi+sl8lN8rXXbBD6vYn3UYDlGsag8wrZkKcSI8G6KgqKP7vNFaDgeDnfAABq61g==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.27.1.tgz",
+      "integrity": "sha512-oO02gcONcD5O1iTLi/6frMJBIwWEHceWGSGqrpCmEL8nogiS6J9PBlE48CaK20/Jx1LuRml9aDftLgdjXT8+Cw==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.9",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.25.9",
-        "@babel/plugin-transform-optional-chaining": "^7.25.9"
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
+        "@babel/plugin-transform-optional-chaining": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -729,12 +737,13 @@
       }
     },
     "node_modules/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.25.9.tgz",
-      "integrity": "sha512-aLnMXYPnzwwqhYSCyXfKkIkYgJ8zv9RK+roo9DkTXz38ynIhd9XCbN08s3MGvqL2MYGVUGdRQLL/JqBIeJhJBg==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.27.1.tgz",
+      "integrity": "sha512-6BpaYGDavZqkI6yT+KSPdpZFfpnd68UKXbcjI9pJ13pvHhPrCKWOOLp+ysvMeA+DxnhuPpgIaRpxRxo5A9t5jw==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.9",
-        "@babel/traverse": "^7.25.9"
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/traverse": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -755,11 +764,12 @@
       }
     },
     "node_modules/@babel/plugin-syntax-import-assertions": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.26.0.tgz",
-      "integrity": "sha512-QCWT5Hh830hK5EQa7XzuqIkQU9tT/whqbDz7kuaZMHFl1inRRg7JnuAEOQ0Ur0QUl0NufCk1msK2BeY79Aj/eg==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.27.1.tgz",
+      "integrity": "sha512-UT/Jrhw57xg4ILHLFnzFpPDlMbcdEicaAtjPQpbj9wa8T4r5KVWCimHcL/460g8Ht0DMxDyjsLgiWSkVjnwPFg==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.9"
+        "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -769,11 +779,12 @@
       }
     },
     "node_modules/@babel/plugin-syntax-import-attributes": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.26.0.tgz",
-      "integrity": "sha512-e2dttdsJ1ZTpi3B9UYGLw41hifAubg19AtCu/2I/F1QNVclOBr1dYpTdmdyZ84Xiz43BS/tCUkMAZNLv12Pi+A==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.27.1.tgz",
+      "integrity": "sha512-oFT0FrKHgF53f4vOsZGi2Hh3I35PfSmVs4IBFLFj4dnafP+hIWDLg3VyKmUHfLoLHlyxY4C7DGtmHuJgn+IGww==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.9"
+        "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -828,11 +839,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-arrow-functions": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.25.9.tgz",
-      "integrity": "sha512-6jmooXYIwn9ca5/RylZADJ+EnSxVUS5sjeJ9UPk6RWRzXCmOJCy6dqItPJFpw2cuCangPK4OYr5uhGKcmrm5Qg==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.27.1.tgz",
+      "integrity": "sha512-8Z4TGic6xW70FKThA5HYEKKyBpOOsucTOD1DjU3fZxDg+K3zBJcXMFnt/4yQiZnf5+MiOMSXQ9PaEK/Ilh1DeA==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.9"
+        "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -842,13 +854,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-async-generator-functions": {
-      "version": "7.26.8",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.26.8.tgz",
-      "integrity": "sha512-He9Ej2X7tNf2zdKMAGOsmg2MrFc+hfoAhd3po4cWfo/NWjzEAKa0oQruj1ROVUdl0e6fb6/kE/G3SSxE0lRJOg==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.27.1.tgz",
+      "integrity": "sha512-eST9RrwlpaoJBDHShc+DS2SG4ATTi2MYNb4OxYkf3n+7eb49LWpnS+HSpVfW4x927qQwgk8A2hGNVaajAEw0EA==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.26.5",
-        "@babel/helper-remap-async-to-generator": "^7.25.9",
-        "@babel/traverse": "^7.26.8"
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-remap-async-to-generator": "^7.27.1",
+        "@babel/traverse": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -858,13 +871,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-async-to-generator": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.25.9.tgz",
-      "integrity": "sha512-NT7Ejn7Z/LjUH0Gv5KsBCxh7BH3fbLTV0ptHvpeMvrt3cPThHfJfst9Wrb7S8EvJ7vRTFI7z+VAvFVEQn/m5zQ==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.27.1.tgz",
+      "integrity": "sha512-NREkZsZVJS4xmTr8qzE5y8AfIPqsdQfRuUiLRTEzb7Qii8iFWCyDKaUV2c0rCuh4ljDZ98ALHP/PetiBV2nddA==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.25.9",
-        "@babel/helper-plugin-utils": "^7.25.9",
-        "@babel/helper-remap-async-to-generator": "^7.25.9"
+        "@babel/helper-module-imports": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-remap-async-to-generator": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -874,11 +888,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-block-scoped-functions": {
-      "version": "7.26.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.26.5.tgz",
-      "integrity": "sha512-chuTSY+hq09+/f5lMj8ZSYgCFpppV2CbYrhNFJ1BFoXpiWPnnAb7R0MqrafCpN8E1+YRrtM1MXZHJdIx8B6rMQ==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.27.1.tgz",
+      "integrity": "sha512-cnqkuOtZLapWYZUYM5rVIdv1nXYuFVIltZ6ZJ7nIj585QsjKM5dhL2Fu/lICXZ1OyIAFc7Qy+bvDAtTXqGrlhg==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.26.5"
+        "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -888,11 +903,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-block-scoping": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.25.9.tgz",
-      "integrity": "sha512-1F05O7AYjymAtqbsFETboN1NvBdcnzMerO+zlMyJBEz6WkMdejvGWw9p05iTSjC85RLlBseHHQpYaM4gzJkBGg==",
+      "version": "7.27.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.27.5.tgz",
+      "integrity": "sha512-JF6uE2s67f0y2RZcm2kpAUEbD50vH62TyWVebxwHAlbSdM49VqPz8t4a1uIjp4NIOIZ4xzLfjY5emt/RCyC7TQ==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.9"
+        "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -902,12 +918,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-class-properties": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.25.9.tgz",
-      "integrity": "sha512-bbMAII8GRSkcd0h0b4X+36GksxuheLFjP65ul9w6C3KgAamI3JqErNgSrosX6ZPj+Mpim5VvEbawXxJCyEUV3Q==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.27.1.tgz",
+      "integrity": "sha512-D0VcalChDMtuRvJIu3U/fwWjf8ZMykz5iZsg77Nuj821vCKI3zCyRLwRdWbsuJ/uRwZhZ002QtCqIkwC/ZkvbA==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-create-class-features-plugin": "^7.25.9",
-        "@babel/helper-plugin-utils": "^7.25.9"
+        "@babel/helper-create-class-features-plugin": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -917,12 +934,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-class-static-block": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.26.0.tgz",
-      "integrity": "sha512-6J2APTs7BDDm+UMqP1useWqhcRAXo0WIoVj26N7kPFB6S73Lgvyka4KTZYIxtgYXiN5HTyRObA72N2iu628iTQ==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.27.1.tgz",
+      "integrity": "sha512-s734HmYU78MVzZ++joYM+NkJusItbdRcbm+AGRgJCt3iA+yux0QpD9cBVdz3tKyrjVYWRl7j0mHSmv4lhV0aoA==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-create-class-features-plugin": "^7.25.9",
-        "@babel/helper-plugin-utils": "^7.25.9"
+        "@babel/helper-create-class-features-plugin": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -932,15 +950,16 @@
       }
     },
     "node_modules/@babel/plugin-transform-classes": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.25.9.tgz",
-      "integrity": "sha512-mD8APIXmseE7oZvZgGABDyM34GUmK45Um2TXiBUt7PnuAxrgoSVf123qUzPxEr/+/BHrRn5NMZCdE2m/1F8DGg==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.27.1.tgz",
+      "integrity": "sha512-7iLhfFAubmpeJe/Wo2TVuDrykh/zlWXLzPNdL0Jqn/Xu8R3QQ8h9ff8FQoISZOsw74/HFqFI7NX63HN7QFIHKA==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.25.9",
-        "@babel/helper-compilation-targets": "^7.25.9",
-        "@babel/helper-plugin-utils": "^7.25.9",
-        "@babel/helper-replace-supers": "^7.25.9",
-        "@babel/traverse": "^7.25.9",
+        "@babel/helper-annotate-as-pure": "^7.27.1",
+        "@babel/helper-compilation-targets": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-replace-supers": "^7.27.1",
+        "@babel/traverse": "^7.27.1",
         "globals": "^11.1.0"
       },
       "engines": {
@@ -951,12 +970,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-computed-properties": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.25.9.tgz",
-      "integrity": "sha512-HnBegGqXZR12xbcTHlJ9HGxw1OniltT26J5YpfruGqtUHlz/xKf/G2ak9e+t0rVqrjXa9WOhvYPz1ERfMj23AA==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.27.1.tgz",
+      "integrity": "sha512-lj9PGWvMTVksbWiDT2tW68zGS/cyo4AkZ/QTp0sQT0mjPopCmrSkzxeXkznjqBxzDI6TclZhOJbBmbBLjuOZUw==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.9",
-        "@babel/template": "^7.25.9"
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/template": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -966,11 +986,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-destructuring": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.25.9.tgz",
-      "integrity": "sha512-WkCGb/3ZxXepmMiX101nnGiU+1CAdut8oHyEOHxkKuS1qKpU2SMXE2uSvfz8PBuLd49V6LEsbtyPhWC7fnkgvQ==",
+      "version": "7.27.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.27.3.tgz",
+      "integrity": "sha512-s4Jrok82JpiaIprtY2nHsYmrThKvvwgHwjgd7UMiYhZaN0asdXNLr0y+NjTfkA7SyQE5i2Fb7eawUOZmLvyqOA==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.9"
+        "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -980,12 +1001,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-dotall-regex": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.25.9.tgz",
-      "integrity": "sha512-t7ZQ7g5trIgSRYhI9pIJtRl64KHotutUJsh4Eze5l7olJv+mRSg4/MmbZ0tv1eeqRbdvo/+trvJD/Oc5DmW2cA==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.27.1.tgz",
+      "integrity": "sha512-gEbkDVGRvjj7+T1ivxrfgygpT7GUd4vmODtYpbs0gZATdkX8/iSnOtZSxiZnsgm1YjTgjI6VKBGSJJevkrclzw==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-create-regexp-features-plugin": "^7.25.9",
-        "@babel/helper-plugin-utils": "^7.25.9"
+        "@babel/helper-create-regexp-features-plugin": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -995,11 +1017,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-duplicate-keys": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.25.9.tgz",
-      "integrity": "sha512-LZxhJ6dvBb/f3x8xwWIuyiAHy56nrRG3PeYTpBkkzkYRRQ6tJLu68lEF5VIqMUZiAV7a8+Tb78nEoMCMcqjXBw==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.27.1.tgz",
+      "integrity": "sha512-MTyJk98sHvSs+cvZ4nOauwTTG1JeonDjSGvGGUNHreGQns+Mpt6WX/dVzWBHgg+dYZhkC4X+zTDfkTU+Vy9y7Q==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.9"
+        "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1009,12 +1032,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-duplicate-named-capturing-groups-regex": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-named-capturing-groups-regex/-/plugin-transform-duplicate-named-capturing-groups-regex-7.25.9.tgz",
-      "integrity": "sha512-0UfuJS0EsXbRvKnwcLjFtJy/Sxc5J5jhLHnFhy7u4zih97Hz6tJkLU+O+FMMrNZrosUPxDi6sYxJ/EA8jDiAog==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-named-capturing-groups-regex/-/plugin-transform-duplicate-named-capturing-groups-regex-7.27.1.tgz",
+      "integrity": "sha512-hkGcueTEzuhB30B3eJCbCYeCaaEQOmQR0AdvzpD4LoN0GXMWzzGSuRrxR2xTnCrvNbVwK9N6/jQ92GSLfiZWoQ==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-create-regexp-features-plugin": "^7.25.9",
-        "@babel/helper-plugin-utils": "^7.25.9"
+        "@babel/helper-create-regexp-features-plugin": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1024,11 +1048,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-dynamic-import": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-7.25.9.tgz",
-      "integrity": "sha512-GCggjexbmSLaFhqsojeugBpeaRIgWNTcgKVq/0qIteFEqY2A+b9QidYadrWlnbWQUrW5fn+mCvf3tr7OeBFTyg==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-7.27.1.tgz",
+      "integrity": "sha512-MHzkWQcEmjzzVW9j2q8LGjwGWpG2mjwaaB0BNQwst3FIjqsg8Ct/mIZlvSPJvfi9y2AC8mi/ktxbFVL9pZ1I4A==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.9"
+        "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1038,11 +1063,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-exponentiation-operator": {
-      "version": "7.26.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.26.3.tgz",
-      "integrity": "sha512-7CAHcQ58z2chuXPWblnn1K6rLDnDWieghSOEmqQsrBenH0P9InCUtOJYD89pvngljmZlJcz3fcmgYsXFNGa1ZQ==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.27.1.tgz",
+      "integrity": "sha512-uspvXnhHvGKf2r4VVtBpeFnuDWsJLQ6MF6lGJLC89jBR1uoVeqM416AZtTuhTezOfgHicpJQmoD5YUakO/YmXQ==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.9"
+        "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1052,11 +1078,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-export-namespace-from": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-export-namespace-from/-/plugin-transform-export-namespace-from-7.25.9.tgz",
-      "integrity": "sha512-2NsEz+CxzJIVOPx2o9UsW1rXLqtChtLoVnwYHHiB04wS5sgn7mrV45fWMBX0Kk+ub9uXytVYfNP2HjbVbCB3Ww==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-export-namespace-from/-/plugin-transform-export-namespace-from-7.27.1.tgz",
+      "integrity": "sha512-tQvHWSZ3/jH2xuq/vZDy0jNn+ZdXJeM8gHvX4lnJmsc3+50yPlWdZXIc5ay+umX+2/tJIqHqiEqcJvxlmIvRvQ==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.9"
+        "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1066,12 +1093,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-for-of": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.26.9.tgz",
-      "integrity": "sha512-Hry8AusVm8LW5BVFgiyUReuoGzPUpdHQQqJY5bZnbbf+ngOHWuCuYFKw/BqaaWlvEUrF91HMhDtEaI1hZzNbLg==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.27.1.tgz",
+      "integrity": "sha512-BfbWFFEJFQzLCQ5N8VocnCtA8J1CLkNTe2Ms2wocj75dd6VpiqS5Z5quTYcUoo4Yq+DN0rtikODccuv7RU81sw==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.26.5",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.25.9"
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1081,13 +1109,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-function-name": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.25.9.tgz",
-      "integrity": "sha512-8lP+Yxjv14Vc5MuWBpJsoUCd3hD6V9DgBon2FVYL4jJgbnVQ9fTgYmonchzZJOVNgzEgbxp4OwAf6xz6M/14XA==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.27.1.tgz",
+      "integrity": "sha512-1bQeydJF9Nr1eBCMMbC+hdwmRlsv5XYOMu03YSWFwNs0HsAmtSxxF1fyuYPqemVldVyFmlCU7w8UE14LupUSZQ==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-compilation-targets": "^7.25.9",
-        "@babel/helper-plugin-utils": "^7.25.9",
-        "@babel/traverse": "^7.25.9"
+        "@babel/helper-compilation-targets": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/traverse": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1097,11 +1126,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-json-strings": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.25.9.tgz",
-      "integrity": "sha512-xoTMk0WXceiiIvsaquQQUaLLXSW1KJ159KP87VilruQm0LNNGxWzahxSS6T6i4Zg3ezp4vA4zuwiNUR53qmQAw==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.27.1.tgz",
+      "integrity": "sha512-6WVLVJiTjqcQauBhn1LkICsR2H+zm62I3h9faTDKt1qP4jn2o72tSvqMwtGFKGTpojce0gJs+76eZ2uCHRZh0Q==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.9"
+        "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1111,11 +1141,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-literals": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.25.9.tgz",
-      "integrity": "sha512-9N7+2lFziW8W9pBl2TzaNht3+pgMIRP74zizeCSrtnSKVdUl8mAjjOP2OOVQAfZ881P2cNjDj1uAMEdeD50nuQ==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.27.1.tgz",
+      "integrity": "sha512-0HCFSepIpLTkLcsi86GG3mTUzxV5jpmbv97hTETW3yzrAij8aqlD36toB1D0daVFJM8NK6GvKO0gslVQmm+zZA==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.9"
+        "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1125,11 +1156,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-logical-assignment-operators": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.25.9.tgz",
-      "integrity": "sha512-wI4wRAzGko551Y8eVf6iOY9EouIDTtPb0ByZx+ktDGHwv6bHFimrgJM/2T021txPZ2s4c7bqvHbd+vXG6K948Q==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.27.1.tgz",
+      "integrity": "sha512-SJvDs5dXxiae4FbSL1aBJlG4wvl594N6YEVVn9e3JGulwioy6z3oPjx/sQBO3Y4NwUu5HNix6KJ3wBZoewcdbw==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.9"
+        "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1139,11 +1171,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-member-expression-literals": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.25.9.tgz",
-      "integrity": "sha512-PYazBVfofCQkkMzh2P6IdIUaCEWni3iYEerAsRWuVd8+jlM1S9S9cz1dF9hIzyoZ8IA3+OwVYIp9v9e+GbgZhA==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.27.1.tgz",
+      "integrity": "sha512-hqoBX4dcZ1I33jCSWcXrP+1Ku7kdqXf1oeah7ooKOIiAdKQ+uqftgCFNOSzA5AMS2XIHEYeGFg4cKRCdpxzVOQ==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.9"
+        "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1153,12 +1186,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-amd": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.25.9.tgz",
-      "integrity": "sha512-g5T11tnI36jVClQlMlt4qKDLlWnG5pP9CSM4GhdRciTNMRgkfpo5cR6b4rGIOYPgRRuFAvwjPQ/Yk+ql4dyhbw==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.27.1.tgz",
+      "integrity": "sha512-iCsytMg/N9/oFq6n+gFTvUYDZQOMK5kEdeYxmxt91fcJGycfxVP9CnrxoliM0oumFERba2i8ZtwRUCMhvP1LnA==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-transforms": "^7.25.9",
-        "@babel/helper-plugin-utils": "^7.25.9"
+        "@babel/helper-module-transforms": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1184,14 +1218,15 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-systemjs": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.25.9.tgz",
-      "integrity": "sha512-hyss7iIlH/zLHaehT+xwiymtPOpsiwIIRlCAOwBB04ta5Tt+lNItADdlXw3jAWZ96VJ2jlhl/c+PNIQPKNfvcA==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.27.1.tgz",
+      "integrity": "sha512-w5N1XzsRbc0PQStASMksmUeqECuzKuTJer7kFagK8AXgpCMkeDMO5S+aaFb7A51ZYDF7XI34qsTX+fkHiIm5yA==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-transforms": "^7.25.9",
-        "@babel/helper-plugin-utils": "^7.25.9",
-        "@babel/helper-validator-identifier": "^7.25.9",
-        "@babel/traverse": "^7.25.9"
+        "@babel/helper-module-transforms": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1",
+        "@babel/traverse": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1201,12 +1236,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-umd": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.25.9.tgz",
-      "integrity": "sha512-bS9MVObUgE7ww36HEfwe6g9WakQ0KF07mQF74uuXdkoziUPfKyu/nIm663kz//e5O1nPInPFx36z7WJmJ4yNEw==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.27.1.tgz",
+      "integrity": "sha512-iQBE/xC5BV1OxJbp6WG7jq9IWiD+xxlZhLrdwpPkTX3ydmXdvoCpyfJN7acaIBZaOqTfr76pgzqBJflNbeRK+w==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-transforms": "^7.25.9",
-        "@babel/helper-plugin-utils": "^7.25.9"
+        "@babel/helper-module-transforms": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1216,12 +1252,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-named-capturing-groups-regex": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.25.9.tgz",
-      "integrity": "sha512-oqB6WHdKTGl3q/ItQhpLSnWWOpjUJLsOCLVyeFgeTktkBSCiurvPOsyt93gibI9CmuKvTUEtWmG5VhZD+5T/KA==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.27.1.tgz",
+      "integrity": "sha512-SstR5JYy8ddZvD6MhV0tM/j16Qds4mIpJTOd1Yu9J9pJjH93bxHECF7pgtc28XvkzTD6Pxcm/0Z73Hvk7kb3Ng==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-create-regexp-features-plugin": "^7.25.9",
-        "@babel/helper-plugin-utils": "^7.25.9"
+        "@babel/helper-create-regexp-features-plugin": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1231,11 +1268,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-new-target": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.25.9.tgz",
-      "integrity": "sha512-U/3p8X1yCSoKyUj2eOBIx3FOn6pElFOKvAAGf8HTtItuPyB+ZeOqfn+mvTtg9ZlOAjsPdK3ayQEjqHjU/yLeVQ==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.27.1.tgz",
+      "integrity": "sha512-f6PiYeqXQ05lYq3TIfIDu/MtliKUbNwkGApPUvyo6+tc7uaR4cPjPe7DFPr15Uyycg2lZU6btZ575CuQoYh7MQ==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.9"
+        "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1245,11 +1283,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-nullish-coalescing-operator": {
-      "version": "7.26.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.26.6.tgz",
-      "integrity": "sha512-CKW8Vu+uUZneQCPtXmSBUC6NCAUdya26hWCElAWh5mVSlSRsmiCPUUDKb3Z0szng1hiAJa098Hkhg9o4SE35Qw==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.27.1.tgz",
+      "integrity": "sha512-aGZh6xMo6q9vq1JGcw58lZ1Z0+i0xB2x0XaauNIUXd6O1xXc3RwoWEBlsTQrY4KQ9Jf0s5rgD6SiNkaUdJegTA==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.26.5"
+        "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1259,11 +1298,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-numeric-separator": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.25.9.tgz",
-      "integrity": "sha512-TlprrJ1GBZ3r6s96Yq8gEQv82s8/5HnCVHtEJScUj90thHQbwe+E5MLhi2bbNHBEJuzrvltXSru+BUxHDoog7Q==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.27.1.tgz",
+      "integrity": "sha512-fdPKAcujuvEChxDBJ5c+0BTaS6revLV7CJL08e4m3de8qJfNIuCc2nc7XJYOjBoTMJeqSmwXJ0ypE14RCjLwaw==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.9"
+        "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1273,13 +1313,15 @@
       }
     },
     "node_modules/@babel/plugin-transform-object-rest-spread": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.25.9.tgz",
-      "integrity": "sha512-fSaXafEE9CVHPweLYw4J0emp1t8zYTXyzN3UuG+lylqkvYd7RMrsOQ8TYx5RF231be0vqtFC6jnx3UmpJmKBYg==",
+      "version": "7.27.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.27.3.tgz",
+      "integrity": "sha512-7ZZtznF9g4l2JCImCo5LNKFHB5eXnN39lLtLY5Tg+VkR0jwOt7TBciMckuiQIOIW7L5tkQOCh3bVGYeXgMx52Q==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-compilation-targets": "^7.25.9",
-        "@babel/helper-plugin-utils": "^7.25.9",
-        "@babel/plugin-transform-parameters": "^7.25.9"
+        "@babel/helper-compilation-targets": "^7.27.2",
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/plugin-transform-destructuring": "^7.27.3",
+        "@babel/plugin-transform-parameters": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1289,12 +1331,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-object-super": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.25.9.tgz",
-      "integrity": "sha512-Kj/Gh+Rw2RNLbCK1VAWj2U48yxxqL2x0k10nPtSdRa0O2xnHXalD0s+o1A6a0W43gJ00ANo38jxkQreckOzv5A==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.27.1.tgz",
+      "integrity": "sha512-SFy8S9plRPbIcxlJ8A6mT/CxFdJx/c04JEctz4jf8YZaVS2px34j7NXRrlGlHkN/M2gnpL37ZpGRGVFLd3l8Ng==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.9",
-        "@babel/helper-replace-supers": "^7.25.9"
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-replace-supers": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1304,11 +1347,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-optional-catch-binding": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.25.9.tgz",
-      "integrity": "sha512-qM/6m6hQZzDcZF3onzIhZeDHDO43bkNNlOX0i8n3lR6zLbu0GN2d8qfM/IERJZYauhAHSLHy39NF0Ctdvcid7g==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.27.1.tgz",
+      "integrity": "sha512-txEAEKzYrHEX4xSZN4kJ+OfKXFVSWKB2ZxM9dpcE3wT7smwkNmXo5ORRlVzMVdJbD+Q8ILTgSD7959uj+3Dm3Q==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.9"
+        "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1318,12 +1362,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-optional-chaining": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.25.9.tgz",
-      "integrity": "sha512-6AvV0FsLULbpnXeBjrY4dmWF8F7gf8QnvTEoO/wX/5xm/xE1Xo8oPuD3MPS+KS9f9XBEAWN7X1aWr4z9HdOr7A==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.27.1.tgz",
+      "integrity": "sha512-BQmKPPIuc8EkZgNKsv0X4bPmOoayeu4F1YCwx2/CfmDSXDbp7GnzlUH+/ul5VGfRg1AoFPsrIThlEBj2xb4CAg==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.9",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.25.9"
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1333,11 +1378,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-parameters": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.25.9.tgz",
-      "integrity": "sha512-wzz6MKwpnshBAiRmn4jR8LYz/g8Ksg0o80XmwZDlordjwEk9SxBzTWC7F5ef1jhbrbOW2DJ5J6ayRukrJmnr0g==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.27.1.tgz",
+      "integrity": "sha512-018KRk76HWKeZ5l4oTj2zPpSh+NbGdt0st5S6x0pga6HgrjBOJb24mMDHorFopOOd6YHkLgOZ+zaCjZGPO4aKg==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.9"
+        "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1347,12 +1393,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-private-methods": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.25.9.tgz",
-      "integrity": "sha512-D/JUozNpQLAPUVusvqMxyvjzllRaF8/nSrP1s2YGQT/W4LHK4xxsMcHjhOGTS01mp9Hda8nswb+FblLdJornQw==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.27.1.tgz",
+      "integrity": "sha512-10FVt+X55AjRAYI9BrdISN9/AQWHqldOeZDUoLyif1Kn05a56xVBXb8ZouL8pZ9jem8QpXaOt8TS7RHUIS+GPA==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-create-class-features-plugin": "^7.25.9",
-        "@babel/helper-plugin-utils": "^7.25.9"
+        "@babel/helper-create-class-features-plugin": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1362,13 +1409,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-private-property-in-object": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.25.9.tgz",
-      "integrity": "sha512-Evf3kcMqzXA3xfYJmZ9Pg1OvKdtqsDMSWBDzZOPLvHiTt36E75jLDQo5w1gtRU95Q4E5PDttrTf25Fw8d/uWLw==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.27.1.tgz",
+      "integrity": "sha512-5J+IhqTi1XPa0DXF83jYOaARrX+41gOewWbkPyjMNRDqgOCqdffGh8L3f/Ek5utaEBZExjSAzcyjmV9SSAWObQ==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.25.9",
-        "@babel/helper-create-class-features-plugin": "^7.25.9",
-        "@babel/helper-plugin-utils": "^7.25.9"
+        "@babel/helper-annotate-as-pure": "^7.27.1",
+        "@babel/helper-create-class-features-plugin": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1378,11 +1426,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-property-literals": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.25.9.tgz",
-      "integrity": "sha512-IvIUeV5KrS/VPavfSM/Iu+RE6llrHrYIKY1yfCzyO/lMXHQ+p7uGhonmGVisv6tSBSVgWzMBohTcvkC9vQcQFA==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.27.1.tgz",
+      "integrity": "sha512-oThy3BCuCha8kDZ8ZkgOg2exvPYUlprMukKQXI1r1pJ47NCvxfkEy8vK+r/hT9nF0Aa4H1WUPZZjHTFtAhGfmQ==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.9"
+        "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1392,11 +1441,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-react-display-name": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.25.9.tgz",
-      "integrity": "sha512-KJfMlYIUxQB1CJfO3e0+h0ZHWOTLCPP115Awhaz8U0Zpq36Gl/cXlpoyMRnUWlhNUBAzldnCiAZNvCDj7CrKxQ==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.27.1.tgz",
+      "integrity": "sha512-p9+Vl3yuHPmkirRrg021XiP+EETmPMQTLr6Ayjj85RLNEbb3Eya/4VI0vAdzQG9SEAl2Lnt7fy5lZyMzjYoZQQ==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.9"
+        "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1406,15 +1456,16 @@
       }
     },
     "node_modules/@babel/plugin-transform-react-jsx": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.25.9.tgz",
-      "integrity": "sha512-s5XwpQYCqGerXl+Pu6VDL3x0j2d82eiV77UJ8a2mDHAW7j9SWRqQ2y1fNo1Z74CdcYipl5Z41zvjj4Nfzq36rw==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.27.1.tgz",
+      "integrity": "sha512-2KH4LWGSrJIkVf5tSiBFYuXDAoWRq2MMwgivCf+93dd0GQi8RXLjKA/0EvRnVV5G0hrHczsquXuD01L8s6dmBw==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.25.9",
-        "@babel/helper-module-imports": "^7.25.9",
-        "@babel/helper-plugin-utils": "^7.25.9",
-        "@babel/plugin-syntax-jsx": "^7.25.9",
-        "@babel/types": "^7.25.9"
+        "@babel/helper-annotate-as-pure": "^7.27.1",
+        "@babel/helper-module-imports": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/plugin-syntax-jsx": "^7.27.1",
+        "@babel/types": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1424,11 +1475,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-react-jsx-development": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.25.9.tgz",
-      "integrity": "sha512-9mj6rm7XVYs4mdLIpbZnHOYdpW42uoiBCTVowg7sP1thUOiANgMb4UtpRivR0pp5iL+ocvUv7X4mZgFRpJEzGw==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.27.1.tgz",
+      "integrity": "sha512-ykDdF5yI4f1WrAolLqeF3hmYU12j9ntLQl/AOG1HAS21jxyg1Q0/J/tpREuYLfatGdGmXp/3yS0ZA76kOlVq9Q==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/plugin-transform-react-jsx": "^7.25.9"
+        "@babel/plugin-transform-react-jsx": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1468,12 +1520,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-react-pure-annotations": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.25.9.tgz",
-      "integrity": "sha512-KQ/Takk3T8Qzj5TppkS1be588lkbTp5uj7w6a0LeQaTMSckU/wK0oJ/pih+T690tkgI5jfmg2TqDJvd41Sj1Cg==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.27.1.tgz",
+      "integrity": "sha512-JfuinvDOsD9FVMTHpzA/pBLisxpv1aSf+OIV8lgH3MuWrks19R27e6a6DipIg4aX1Zm9Wpb04p8wljfKrVSnPA==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.25.9",
-        "@babel/helper-plugin-utils": "^7.25.9"
+        "@babel/helper-annotate-as-pure": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1483,12 +1536,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-regenerator": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.25.9.tgz",
-      "integrity": "sha512-vwDcDNsgMPDGP0nMqzahDWE5/MLcX8sv96+wfX7as7LoF/kr97Bo/7fI00lXY4wUXYfVmwIIyG80fGZ1uvt2qg==",
+      "version": "7.27.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.27.5.tgz",
+      "integrity": "sha512-uhB8yHerfe3MWnuLAhEbeQ4afVoqv8BQsPqrTv7e/jZ9y00kJL6l9a/f4OWaKxotmjzewfEyXE1vgDJenkQ2/Q==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.9",
-        "regenerator-transform": "^0.15.2"
+        "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1498,12 +1551,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-regexp-modifiers": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regexp-modifiers/-/plugin-transform-regexp-modifiers-7.26.0.tgz",
-      "integrity": "sha512-vN6saax7lrA2yA/Pak3sCxuD6F5InBjn9IcrIKQPjpsLvuHYLVroTxjdlVRHjjBWxKOqIwpTXDkOssYT4BFdRw==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regexp-modifiers/-/plugin-transform-regexp-modifiers-7.27.1.tgz",
+      "integrity": "sha512-TtEciroaiODtXvLZv4rmfMhkCv8jx3wgKpL68PuiPh2M4fvz5jhsA7697N1gMvkvr/JTF13DrFYyEbY9U7cVPA==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-create-regexp-features-plugin": "^7.25.9",
-        "@babel/helper-plugin-utils": "^7.25.9"
+        "@babel/helper-create-regexp-features-plugin": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1513,11 +1567,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-reserved-words": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.25.9.tgz",
-      "integrity": "sha512-7DL7DKYjn5Su++4RXu8puKZm2XBPHyjWLUidaPEkCUBbE7IPcsrkRHggAOOKydH1dASWdcUBxrkOGNxUv5P3Jg==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.27.1.tgz",
+      "integrity": "sha512-V2ABPHIJX4kC7HegLkYoDpfg9PVmuWy/i6vUM5eGK22bx4YVFD3M5F0QQnWQoDs6AGsUWTVOopBiMFQgHaSkVw==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.9"
+        "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1527,11 +1582,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-shorthand-properties": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.25.9.tgz",
-      "integrity": "sha512-MUv6t0FhO5qHnS/W8XCbHmiRWOphNufpE1IVxhK5kuN3Td9FT1x4rx4K42s3RYdMXCXpfWkGSbCSd0Z64xA7Ng==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.27.1.tgz",
+      "integrity": "sha512-N/wH1vcn4oYawbJ13Y/FxcQrWk63jhfNa7jef0ih7PHSIHX2LB7GWE1rkPrOnka9kwMxb6hMl19p7lidA+EHmQ==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.9"
+        "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1541,12 +1597,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-spread": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.25.9.tgz",
-      "integrity": "sha512-oNknIB0TbURU5pqJFVbOOFspVlrpVwo2H1+HUIsVDvp5VauGGDP1ZEvO8Nn5xyMEs3dakajOxlmkNW7kNgSm6A==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.27.1.tgz",
+      "integrity": "sha512-kpb3HUqaILBJcRFVhFUs6Trdd4mkrzcGXss+6/mxUd273PfbWqSDHRzMT2234gIg2QYfAjvXLSquP1xECSg09Q==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.9",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.25.9"
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1556,11 +1613,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-sticky-regex": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.25.9.tgz",
-      "integrity": "sha512-WqBUSgeVwucYDP9U/xNRQam7xV8W5Zf+6Eo7T2SRVUFlhRiMNFdFz58u0KZmCVVqs2i7SHgpRnAhzRNmKfi2uA==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.27.1.tgz",
+      "integrity": "sha512-lhInBO5bi/Kowe2/aLdBAawijx+q1pQzicSgnkB6dUPc1+RC8QmJHKf2OjvU+NZWitguJHEaEmbV6VWEouT58g==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.9"
+        "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1570,11 +1628,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-template-literals": {
-      "version": "7.26.8",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.26.8.tgz",
-      "integrity": "sha512-OmGDL5/J0CJPJZTHZbi2XpO0tyT2Ia7fzpW5GURwdtp2X3fMmN8au/ej6peC/T33/+CRiIpA8Krse8hFGVmT5Q==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.27.1.tgz",
+      "integrity": "sha512-fBJKiV7F2DxZUkg5EtHKXQdbsbURW3DZKQUWphDum0uRP6eHGGa/He9mc0mypL680pb+e/lDIthRohlv8NCHkg==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.26.5"
+        "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1584,11 +1643,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-typeof-symbol": {
-      "version": "7.26.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.26.7.tgz",
-      "integrity": "sha512-jfoTXXZTgGg36BmhqT3cAYK5qkmqvJpvNrPhaK/52Vgjhw4Rq29s9UqpWWV0D6yuRmgiFH/BUVlkl96zJWqnaw==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.27.1.tgz",
+      "integrity": "sha512-RiSILC+nRJM7FY5srIyc4/fGIwUhyDuuBSdWn4y6yT6gm652DpCHZjIipgn6B7MQ1ITOUnAKWixEUjQRIBIcLw==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.26.5"
+        "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1617,11 +1677,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-unicode-escapes": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.25.9.tgz",
-      "integrity": "sha512-s5EDrE6bW97LtxOcGj1Khcx5AaXwiMmi4toFWRDP9/y0Woo6pXC+iyPu/KuhKtfSrNFd7jJB+/fkOtZy6aIC6Q==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.27.1.tgz",
+      "integrity": "sha512-Ysg4v6AmF26k9vpfFuTZg8HRfVWzsh1kVfowA23y9j/Gu6dOuahdUVhkLqpObp3JIv27MLSii6noRnuKN8H0Mg==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.9"
+        "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1631,12 +1692,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-unicode-property-regex": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-7.25.9.tgz",
-      "integrity": "sha512-Jt2d8Ga+QwRluxRQ307Vlxa6dMrYEMZCgGxoPR8V52rxPyldHu3hdlHspxaqYmE7oID5+kB+UKUB/eWS+DkkWg==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-7.27.1.tgz",
+      "integrity": "sha512-uW20S39PnaTImxp39O5qFlHLS9LJEmANjMG7SxIhap8rCHqu0Ik+tLEPX5DKmHn6CsWQ7j3lix2tFOa5YtL12Q==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-create-regexp-features-plugin": "^7.25.9",
-        "@babel/helper-plugin-utils": "^7.25.9"
+        "@babel/helper-create-regexp-features-plugin": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1646,12 +1708,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-unicode-regex": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.25.9.tgz",
-      "integrity": "sha512-yoxstj7Rg9dlNn9UQxzk4fcNivwv4nUYz7fYXBaKxvw/lnmPuOm/ikoELygbYq68Bls3D/D+NBPHiLwZdZZ4HA==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.27.1.tgz",
+      "integrity": "sha512-xvINq24TRojDuyt6JGtHmkVkrfVV3FPT16uytxImLeBZqW3/H52yN+kM1MGuyPkIQxrzKwPHs5U/MP3qKyzkGw==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-create-regexp-features-plugin": "^7.25.9",
-        "@babel/helper-plugin-utils": "^7.25.9"
+        "@babel/helper-create-regexp-features-plugin": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1661,12 +1724,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-unicode-sets-regex": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.25.9.tgz",
-      "integrity": "sha512-8BYqO3GeVNHtx69fdPshN3fnzUNLrWdHhk/icSwigksJGczKSizZ+Z6SBCxTs723Fr5VSNorTIK7a+R2tISvwQ==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.27.1.tgz",
+      "integrity": "sha512-EtkOujbc4cgvb0mlpQefi4NTPBzhSIevblFevACNLUspmrALgmEBdL/XfnyyITfd8fKBZrZys92zOWcik7j9Tw==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-create-regexp-features-plugin": "^7.25.9",
-        "@babel/helper-plugin-utils": "^7.25.9"
+        "@babel/helper-create-regexp-features-plugin": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1676,73 +1740,74 @@
       }
     },
     "node_modules/@babel/preset-env": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.26.9.tgz",
-      "integrity": "sha512-vX3qPGE8sEKEAZCWk05k3cpTAE3/nOYca++JA+Rd0z2NCNzabmYvEiSShKzm10zdquOIAVXsy2Ei/DTW34KlKQ==",
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.27.2.tgz",
+      "integrity": "sha512-Ma4zSuYSlGNRlCLO+EAzLnCmJK2vdstgv+n7aUP+/IKZrOfWHOJVdSJtuub8RzHTj3ahD37k5OKJWvzf16TQyQ==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.26.8",
-        "@babel/helper-compilation-targets": "^7.26.5",
-        "@babel/helper-plugin-utils": "^7.26.5",
-        "@babel/helper-validator-option": "^7.25.9",
-        "@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^7.25.9",
-        "@babel/plugin-bugfix-safari-class-field-initializer-scope": "^7.25.9",
-        "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.25.9",
-        "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.25.9",
-        "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.25.9",
+        "@babel/compat-data": "^7.27.2",
+        "@babel/helper-compilation-targets": "^7.27.2",
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^7.27.1",
+        "@babel/plugin-bugfix-safari-class-field-initializer-scope": "^7.27.1",
+        "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.27.1",
+        "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.27.1",
+        "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.27.1",
         "@babel/plugin-proposal-private-property-in-object": "7.21.0-placeholder-for-preset-env.2",
-        "@babel/plugin-syntax-import-assertions": "^7.26.0",
-        "@babel/plugin-syntax-import-attributes": "^7.26.0",
+        "@babel/plugin-syntax-import-assertions": "^7.27.1",
+        "@babel/plugin-syntax-import-attributes": "^7.27.1",
         "@babel/plugin-syntax-unicode-sets-regex": "^7.18.6",
-        "@babel/plugin-transform-arrow-functions": "^7.25.9",
-        "@babel/plugin-transform-async-generator-functions": "^7.26.8",
-        "@babel/plugin-transform-async-to-generator": "^7.25.9",
-        "@babel/plugin-transform-block-scoped-functions": "^7.26.5",
-        "@babel/plugin-transform-block-scoping": "^7.25.9",
-        "@babel/plugin-transform-class-properties": "^7.25.9",
-        "@babel/plugin-transform-class-static-block": "^7.26.0",
-        "@babel/plugin-transform-classes": "^7.25.9",
-        "@babel/plugin-transform-computed-properties": "^7.25.9",
-        "@babel/plugin-transform-destructuring": "^7.25.9",
-        "@babel/plugin-transform-dotall-regex": "^7.25.9",
-        "@babel/plugin-transform-duplicate-keys": "^7.25.9",
-        "@babel/plugin-transform-duplicate-named-capturing-groups-regex": "^7.25.9",
-        "@babel/plugin-transform-dynamic-import": "^7.25.9",
-        "@babel/plugin-transform-exponentiation-operator": "^7.26.3",
-        "@babel/plugin-transform-export-namespace-from": "^7.25.9",
-        "@babel/plugin-transform-for-of": "^7.26.9",
-        "@babel/plugin-transform-function-name": "^7.25.9",
-        "@babel/plugin-transform-json-strings": "^7.25.9",
-        "@babel/plugin-transform-literals": "^7.25.9",
-        "@babel/plugin-transform-logical-assignment-operators": "^7.25.9",
-        "@babel/plugin-transform-member-expression-literals": "^7.25.9",
-        "@babel/plugin-transform-modules-amd": "^7.25.9",
-        "@babel/plugin-transform-modules-commonjs": "^7.26.3",
-        "@babel/plugin-transform-modules-systemjs": "^7.25.9",
-        "@babel/plugin-transform-modules-umd": "^7.25.9",
-        "@babel/plugin-transform-named-capturing-groups-regex": "^7.25.9",
-        "@babel/plugin-transform-new-target": "^7.25.9",
-        "@babel/plugin-transform-nullish-coalescing-operator": "^7.26.6",
-        "@babel/plugin-transform-numeric-separator": "^7.25.9",
-        "@babel/plugin-transform-object-rest-spread": "^7.25.9",
-        "@babel/plugin-transform-object-super": "^7.25.9",
-        "@babel/plugin-transform-optional-catch-binding": "^7.25.9",
-        "@babel/plugin-transform-optional-chaining": "^7.25.9",
-        "@babel/plugin-transform-parameters": "^7.25.9",
-        "@babel/plugin-transform-private-methods": "^7.25.9",
-        "@babel/plugin-transform-private-property-in-object": "^7.25.9",
-        "@babel/plugin-transform-property-literals": "^7.25.9",
-        "@babel/plugin-transform-regenerator": "^7.25.9",
-        "@babel/plugin-transform-regexp-modifiers": "^7.26.0",
-        "@babel/plugin-transform-reserved-words": "^7.25.9",
-        "@babel/plugin-transform-shorthand-properties": "^7.25.9",
-        "@babel/plugin-transform-spread": "^7.25.9",
-        "@babel/plugin-transform-sticky-regex": "^7.25.9",
-        "@babel/plugin-transform-template-literals": "^7.26.8",
-        "@babel/plugin-transform-typeof-symbol": "^7.26.7",
-        "@babel/plugin-transform-unicode-escapes": "^7.25.9",
-        "@babel/plugin-transform-unicode-property-regex": "^7.25.9",
-        "@babel/plugin-transform-unicode-regex": "^7.25.9",
-        "@babel/plugin-transform-unicode-sets-regex": "^7.25.9",
+        "@babel/plugin-transform-arrow-functions": "^7.27.1",
+        "@babel/plugin-transform-async-generator-functions": "^7.27.1",
+        "@babel/plugin-transform-async-to-generator": "^7.27.1",
+        "@babel/plugin-transform-block-scoped-functions": "^7.27.1",
+        "@babel/plugin-transform-block-scoping": "^7.27.1",
+        "@babel/plugin-transform-class-properties": "^7.27.1",
+        "@babel/plugin-transform-class-static-block": "^7.27.1",
+        "@babel/plugin-transform-classes": "^7.27.1",
+        "@babel/plugin-transform-computed-properties": "^7.27.1",
+        "@babel/plugin-transform-destructuring": "^7.27.1",
+        "@babel/plugin-transform-dotall-regex": "^7.27.1",
+        "@babel/plugin-transform-duplicate-keys": "^7.27.1",
+        "@babel/plugin-transform-duplicate-named-capturing-groups-regex": "^7.27.1",
+        "@babel/plugin-transform-dynamic-import": "^7.27.1",
+        "@babel/plugin-transform-exponentiation-operator": "^7.27.1",
+        "@babel/plugin-transform-export-namespace-from": "^7.27.1",
+        "@babel/plugin-transform-for-of": "^7.27.1",
+        "@babel/plugin-transform-function-name": "^7.27.1",
+        "@babel/plugin-transform-json-strings": "^7.27.1",
+        "@babel/plugin-transform-literals": "^7.27.1",
+        "@babel/plugin-transform-logical-assignment-operators": "^7.27.1",
+        "@babel/plugin-transform-member-expression-literals": "^7.27.1",
+        "@babel/plugin-transform-modules-amd": "^7.27.1",
+        "@babel/plugin-transform-modules-commonjs": "^7.27.1",
+        "@babel/plugin-transform-modules-systemjs": "^7.27.1",
+        "@babel/plugin-transform-modules-umd": "^7.27.1",
+        "@babel/plugin-transform-named-capturing-groups-regex": "^7.27.1",
+        "@babel/plugin-transform-new-target": "^7.27.1",
+        "@babel/plugin-transform-nullish-coalescing-operator": "^7.27.1",
+        "@babel/plugin-transform-numeric-separator": "^7.27.1",
+        "@babel/plugin-transform-object-rest-spread": "^7.27.2",
+        "@babel/plugin-transform-object-super": "^7.27.1",
+        "@babel/plugin-transform-optional-catch-binding": "^7.27.1",
+        "@babel/plugin-transform-optional-chaining": "^7.27.1",
+        "@babel/plugin-transform-parameters": "^7.27.1",
+        "@babel/plugin-transform-private-methods": "^7.27.1",
+        "@babel/plugin-transform-private-property-in-object": "^7.27.1",
+        "@babel/plugin-transform-property-literals": "^7.27.1",
+        "@babel/plugin-transform-regenerator": "^7.27.1",
+        "@babel/plugin-transform-regexp-modifiers": "^7.27.1",
+        "@babel/plugin-transform-reserved-words": "^7.27.1",
+        "@babel/plugin-transform-shorthand-properties": "^7.27.1",
+        "@babel/plugin-transform-spread": "^7.27.1",
+        "@babel/plugin-transform-sticky-regex": "^7.27.1",
+        "@babel/plugin-transform-template-literals": "^7.27.1",
+        "@babel/plugin-transform-typeof-symbol": "^7.27.1",
+        "@babel/plugin-transform-unicode-escapes": "^7.27.1",
+        "@babel/plugin-transform-unicode-property-regex": "^7.27.1",
+        "@babel/plugin-transform-unicode-regex": "^7.27.1",
+        "@babel/plugin-transform-unicode-sets-regex": "^7.27.1",
         "@babel/preset-modules": "0.1.6-no-external-plugins",
         "babel-plugin-polyfill-corejs2": "^0.4.10",
         "babel-plugin-polyfill-corejs3": "^0.11.0",
@@ -1779,16 +1844,17 @@
       }
     },
     "node_modules/@babel/preset-react": {
-      "version": "7.26.3",
-      "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.26.3.tgz",
-      "integrity": "sha512-Nl03d6T9ky516DGK2YMxrTqvnpUW63TnJMOMonj+Zae0JiPC5BC9xPMSL6L8fiSpA5vP88qfygavVQvnLp+6Cw==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.27.1.tgz",
+      "integrity": "sha512-oJHWh2gLhU9dW9HHr42q0cI0/iHHXTLGe39qvpAZZzagHy0MzYLCnCVV0symeRvzmjHyVU7mw2K06E6u/JwbhA==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.9",
-        "@babel/helper-validator-option": "^7.25.9",
-        "@babel/plugin-transform-react-display-name": "^7.25.9",
-        "@babel/plugin-transform-react-jsx": "^7.25.9",
-        "@babel/plugin-transform-react-jsx-development": "^7.25.9",
-        "@babel/plugin-transform-react-pure-annotations": "^7.25.9"
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/plugin-transform-react-display-name": "^7.27.1",
+        "@babel/plugin-transform-react-jsx": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-development": "^7.27.1",
+        "@babel/plugin-transform-react-pure-annotations": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1901,9 +1967,10 @@
       }
     },
     "node_modules/@codemirror/commands": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.8.0.tgz",
-      "integrity": "sha512-q8VPEFaEP4ikSlt6ZxjB3zW72+7osfAYW9i8Zu943uqbKuz6utc1+F170hyLUCUltXORjQXRyYQNfkckzA/bPQ==",
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.8.1.tgz",
+      "integrity": "sha512-KlGVYufHMQzxbdQONiLyGQDUW0itrLZwq3CcY7xpv9ZLRHqzkBSoteocBHtMCoY7/Ci4xhzSrToIeLg7FxHuaw==",
+      "license": "MIT",
       "dependencies": {
         "@codemirror/language": "^6.0.0",
         "@codemirror/state": "^6.4.0",
@@ -1912,9 +1979,10 @@
       }
     },
     "node_modules/@codemirror/lang-javascript": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-6.2.3.tgz",
-      "integrity": "sha512-8PR3vIWg7pSu7ur8A07pGiYHgy3hHj+mRYRCSG8q+mPIrl0F02rgpGv+DsQTHRTc30rydOsf5PZ7yjKFg2Ackw==",
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-6.2.4.tgz",
+      "integrity": "sha512-0WVmhp1QOqZ4Rt6GlVGwKJN3KW7Xh4H2q8ZZNGZaP6lRdxXJzmjm4FqvmOojVj6khWJHIb9sp7U/72W7xQgqAA==",
+      "license": "MIT",
       "dependencies": {
         "@codemirror/autocomplete": "^6.0.0",
         "@codemirror/language": "^6.6.0",
@@ -1926,9 +1994,10 @@
       }
     },
     "node_modules/@codemirror/language": {
-      "version": "6.10.8",
-      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.10.8.tgz",
-      "integrity": "sha512-wcP8XPPhDH2vTqf181U8MbZnW+tDyPYy0UzVOa+oHORjyT+mhhom9vBd7dApJwoDz9Nb/a8kHjJIsuA/t8vNFw==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.11.1.tgz",
+      "integrity": "sha512-5kS1U7emOGV84vxC+ruBty5sUgcD0te6dyupyRVG2zaSjhTDM73LhVKUtVwiqSe6QwmEoA4SCiU8AKPFyumAWQ==",
+      "license": "MIT",
       "dependencies": {
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.23.0",
@@ -1949,9 +2018,10 @@
       }
     },
     "node_modules/@codemirror/search": {
-      "version": "6.5.9",
-      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.5.9.tgz",
-      "integrity": "sha512-7DdQ9aaZMMxuWB1u6IIFWWuK9NocVZwvo4nG8QjJTS6oZGvteoLSiXw3EbVZVlO08Ri2ltO89JVInMpfcJxhtg==",
+      "version": "6.5.11",
+      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.5.11.tgz",
+      "integrity": "sha512-KmWepDE6jUdL6n8cAAqIpRmLPBZ5ZKnicE8oGU/s3QrAVID+0VhLFrzUucVKHG5035/BSykhExDL/Xm7dHthiA==",
+      "license": "MIT",
       "dependencies": {
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.0.0",
@@ -1978,11 +2048,13 @@
       }
     },
     "node_modules/@codemirror/view": {
-      "version": "6.36.3",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.36.3.tgz",
-      "integrity": "sha512-N2bilM47QWC8Hnx0rMdDxO2x2ImJ1FvZWXubwKgjeoOrWwEiFrtpA7SFHcuZ+o2Ze2VzbkgbzWVj4+V18LVkeg==",
+      "version": "6.37.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.37.2.tgz",
+      "integrity": "sha512-XD3LdgQpxQs5jhOOZ2HRVT+Rj59O4Suc7g2ULvZ+Yi8eCkickrkZ5JFuoDhs2ST1mNI5zSsNYgR3NGa4OUrbnw==",
+      "license": "MIT",
       "dependencies": {
         "@codemirror/state": "^6.5.0",
+        "crelt": "^1.0.6",
         "style-mod": "^4.1.0",
         "w3c-keyname": "^2.2.4"
       }
@@ -3844,17 +3916,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@jridgewell/source-map": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.6.tgz",
-      "integrity": "sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.25"
-      }
-    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
@@ -3888,9 +3949,10 @@
       }
     },
     "node_modules/@lezer/javascript": {
-      "version": "1.4.21",
-      "resolved": "https://registry.npmjs.org/@lezer/javascript/-/javascript-1.4.21.tgz",
-      "integrity": "sha512-lL+1fcuxWYPURMM/oFZLEDm0XuLN128QPV+VuGtKpeaOGdcl9F2LYC3nh1S9LkPqx9M0mndZFdXCipNAZpzIkQ==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@lezer/javascript/-/javascript-1.5.1.tgz",
+      "integrity": "sha512-ATOImjeVJuvgm3JQ/bpo2Tmv55HSScE2MTPnKRMRIPx2cLhHGyX2VnqpHhtIV1tVzIjZDbcWQm+NCTF40ggZVw==",
+      "license": "MIT",
       "dependencies": {
         "@lezer/common": "^1.2.0",
         "@lezer/highlight": "^1.1.3",
@@ -4314,9 +4376,9 @@
       }
     },
     "node_modules/@oclif/core": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-4.3.3.tgz",
-      "integrity": "sha512-A0mk4nlVE+r34fl91OdglXVPwhhfzM59IhSxnOigqMkwxFgT8z3i2WlUgzmazzvzSccs2KM4N2HkTS3NEvW96g==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-4.4.0.tgz",
+      "integrity": "sha512-wH5g3SLmbRutnr7UzQBSozRFEAZ7U9YGB/wFuBRr0ZghTgv5DE+KQaf6ZtU7iFb9pvkvoVRnT5XheNAtbjRDaQ==",
       "license": "MIT",
       "dependencies": {
         "ansi-escapes": "^4.3.2",
@@ -4343,9 +4405,9 @@
       }
     },
     "node_modules/@oclif/core/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -4403,9 +4465,9 @@
       }
     },
     "node_modules/@oclif/plugin-help": {
-      "version": "6.2.28",
-      "resolved": "https://registry.npmjs.org/@oclif/plugin-help/-/plugin-help-6.2.28.tgz",
-      "integrity": "sha512-eFLP2yjiK+xMRGcv9k9jOWV08HB+/Cgg1ND91zS4Uwgp1krMoL39Is+hIqnZOKkmiEMtiv8k5EDqCVv+DTRywg==",
+      "version": "6.2.29",
+      "resolved": "https://registry.npmjs.org/@oclif/plugin-help/-/plugin-help-6.2.29.tgz",
+      "integrity": "sha512-90DMOngEHiQw1I7oylVE1Hco991OkeDFJMx3CNJ2M3g5F1dhXgscjbaIlYHdiuNyVs0mTkKevdiMs911suD4yA==",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "^4"
@@ -4605,26 +4667,26 @@
       }
     },
     "node_modules/@portabletext/block-tools": {
-      "version": "1.1.29",
-      "resolved": "https://registry.npmjs.org/@portabletext/block-tools/-/block-tools-1.1.29.tgz",
-      "integrity": "sha512-yEPpMwl7mXd8WlOqkxqUdio4I9v9RFkDVXi+fTjgVAjAvlaYMkIqN+DAHJ4J8j52n6r+sf0M0WVbKuUlUfcI1w==",
+      "version": "1.1.30",
+      "resolved": "https://registry.npmjs.org/@portabletext/block-tools/-/block-tools-1.1.30.tgz",
+      "integrity": "sha512-vYOyioB6b2EMriVfgt+eOrRIdrL4a7DgYestANGBQXaGgqdNnGOxgd6Ije3AxxCrosA2qGjZ6KuKkJzLZHb1YA==",
       "license": "MIT",
       "dependencies": {
         "get-random-values-esm": "1.0.2",
         "lodash": "^4.17.21"
       },
       "peerDependencies": {
-        "@sanity/types": "^3.91.0",
+        "@sanity/types": "^3.92.0",
         "@types/react": "18 || 19"
       }
     },
     "node_modules/@portabletext/editor": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/@portabletext/editor/-/editor-1.52.0.tgz",
-      "integrity": "sha512-pSeaMatCFYg0/fX4jq7PUMzIvLo4cIrQ2aZa0Ypw8bHWIDFTQ/PQArR8MGO+YoiTVMU1NUTS+/q+Pm1BwvLPCA==",
+      "version": "1.53.0",
+      "resolved": "https://registry.npmjs.org/@portabletext/editor/-/editor-1.53.0.tgz",
+      "integrity": "sha512-72D1TZV4Uqu/21JC/M9lBSiUfzmg8xN1ijnrLlPny6g+ljm/UVjk3xVcgufCbRy8P8/ZE5mSVcbHgFx/ddc01w==",
       "license": "MIT",
       "dependencies": {
-        "@portabletext/block-tools": "1.1.29",
+        "@portabletext/block-tools": "1.1.30",
         "@portabletext/patches": "1.1.4",
         "@portabletext/to-html": "^2.0.14",
         "@xstate/react": "^5.0.5",
@@ -4637,15 +4699,15 @@
         "slate": "0.115.1",
         "slate-dom": "^0.114.0",
         "slate-react": "0.114.2",
-        "use-effect-event": "^2.0.0",
+        "use-effect-event": "^1.0.2",
         "xstate": "^5.19.4"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "@sanity/schema": "^3.91.0",
-        "@sanity/types": "^3.91.0",
+        "@sanity/schema": "^3.92.0",
+        "@sanity/types": "^3.92.0",
         "react": "^16.9 || ^17 || ^18 || ^19",
         "rxjs": "^7.8.2"
       }
@@ -4657,15 +4719,6 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0 || ^0.0.0-experimental"
-      }
-    },
-    "node_modules/@portabletext/editor/node_modules/use-effect-event": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/use-effect-event/-/use-effect-event-2.0.0.tgz",
-      "integrity": "sha512-CIRGe/RUfngbmivpY5F7rc0m7q0VYzqtQOcKJ19FPEeyf7tS44Zk+9tcDicP+z+d32+E2r+Zs7+20MHXa8JBUA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^18.3 || ^19.0.0-0"
       }
     },
     "node_modules/@portabletext/patches": {
@@ -6073,9 +6126,9 @@
       "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.41.0.tgz",
-      "integrity": "sha512-KxN+zCjOYHGwCl4UCtSfZ6jrq/qi88JDUtiEFk8LELEHq2Egfc/FgW+jItZiOLRuQfb/3xJSgFuNPC9jzggX+A==",
+      "version": "4.43.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.43.0.tgz",
+      "integrity": "sha512-Krjy9awJl6rKbruhQDgivNbD1WuLb8xAclM4IR4cN5pHGAs2oIMMQJEiC3IC/9TZJ+QZkmZhlMO/6MBGxPidpw==",
       "cpu": [
         "arm"
       ],
@@ -6086,9 +6139,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.41.0.tgz",
-      "integrity": "sha512-yDvqx3lWlcugozax3DItKJI5j05B0d4Kvnjx+5mwiUpWramVvmAByYigMplaoAQ3pvdprGCTCE03eduqE/8mPQ==",
+      "version": "4.43.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.43.0.tgz",
+      "integrity": "sha512-ss4YJwRt5I63454Rpj+mXCXicakdFmKnUNxr1dLK+5rv5FJgAxnN7s31a5VchRYxCFWdmnDWKd0wbAdTr0J5EA==",
       "cpu": [
         "arm64"
       ],
@@ -6099,9 +6152,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.41.0.tgz",
-      "integrity": "sha512-2KOU574vD3gzcPSjxO0eyR5iWlnxxtmW1F5CkNOHmMlueKNCQkxR6+ekgWyVnz6zaZihpUNkGxjsYrkTJKhkaw==",
+      "version": "4.43.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.43.0.tgz",
+      "integrity": "sha512-eKoL8ykZ7zz8MjgBenEF2OoTNFAPFz1/lyJ5UmmFSz5jW+7XbH1+MAgCVHy72aG59rbuQLcJeiMrP8qP5d/N0A==",
       "cpu": [
         "arm64"
       ],
@@ -6112,9 +6165,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.41.0.tgz",
-      "integrity": "sha512-gE5ACNSxHcEZyP2BA9TuTakfZvULEW4YAOtxl/A/YDbIir/wPKukde0BNPlnBiP88ecaN4BJI2TtAd+HKuZPQQ==",
+      "version": "4.43.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.43.0.tgz",
+      "integrity": "sha512-SYwXJgaBYW33Wi/q4ubN+ldWC4DzQY62S4Ll2dgfr/dbPoF50dlQwEaEHSKrQdSjC6oIe1WgzosoaNoHCdNuMg==",
       "cpu": [
         "x64"
       ],
@@ -6125,9 +6178,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.41.0.tgz",
-      "integrity": "sha512-GSxU6r5HnWij7FoSo7cZg3l5GPg4HFLkzsFFh0N/b16q5buW1NAWuCJ+HMtIdUEi6XF0qH+hN0TEd78laRp7Dg==",
+      "version": "4.43.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.43.0.tgz",
+      "integrity": "sha512-SV+U5sSo0yujrjzBF7/YidieK2iF6E7MdF6EbYxNz94lA+R0wKl3SiixGyG/9Klab6uNBIqsN7j4Y/Fya7wAjQ==",
       "cpu": [
         "arm64"
       ],
@@ -6138,9 +6191,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.41.0.tgz",
-      "integrity": "sha512-KGiGKGDg8qLRyOWmk6IeiHJzsN/OYxO6nSbT0Vj4MwjS2XQy/5emsmtoqLAabqrohbgLWJ5GV3s/ljdrIr8Qjg==",
+      "version": "4.43.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.43.0.tgz",
+      "integrity": "sha512-J7uCsiV13L/VOeHJBo5SjasKiGxJ0g+nQTrBkAsmQBIdil3KhPnSE9GnRon4ejX1XDdsmK/l30IYLiAaQEO0Cg==",
       "cpu": [
         "x64"
       ],
@@ -6151,9 +6204,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.41.0.tgz",
-      "integrity": "sha512-46OzWeqEVQyX3N2/QdiU/CMXYDH/lSHpgfBkuhl3igpZiaB3ZIfSjKuOnybFVBQzjsLwkus2mjaESy8H41SzvA==",
+      "version": "4.43.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.43.0.tgz",
+      "integrity": "sha512-gTJ/JnnjCMc15uwB10TTATBEhK9meBIY+gXP4s0sHD1zHOaIh4Dmy1X9wup18IiY9tTNk5gJc4yx9ctj/fjrIw==",
       "cpu": [
         "arm"
       ],
@@ -6164,9 +6217,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.41.0.tgz",
-      "integrity": "sha512-lfgW3KtQP4YauqdPpcUZHPcqQXmTmH4nYU0cplNeW583CMkAGjtImw4PKli09NFi2iQgChk4e9erkwlfYem6Lg==",
+      "version": "4.43.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.43.0.tgz",
+      "integrity": "sha512-ZJ3gZynL1LDSIvRfz0qXtTNs56n5DI2Mq+WACWZ7yGHFUEirHBRt7fyIk0NsCKhmRhn7WAcjgSkSVVxKlPNFFw==",
       "cpu": [
         "arm"
       ],
@@ -6177,9 +6230,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.41.0.tgz",
-      "integrity": "sha512-nn8mEyzMbdEJzT7cwxgObuwviMx6kPRxzYiOl6o/o+ChQq23gfdlZcUNnt89lPhhz3BYsZ72rp0rxNqBSfqlqw==",
+      "version": "4.43.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.43.0.tgz",
+      "integrity": "sha512-8FnkipasmOOSSlfucGYEu58U8cxEdhziKjPD2FIa0ONVMxvl/hmONtX/7y4vGjdUhjcTHlKlDhw3H9t98fPvyA==",
       "cpu": [
         "arm64"
       ],
@@ -6190,9 +6243,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.41.0.tgz",
-      "integrity": "sha512-l+QK99je2zUKGd31Gh+45c4pGDAqZSuWQiuRFCdHYC2CSiO47qUWsCcenrI6p22hvHZrDje9QjwSMAFL3iwXwQ==",
+      "version": "4.43.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.43.0.tgz",
+      "integrity": "sha512-KPPyAdlcIZ6S9C3S2cndXDkV0Bb1OSMsX0Eelr2Bay4EsF9yi9u9uzc9RniK3mcUGCLhWY9oLr6er80P5DE6XA==",
       "cpu": [
         "arm64"
       ],
@@ -6203,9 +6256,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.41.0.tgz",
-      "integrity": "sha512-WbnJaxPv1gPIm6S8O/Wg+wfE/OzGSXlBMbOe4ie+zMyykMOeqmgD1BhPxZQuDqwUN+0T/xOFtL2RUWBspnZj3w==",
+      "version": "4.43.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.43.0.tgz",
+      "integrity": "sha512-HPGDIH0/ZzAZjvtlXj6g+KDQ9ZMHfSP553za7o2Odegb/BEfwJcR0Sw0RLNpQ9nC6Gy8s+3mSS9xjZ0n3rhcYg==",
       "cpu": [
         "loong64"
       ],
@@ -6216,9 +6269,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.41.0.tgz",
-      "integrity": "sha512-eRDWR5t67/b2g8Q/S8XPi0YdbKcCs4WQ8vklNnUYLaSWF+Cbv2axZsp4jni6/j7eKvMLYCYdcsv8dcU+a6QNFg==",
+      "version": "4.43.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.43.0.tgz",
+      "integrity": "sha512-gEmwbOws4U4GLAJDhhtSPWPXUzDfMRedT3hFMyRAvM9Mrnj+dJIFIeL7otsv2WF3D7GrV0GIewW0y28dOYWkmw==",
       "cpu": [
         "ppc64"
       ],
@@ -6229,9 +6282,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.41.0.tgz",
-      "integrity": "sha512-TWrZb6GF5jsEKG7T1IHwlLMDRy2f3DPqYldmIhnA2DVqvvhY2Ai184vZGgahRrg8k9UBWoSlHv+suRfTN7Ua4A==",
+      "version": "4.43.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.43.0.tgz",
+      "integrity": "sha512-XXKvo2e+wFtXZF/9xoWohHg+MuRnvO29TI5Hqe9xwN5uN8NKUYy7tXUG3EZAlfchufNCTHNGjEx7uN78KsBo0g==",
       "cpu": [
         "riscv64"
       ],
@@ -6242,9 +6295,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.41.0.tgz",
-      "integrity": "sha512-ieQljaZKuJpmWvd8gW87ZmSFwid6AxMDk5bhONJ57U8zT77zpZ/TPKkU9HpnnFrM4zsgr4kiGuzbIbZTGi7u9A==",
+      "version": "4.43.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.43.0.tgz",
+      "integrity": "sha512-ruf3hPWhjw6uDFsOAzmbNIvlXFXlBQ4nk57Sec8E8rUxs/AI4HD6xmiiasOOx/3QxS2f5eQMKTAwk7KHwpzr/Q==",
       "cpu": [
         "riscv64"
       ],
@@ -6255,9 +6308,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.41.0.tgz",
-      "integrity": "sha512-/L3pW48SxrWAlVsKCN0dGLB2bi8Nv8pr5S5ocSM+S0XCn5RCVCXqi8GVtHFsOBBCSeR+u9brV2zno5+mg3S4Aw==",
+      "version": "4.43.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.43.0.tgz",
+      "integrity": "sha512-QmNIAqDiEMEvFV15rsSnjoSmO0+eJLoKRD9EAa9rrYNwO/XRCtOGM3A5A0X+wmG+XRrw9Fxdsw+LnyYiZWWcVw==",
       "cpu": [
         "s390x"
       ],
@@ -6268,9 +6321,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.41.0.tgz",
-      "integrity": "sha512-XMLeKjyH8NsEDCRptf6LO8lJk23o9wvB+dJwcXMaH6ZQbbkHu2dbGIUindbMtRN6ux1xKi16iXWu6q9mu7gDhQ==",
+      "version": "4.43.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.43.0.tgz",
+      "integrity": "sha512-jAHr/S0iiBtFyzjhOkAics/2SrXE092qyqEg96e90L3t9Op8OTzS6+IX0Fy5wCt2+KqeHAkti+eitV0wvblEoQ==",
       "cpu": [
         "x64"
       ],
@@ -6281,9 +6334,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.41.0.tgz",
-      "integrity": "sha512-m/P7LycHZTvSQeXhFmgmdqEiTqSV80zn6xHaQ1JSqwCtD1YGtwEK515Qmy9DcB2HK4dOUVypQxvhVSy06cJPEg==",
+      "version": "4.43.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.43.0.tgz",
+      "integrity": "sha512-3yATWgdeXyuHtBhrLt98w+5fKurdqvs8B53LaoKD7P7H7FKOONLsBVMNl9ghPQZQuYcceV5CDyPfyfGpMWD9mQ==",
       "cpu": [
         "x64"
       ],
@@ -6294,9 +6347,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.41.0.tgz",
-      "integrity": "sha512-4yodtcOrFHpbomJGVEqZ8fzD4kfBeCbpsUy5Pqk4RluXOdsWdjLnjhiKy2w3qzcASWd04fp52Xz7JKarVJ5BTg==",
+      "version": "4.43.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.43.0.tgz",
+      "integrity": "sha512-wVzXp2qDSCOpcBCT5WRWLmpJRIzv23valvcTwMHEobkjippNf+C3ys/+wf07poPkeNix0paTNemB2XrHr2TnGw==",
       "cpu": [
         "arm64"
       ],
@@ -6307,9 +6360,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.41.0.tgz",
-      "integrity": "sha512-tmazCrAsKzdkXssEc65zIE1oC6xPHwfy9d5Ta25SRCDOZS+I6RypVVShWALNuU9bxIfGA0aqrmzlzoM5wO5SPQ==",
+      "version": "4.43.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.43.0.tgz",
+      "integrity": "sha512-fYCTEyzf8d+7diCw8b+asvWDCLMjsCEA8alvtAutqJOJp/wL5hs1rWSqJ1vkjgW0L2NB4bsYJrpKkiIPRR9dvw==",
       "cpu": [
         "ia32"
       ],
@@ -6320,9 +6373,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.41.0.tgz",
-      "integrity": "sha512-h1J+Yzjo/X+0EAvR2kIXJDuTuyT7drc+t2ALY0nIcGPbTatNOf0VWdhEA2Z4AAjv6X1NJV7SYo5oCTYRJhSlVA==",
+      "version": "4.43.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.43.0.tgz",
+      "integrity": "sha512-SnGhLiE5rlK0ofq8kzuDkM0g7FN1s5VYY+YSMTibP7CqShxCQvqtNxTARS4xX4PFJfHjG0ZQYX9iGzI3FQh5Aw==",
       "cpu": [
         "x64"
       ],
@@ -6389,27 +6442,27 @@
       }
     },
     "node_modules/@sanity/cli": {
-      "version": "3.92.0",
-      "resolved": "https://registry.npmjs.org/@sanity/cli/-/cli-3.92.0.tgz",
-      "integrity": "sha512-7PwHteYuYz3N280eFWcZBabAifEn/lJMFO7Mi+I5/r4ZK1b4bz7LtB+L0kCI+/03jIBWc8BmSUCgHs85pus3uQ==",
+      "version": "3.93.0",
+      "resolved": "https://registry.npmjs.org/@sanity/cli/-/cli-3.93.0.tgz",
+      "integrity": "sha512-8PRrDhMuKcz7kMaa7ugwkT+jHeji2d3ci/CC2ilu/gHU/weYg/16ZDUd1rm4VclCOxzFD+2GuK+ysEJVAHXP3Q==",
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.23.5",
-        "@sanity/client": "^7.5.0",
-        "@sanity/codegen": "3.92.0",
-        "@sanity/runtime-cli": "^8.0.0",
+        "@babel/traverse": "^7.27.4",
+        "@sanity/client": "^7.6.0",
+        "@sanity/codegen": "3.93.0",
+        "@sanity/runtime-cli": "^8.1.0",
         "@sanity/telemetry": "^0.8.0",
         "@sanity/template-validator": "^2.4.3",
-        "@sanity/util": "3.92.0",
+        "@sanity/util": "3.93.0",
         "chalk": "^4.1.2",
         "debug": "^4.3.4",
         "decompress": "^4.2.0",
         "esbuild": "0.25.5",
-        "esbuild-register": "^3.5.0",
+        "esbuild-register": "^3.6.0",
         "get-it": "^8.6.9",
         "groq-js": "^1.17.0",
         "pkg-dir": "^5.0.0",
-        "prettier": "^3.3.0",
+        "prettier": "^3.5.3",
         "semver": "^7.3.5",
         "validate-npm-package-name": "^3.0.0"
       },
@@ -6421,9 +6474,9 @@
       }
     },
     "node_modules/@sanity/cli/node_modules/@sanity/client": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/@sanity/client/-/client-7.5.0.tgz",
-      "integrity": "sha512-Hy5jru/ePBlwTjc6dDxq8kqwiDbHb1l01WOQxRDITyqF8/ksa5fDcfmwjfhIBcFKkC222POd5UZ2vBsS4PSu/w==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@sanity/client/-/client-7.6.0.tgz",
+      "integrity": "sha512-bNgqWkKzzbAh2qDKHK0IYgR+7TaRsmk6rCpeX+kwIJ6J8ot8ZnZxzRgwfPmBztOQu8YfahQ6t90giT4uVhQNEg==",
       "license": "MIT",
       "dependencies": {
         "@sanity/eventsource": "^5.0.2",
@@ -6531,22 +6584,22 @@
       }
     },
     "node_modules/@sanity/codegen": {
-      "version": "3.92.0",
-      "resolved": "https://registry.npmjs.org/@sanity/codegen/-/codegen-3.92.0.tgz",
-      "integrity": "sha512-w/kwNtSfZDR7cIJ7Wbb8vxXDX3vOJhpt5RVSMEZ8QXjilZtZl75hi/yBF+y/rs2Jf0//LzF6/a8tu4sepPXyMw==",
+      "version": "3.93.0",
+      "resolved": "https://registry.npmjs.org/@sanity/codegen/-/codegen-3.93.0.tgz",
+      "integrity": "sha512-kfOdmOHDA63Ntmpit7wHGKkcTg/JOhObXcyXhSKY9xjkmeB8zwoR+zes8LuM4BZ9jv5bxzUebrubi6zabd4Egg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/core": "^7.23.9",
-        "@babel/generator": "^7.23.6",
-        "@babel/preset-env": "^7.23.8",
-        "@babel/preset-react": "^7.23.3",
-        "@babel/preset-typescript": "^7.23.3",
-        "@babel/register": "^7.23.7",
-        "@babel/traverse": "^7.23.5",
-        "@babel/types": "^7.23.9",
+        "@babel/core": "^7.27.4",
+        "@babel/generator": "^7.27.5",
+        "@babel/preset-env": "^7.27.2",
+        "@babel/preset-react": "^7.27.1",
+        "@babel/preset-typescript": "^7.27.1",
+        "@babel/register": "^7.27.1",
+        "@babel/traverse": "^7.27.4",
+        "@babel/types": "^7.27.6",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
-        "groq": "3.92.0",
+        "groq": "3.93.0",
         "groq-js": "^1.17.0",
         "json5": "^2.2.3",
         "tsconfig-paths": "^4.2.0",
@@ -6604,13 +6657,25 @@
         "uuid": "dist/esm/bin/uuid"
       }
     },
-    "node_modules/@sanity/diff": {
-      "version": "3.92.0",
-      "resolved": "https://registry.npmjs.org/@sanity/diff/-/diff-3.92.0.tgz",
-      "integrity": "sha512-SaX1H9lVqfRMv96ozzK1FeVNDPyc0p56Ibe2mvNvkwn+H4sUGpLZ6IloWKIXwARQ5zl24xkGdJaVGlRGDhAYNA==",
+    "node_modules/@sanity/descriptors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@sanity/descriptors/-/descriptors-1.0.0.tgz",
+      "integrity": "sha512-Gxp/N1GHkteSALUkURxMXZdKxl8LzUqfYMk0vq37Z4YznMs7wMDNHIgD5SwL3E3w6rQkALz69xki8hUBa23GsA==",
       "license": "MIT",
       "dependencies": {
-        "@sanity/diff-match-patch": "^3.1.1"
+        "sha256-uint8array": "^0.10.7"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@sanity/diff": {
+      "version": "3.93.0",
+      "resolved": "https://registry.npmjs.org/@sanity/diff/-/diff-3.93.0.tgz",
+      "integrity": "sha512-4/3nqMMdmMLfgJvLivFHLXS9FniEq5Ot9fMqArUMELNr7p25BSau5q4Sf+KKOQ/TGaW3eujB8yUD4bryDR7Hdg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sanity/diff-match-patch": "^3.2.0"
       },
       "engines": {
         "node": ">=18"
@@ -6988,15 +7053,15 @@
       }
     },
     "node_modules/@sanity/migrate": {
-      "version": "3.92.0",
-      "resolved": "https://registry.npmjs.org/@sanity/migrate/-/migrate-3.92.0.tgz",
-      "integrity": "sha512-Q3/m6nrAfDQvY/xTvpmiPXO67r8N/EaCali+ixriHVM52I9VICfQrQotF+xFAEwjbsdA1yqpqlCGsJnLLycnHA==",
+      "version": "3.93.0",
+      "resolved": "https://registry.npmjs.org/@sanity/migrate/-/migrate-3.93.0.tgz",
+      "integrity": "sha512-dOVhDdAlsm5971Tqmkuss3OxNPqSK7Takm3wPVgOlqHJPqoeZu4BagVE/mwL/ogozpPT+NrqhVU6/se5ldsdnw==",
       "license": "MIT",
       "dependencies": {
-        "@sanity/client": "^7.5.0",
+        "@sanity/client": "^7.6.0",
         "@sanity/mutate": "^0.12.4",
-        "@sanity/types": "3.92.0",
-        "@sanity/util": "3.92.0",
+        "@sanity/types": "3.93.0",
+        "@sanity/util": "3.93.0",
         "arrify": "^2.0.1",
         "debug": "^4.3.4",
         "fast-fifo": "^1.3.2",
@@ -7008,9 +7073,9 @@
       }
     },
     "node_modules/@sanity/migrate/node_modules/@sanity/client": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/@sanity/client/-/client-7.5.0.tgz",
-      "integrity": "sha512-Hy5jru/ePBlwTjc6dDxq8kqwiDbHb1l01WOQxRDITyqF8/ksa5fDcfmwjfhIBcFKkC222POd5UZ2vBsS4PSu/w==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@sanity/client/-/client-7.6.0.tgz",
+      "integrity": "sha512-bNgqWkKzzbAh2qDKHK0IYgR+7TaRsmk6rCpeX+kwIJ6J8ot8ZnZxzRgwfPmBztOQu8YfahQ6t90giT4uVhQNEg==",
       "license": "MIT",
       "dependencies": {
         "@sanity/eventsource": "^5.0.2",
@@ -7099,13 +7164,13 @@
       }
     },
     "node_modules/@sanity/mutator": {
-      "version": "3.92.0",
-      "resolved": "https://registry.npmjs.org/@sanity/mutator/-/mutator-3.92.0.tgz",
-      "integrity": "sha512-P3/MYXGnW020JRg0dy3LYyshwcFZRrQJq1orJH6MJZHq8SsVxqT9vSGnqUT4qPE+6tCPRVt8Gf2pHWI2+NLkeg==",
+      "version": "3.93.0",
+      "resolved": "https://registry.npmjs.org/@sanity/mutator/-/mutator-3.93.0.tgz",
+      "integrity": "sha512-RZIQ9ZZCnEyOfaLSGGhGTMciYD2dddWv1qwdh9kAmnSoW4QKhInW67ql9/MHRu7y+i5M59pGf4qYnRrU6S+jLw==",
       "license": "MIT",
       "dependencies": {
-        "@sanity/diff-match-patch": "^3.1.1",
-        "@sanity/types": "3.92.0",
+        "@sanity/diff-match-patch": "^3.2.0",
+        "@sanity/types": "3.93.0",
         "@sanity/uuid": "^3.0.1",
         "debug": "^4.3.4",
         "lodash": "^4.17.21"
@@ -7181,9 +7246,9 @@
       }
     },
     "node_modules/@sanity/runtime-cli": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@sanity/runtime-cli/-/runtime-cli-8.0.0.tgz",
-      "integrity": "sha512-ApwAN3S2KhfUS1kpBTiYRTGqfXYrqhkYE0Ej3qGsAg42JbcchSsnQeqmIO+RUa2L9vq86IZoSkNUapXfnEkxLg==",
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/@sanity/runtime-cli/-/runtime-cli-8.1.2.tgz",
+      "integrity": "sha512-js1IL1cGMVQmqaPfGY7Cn1JGbLdzidj2M5YZAMfUB7UCIL0IPqfUKYWnhcgYOXlnVCy0MgFgb6oKGB+GqEsBvQ==",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "^4.3.0",
@@ -7199,6 +7264,7 @@
         "jiti": "^2.4.2",
         "mime-types": "^3.0.1",
         "ora": "^8.2.0",
+        "tar-stream": "^3.1.7",
         "vite": "^6.3.5",
         "vite-tsconfig-paths": "^5.1.4",
         "ws": "^8.18.2",
@@ -7535,13 +7601,14 @@
       }
     },
     "node_modules/@sanity/schema": {
-      "version": "3.92.0",
-      "resolved": "https://registry.npmjs.org/@sanity/schema/-/schema-3.92.0.tgz",
-      "integrity": "sha512-KYwBRLGli8itmTOpJvghAoKJpnMVREBDqOSDBk7XkIzRh2jwRXC8DBE3utVhqYzl7qGLmSJrE2H7mLiHYhfrQA==",
+      "version": "3.93.0",
+      "resolved": "https://registry.npmjs.org/@sanity/schema/-/schema-3.93.0.tgz",
+      "integrity": "sha512-uY6PaVlEgXrIN+X1eW/RrKpCzomOQ/uQhLN74XXTAri19EVOBBrIrBOkUVIb4EB7RrAKPAV7xMGFYEoAiRy3PQ==",
       "license": "MIT",
       "dependencies": {
+        "@sanity/descriptors": "1.0.0",
         "@sanity/generate-help-url": "^3.0.0",
-        "@sanity/types": "3.92.0",
+        "@sanity/types": "3.93.0",
         "arrify": "^2.0.1",
         "groq-js": "^1.17.0",
         "humanize-list": "^1.0.1",
@@ -7658,21 +7725,21 @@
       }
     },
     "node_modules/@sanity/types": {
-      "version": "3.92.0",
-      "resolved": "https://registry.npmjs.org/@sanity/types/-/types-3.92.0.tgz",
-      "integrity": "sha512-YJP3SGRbxRWwXi0YQnZEqjts5+JetkLalNyFaeX+DzUBw6yyITrJUcjPbaY5G2+jOFzYdZCDi9ktoQJnVhc7xA==",
+      "version": "3.93.0",
+      "resolved": "https://registry.npmjs.org/@sanity/types/-/types-3.93.0.tgz",
+      "integrity": "sha512-W3ZxNpQcZ2qV4qkF9993osxzt2rWwbMZpdU7H3O6aWNA1REpjb6iDDGBLP3+a7fJJhnDvhUjeeKHIuXN2hFOhw==",
       "license": "MIT",
       "dependencies": {
-        "@sanity/client": "^7.5.0"
+        "@sanity/client": "^7.6.0"
       },
       "peerDependencies": {
         "@types/react": "18 || 19"
       }
     },
     "node_modules/@sanity/types/node_modules/@sanity/client": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/@sanity/client/-/client-7.5.0.tgz",
-      "integrity": "sha512-Hy5jru/ePBlwTjc6dDxq8kqwiDbHb1l01WOQxRDITyqF8/ksa5fDcfmwjfhIBcFKkC222POd5UZ2vBsS4PSu/w==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@sanity/client/-/client-7.6.0.tgz",
+      "integrity": "sha512-bNgqWkKzzbAh2qDKHK0IYgR+7TaRsmk6rCpeX+kwIJ6J8ot8ZnZxzRgwfPmBztOQu8YfahQ6t90giT4uVhQNEg==",
       "license": "MIT",
       "dependencies": {
         "@sanity/eventsource": "^5.0.2",
@@ -7710,15 +7777,15 @@
       }
     },
     "node_modules/@sanity/util": {
-      "version": "3.92.0",
-      "resolved": "https://registry.npmjs.org/@sanity/util/-/util-3.92.0.tgz",
-      "integrity": "sha512-Hy4evu56G11OLOUoZmSPzB0XGaANxpxvUK6mgWlwxu9voAyIJ1sBuF0jShppMULT3P4HoY+S1lt7WC3tQhnOcg==",
+      "version": "3.93.0",
+      "resolved": "https://registry.npmjs.org/@sanity/util/-/util-3.93.0.tgz",
+      "integrity": "sha512-evAQ7phKucEOgdoiQvdjsZjgZg5m/Bg2BZ2B+JDPgh8Uo6KHaN3Xna+HL9gHknAoqw+ItUg23wDRW7c5Kqx/IA==",
       "license": "MIT",
       "dependencies": {
         "@date-fns/tz": "^1.2.0",
         "@date-fns/utc": "^2.1.0",
-        "@sanity/client": "^7.5.0",
-        "@sanity/types": "3.92.0",
+        "@sanity/client": "^7.6.0",
+        "@sanity/types": "3.93.0",
         "date-fns": "^4.1.0",
         "get-random-values-esm": "1.0.2",
         "rxjs": "^7.8.2"
@@ -7728,9 +7795,9 @@
       }
     },
     "node_modules/@sanity/util/node_modules/@sanity/client": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/@sanity/client/-/client-7.5.0.tgz",
-      "integrity": "sha512-Hy5jru/ePBlwTjc6dDxq8kqwiDbHb1l01WOQxRDITyqF8/ksa5fDcfmwjfhIBcFKkC222POd5UZ2vBsS4PSu/w==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@sanity/client/-/client-7.6.0.tgz",
+      "integrity": "sha512-bNgqWkKzzbAh2qDKHK0IYgR+7TaRsmk6rCpeX+kwIJ6J8ot8ZnZxzRgwfPmBztOQu8YfahQ6t90giT4uVhQNEg==",
       "license": "MIT",
       "dependencies": {
         "@sanity/eventsource": "^5.0.2",
@@ -7762,23 +7829,23 @@
       }
     },
     "node_modules/@sanity/vision": {
-      "version": "3.92.0",
-      "resolved": "https://registry.npmjs.org/@sanity/vision/-/vision-3.92.0.tgz",
-      "integrity": "sha512-Ae+rhcYtESdRZ8ntXr/x/NrC3A7c+ehPhrAL7qPqpuAy0voz1aZFb37fr+IBEfqMeDw1mW/HPGZplz8xT1/PpQ==",
+      "version": "3.93.0",
+      "resolved": "https://registry.npmjs.org/@sanity/vision/-/vision-3.93.0.tgz",
+      "integrity": "sha512-V0OXq0HF00Mk3XM877cCTxKHPv6CnK7Ogeq5sTvUz+gp5XjXV3nMfYcX+0iCs+eR8yOoCKQWYD5JKo5hIAdKwg==",
       "license": "MIT",
       "dependencies": {
-        "@codemirror/autocomplete": "^6.1.0",
-        "@codemirror/commands": "^6.0.1",
-        "@codemirror/lang-javascript": "^6.0.2",
-        "@codemirror/language": "^6.2.1",
-        "@codemirror/search": "^6.0.1",
-        "@codemirror/state": "^6.0.0",
-        "@codemirror/view": "^6.1.1",
-        "@juggle/resize-observer": "^3.3.1",
+        "@codemirror/autocomplete": "^6.18.6",
+        "@codemirror/commands": "^6.8.1",
+        "@codemirror/lang-javascript": "^6.2.4",
+        "@codemirror/language": "^6.11.1",
+        "@codemirror/search": "^6.5.11",
+        "@codemirror/state": "^6.5.2",
+        "@codemirror/view": "^6.37.2",
+        "@juggle/resize-observer": "^3.4.0",
         "@lezer/highlight": "^1.0.0",
         "@rexxars/react-json-inspector": "^9.0.1",
         "@rexxars/react-split-pane": "^1.0.0",
-        "@sanity/color": "^3.0.0",
+        "@sanity/color": "^3.0.6",
         "@sanity/icons": "^3.7.0",
         "@sanity/ui": "^2.15.18",
         "@sanity/uuid": "^3.0.2",
@@ -7791,7 +7858,7 @@
         "react-compiler-runtime": "19.1.0-rc.2",
         "react-fast-compare": "^3.2.2",
         "rxjs": "^7.8.0",
-        "use-effect-event": "^1.0.2"
+        "use-effect-event": "^2.0.1"
       },
       "peerDependencies": {
         "react": "^18 || ^19.0.0",
@@ -7824,6 +7891,15 @@
         "styled-components": "^5.2 || ^6"
       }
     },
+    "node_modules/@sanity/vision/node_modules/@sanity/ui/node_modules/use-effect-event": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/use-effect-event/-/use-effect-event-1.0.2.tgz",
+      "integrity": "sha512-9c8AAmtQja4LwJXI0EQPhQCip6dmrcSe0FMcTUZBeGh/XTCOLgw3Qbt0JdUT8Rcrm/ZH+Web7MIcMdqgQKdXJg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.3 || ^19.0.0-0"
+      }
+    },
     "node_modules/@sanity/vision/node_modules/react-compiler-runtime": {
       "version": "19.1.0-rc.2",
       "resolved": "https://registry.npmjs.org/react-compiler-runtime/-/react-compiler-runtime-19.1.0-rc.2.tgz",
@@ -7833,12 +7909,14 @@
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0 || ^0.0.0-experimental"
       }
     },
-    "node_modules/@sanity/vision/node_modules/react-is": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.1.0.tgz",
-      "integrity": "sha512-Oe56aUPnkHyyDxxkvqtd7KkdQP5uIUfHxd5XTb3wE9d/kRnZLmKbDB0GWk919tdQ+mxxPtG6EAs6RMT6i1qtHg==",
+    "node_modules/@sanity/vision/node_modules/use-effect-event": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/use-effect-event/-/use-effect-event-2.0.1.tgz",
+      "integrity": "sha512-76rGQGL83WpjyqrYNsQXA9U7y68HNfeGecBz7q8jvEGXucnh0oUedjxHuOmwVucv8kzpHOYx6OlrLAuQ66fvbg==",
       "license": "MIT",
-      "peer": true
+      "peerDependencies": {
+        "react": "^18.3 || ^19.0.0-0"
+      }
     },
     "node_modules/@sanity/visual-editing": {
       "version": "2.13.5",
@@ -8319,11 +8397,12 @@
       }
     },
     "node_modules/@tanstack/react-table": {
-      "version": "8.21.2",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-table/-/react-table-8.21.2.tgz",
-      "integrity": "sha512-11tNlEDTdIhMJba2RBH+ecJ9l1zgS2kjmexDPAraulc8jeNA4xocSNeyzextT0XJyASil4XsCYlJmf5jEWAtYg==",
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-table/-/react-table-8.21.3.tgz",
+      "integrity": "sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==",
+      "license": "MIT",
       "dependencies": {
-        "@tanstack/table-core": "8.21.2"
+        "@tanstack/table-core": "8.21.3"
       },
       "engines": {
         "node": ">=12"
@@ -8338,11 +8417,12 @@
       }
     },
     "node_modules/@tanstack/react-virtual": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.0.tgz",
-      "integrity": "sha512-CchF0NlLIowiM2GxtsoKBkXA4uqSnY2KvnXo+kyUFD4a4ll6+J0qzoRsUPMwXV/H26lRsxgJIr/YmjYum2oEjg==",
+      "version": "3.13.10",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.10.tgz",
+      "integrity": "sha512-nvrzk4E9mWB4124YdJ7/yzwou7IfHxlSef6ugCFcBfRmsnsma3heciiiV97sBNxyc3VuwtZvmwXd0aB5BpucVw==",
+      "license": "MIT",
       "dependencies": {
-        "@tanstack/virtual-core": "3.13.0"
+        "@tanstack/virtual-core": "3.13.10"
       },
       "funding": {
         "type": "github",
@@ -8354,9 +8434,10 @@
       }
     },
     "node_modules/@tanstack/table-core": {
-      "version": "8.21.2",
-      "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.21.2.tgz",
-      "integrity": "sha512-uvXk/U4cBiFMxt+p9/G7yUWI/UbHYbyghLCjlpWZ3mLeIZiUBSKcUnw9UnKkdRz7Z/N4UBuFLWQdJCjUe7HjvA==",
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.21.3.tgz",
+      "integrity": "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==",
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -8366,9 +8447,10 @@
       }
     },
     "node_modules/@tanstack/virtual-core": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.0.tgz",
-      "integrity": "sha512-NBKJP3OIdmZY3COJdWkSonr50FMVIi+aj5ZJ7hI/DTpEKg2RMfo/KvP8A3B/zOSpMgIe52B5E2yn7rryULzA6g==",
+      "version": "3.13.10",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.10.tgz",
+      "integrity": "sha512-sPEDhXREou5HyZYqSWIqdU580rsF6FGeN7vpzijmP3KTiOGjOMZASz4Y6+QKjiFQwhWrR58OP8izYaNGVxvViA==",
+      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
@@ -8575,7 +8657,7 @@
       "version": "18.3.5",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.5.tgz",
       "integrity": "sha512-P4t6saawp+b/dFrUr2cvkVsfvPguwsxtH6dNIYRllMsefqFzkZk5UIjzyDOv5g1dXIPdG4Sp1yCR4Z6RCUsG/Q==",
-      "devOptional": true,
+      "dev": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -9032,7 +9114,7 @@
       "version": "8.14.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
       "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
-      "devOptional": true,
+      "dev": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -12772,6 +12854,20 @@
         "pend": "~1.2.0"
       }
     },
+    "node_modules/fdir": {
+      "version": "6.4.6",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
+      "integrity": "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -12818,9 +12914,9 @@
       }
     },
     "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -13239,13 +13335,13 @@
       }
     },
     "node_modules/framer-motion": {
-      "version": "12.12.1",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.12.1.tgz",
-      "integrity": "sha512-PFw4/GCREHI2suK/NlPSUxd+x6Rkp80uQsfCRFSOQNrm5pZif7eGtmG1VaD/UF1fW9tRBy5AaS77StatB3OJDg==",
+      "version": "12.18.1",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.18.1.tgz",
+      "integrity": "sha512-6o4EDuRPLk4LSZ1kRnnEOurbQ86MklVk+Y1rFBUKiF+d2pCdvMjWVu0ZkyMVCTwl5UyTH2n/zJEJx+jvTYuxow==",
       "license": "MIT",
       "dependencies": {
-        "motion-dom": "^12.12.1",
-        "motion-utils": "^12.12.1",
+        "motion-dom": "^12.18.1",
+        "motion-utils": "^12.18.1",
         "tslib": "^2.4.0"
       },
       "peerDependencies": {
@@ -13814,9 +13910,9 @@
       "dev": true
     },
     "node_modules/groq": {
-      "version": "3.92.0",
-      "resolved": "https://registry.npmjs.org/groq/-/groq-3.92.0.tgz",
-      "integrity": "sha512-hxdCzI7fvoMTx7tB02thfRZN7cjcNtJGfow0VlMhlhOlwakBiwFKSpWJJ4JRxRM72dWTrrGQA+8e25c1wz4APQ==",
+      "version": "3.93.0",
+      "resolved": "https://registry.npmjs.org/groq/-/groq-3.93.0.tgz",
+      "integrity": "sha512-vEEvYwsGOk9CSmdGXXUkWP/YhNB+drG/K7Mv53ve9Yyf1ixQ1VVCTa8B/62ZAlYETs2uQcz9fMsm0kjPJz8Y3w==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -16158,18 +16254,18 @@
       }
     },
     "node_modules/motion-dom": {
-      "version": "12.12.1",
-      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.12.1.tgz",
-      "integrity": "sha512-GXq/uUbZBEiFFE+K1Z/sxdPdadMdfJ/jmBALDfIuHGi0NmtealLOfH9FqT+6aNPgVx8ilq0DtYmyQlo6Uj9LKQ==",
+      "version": "12.18.1",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.18.1.tgz",
+      "integrity": "sha512-dR/4EYT23Snd+eUSLrde63Ws3oXQtJNw/krgautvTfwrN/2cHfCZMdu6CeTxVfRRWREW3Fy1f5vobRDiBb/q+w==",
       "license": "MIT",
       "dependencies": {
-        "motion-utils": "^12.12.1"
+        "motion-utils": "^12.18.1"
       }
     },
     "node_modules/motion-utils": {
-      "version": "12.12.1",
-      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.12.1.tgz",
-      "integrity": "sha512-f9qiqUHm7hWSLlNW8gS9pisnsN7CRFRD58vNjptKdsqFLpkVnX00TNeD6Q0d27V9KzT7ySFyK1TZ/DShfVOv6w==",
+      "version": "12.18.1",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.18.1.tgz",
+      "integrity": "sha512-az26YDU4WoDP0ueAkUtABLk2BIxe28d8NH1qWT8jPGhPyf44XTdDUh8pDk9OPphaSrR9McgpcJlgwSOIw/sfkA==",
       "license": "MIT"
     },
     "node_modules/ms": {
@@ -17825,14 +17921,14 @@
       }
     },
     "node_modules/react-rx": {
-      "version": "4.1.29",
-      "resolved": "https://registry.npmjs.org/react-rx/-/react-rx-4.1.29.tgz",
-      "integrity": "sha512-ET39XJwZyYtBb3dw3hiQjuXVwHB+X6K6SxqRskE3gh3Se5gjly9WrryxiEQy0WsYZ5rJopnCf06TzUvOIkz0yQ==",
+      "version": "4.1.30",
+      "resolved": "https://registry.npmjs.org/react-rx/-/react-rx-4.1.30.tgz",
+      "integrity": "sha512-O5+9CDr+yYqmPNb0Ddc6/wdc4EGpfZnZaK4h5Kf6d6ruleVb++usLUW39PmZowUH2bYCF7QnW5Gl0vLNVIlT0A==",
       "license": "MIT",
       "dependencies": {
         "observable-callback": "^1.0.3",
         "react-compiler-runtime": "19.1.0-rc.2",
-        "use-effect-event": "^2.0.0"
+        "use-effect-event": "^2.0.1"
       },
       "peerDependencies": {
         "react": "^18.3 || >=19.0.0-0",
@@ -17849,9 +17945,9 @@
       }
     },
     "node_modules/react-rx/node_modules/use-effect-event": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/use-effect-event/-/use-effect-event-2.0.0.tgz",
-      "integrity": "sha512-CIRGe/RUfngbmivpY5F7rc0m7q0VYzqtQOcKJ19FPEeyf7tS44Zk+9tcDicP+z+d32+E2r+Zs7+20MHXa8JBUA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/use-effect-event/-/use-effect-event-2.0.1.tgz",
+      "integrity": "sha512-76rGQGL83WpjyqrYNsQXA9U7y68HNfeGecBz7q8jvEGXucnh0oUedjxHuOmwVucv8kzpHOYx6OlrLAuQ66fvbg==",
       "license": "MIT",
       "peerDependencies": {
         "react": "^18.3 || ^19.0.0-0"
@@ -18257,14 +18353,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/regenerator-transform": {
-      "version": "0.15.2",
-      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.15.2.tgz",
-      "integrity": "sha512-hfMp2BoF0qOk3uc5V20ALGDS2ddjQaLrdl7xrGXvAIow7qeWRM2VA2HuCHkUKk9slq3VwEwLNK3DFBqDfPGYtg==",
-      "dependencies": {
-        "@babel/runtime": "^7.8.4"
-      }
-    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
@@ -18438,9 +18526,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.41.0.tgz",
-      "integrity": "sha512-HqMFpUbWlf/tvcxBFNKnJyzc7Lk+XO3FGc3pbNBLqEbOz0gPLRgcrlS3UF4MfUrVlstOaP/q0kM6GVvi+LrLRg==",
+      "version": "4.43.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.43.0.tgz",
+      "integrity": "sha512-wdN2Kd3Twh8MAEOEJZsuxuLKCsBEo4PVNLK6tQWAn10VhsVewQLzcucMgLolRlhFybGxfclbPeEYBaP6RvUFGg==",
       "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.7"
@@ -18453,26 +18541,26 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.41.0",
-        "@rollup/rollup-android-arm64": "4.41.0",
-        "@rollup/rollup-darwin-arm64": "4.41.0",
-        "@rollup/rollup-darwin-x64": "4.41.0",
-        "@rollup/rollup-freebsd-arm64": "4.41.0",
-        "@rollup/rollup-freebsd-x64": "4.41.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.41.0",
-        "@rollup/rollup-linux-arm-musleabihf": "4.41.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.41.0",
-        "@rollup/rollup-linux-arm64-musl": "4.41.0",
-        "@rollup/rollup-linux-loongarch64-gnu": "4.41.0",
-        "@rollup/rollup-linux-powerpc64le-gnu": "4.41.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.41.0",
-        "@rollup/rollup-linux-riscv64-musl": "4.41.0",
-        "@rollup/rollup-linux-s390x-gnu": "4.41.0",
-        "@rollup/rollup-linux-x64-gnu": "4.41.0",
-        "@rollup/rollup-linux-x64-musl": "4.41.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.41.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.41.0",
-        "@rollup/rollup-win32-x64-msvc": "4.41.0",
+        "@rollup/rollup-android-arm-eabi": "4.43.0",
+        "@rollup/rollup-android-arm64": "4.43.0",
+        "@rollup/rollup-darwin-arm64": "4.43.0",
+        "@rollup/rollup-darwin-x64": "4.43.0",
+        "@rollup/rollup-freebsd-arm64": "4.43.0",
+        "@rollup/rollup-freebsd-x64": "4.43.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.43.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.43.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.43.0",
+        "@rollup/rollup-linux-arm64-musl": "4.43.0",
+        "@rollup/rollup-linux-loongarch64-gnu": "4.43.0",
+        "@rollup/rollup-linux-powerpc64le-gnu": "4.43.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.43.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.43.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.43.0",
+        "@rollup/rollup-linux-x64-gnu": "4.43.0",
+        "@rollup/rollup-linux-x64-musl": "4.43.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.43.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.43.0",
+        "@rollup/rollup-win32-x64-msvc": "4.43.0",
         "fsevents": "~2.3.2"
       }
     },
@@ -18616,31 +18704,31 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/sanity": {
-      "version": "3.92.0",
-      "resolved": "https://registry.npmjs.org/sanity/-/sanity-3.92.0.tgz",
-      "integrity": "sha512-1QzHTKGovynUw9S3a5rITr6RDuPllX0/CgXKQnKRdk2u67Rr0pqoTcVrnbnQjopjHzImXWgZCh9wvilu9coLpQ==",
+      "version": "3.93.0",
+      "resolved": "https://registry.npmjs.org/sanity/-/sanity-3.93.0.tgz",
+      "integrity": "sha512-CsVuJ7GR9UeWxqmmGlV5vuc5ZhZLbIFxfUHnKsiMSymNgyg4BqaWreEeyFU6Eq0hlh71UG7W7F6ZdnHF7EO+Rg==",
       "license": "MIT",
       "dependencies": {
-        "@dnd-kit/core": "^6.0.5",
-        "@dnd-kit/modifiers": "^6.0.0",
-        "@dnd-kit/sortable": "^7.0.1",
-        "@dnd-kit/utilities": "^3.2.0",
-        "@juggle/resize-observer": "^3.3.1",
-        "@portabletext/block-tools": "^1.1.28",
-        "@portabletext/editor": "^1.50.8",
-        "@portabletext/react": "^3.0.0",
-        "@portabletext/toolkit": "^2.0.16",
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/modifiers": "^6.0.1",
+        "@dnd-kit/sortable": "^7.0.2",
+        "@dnd-kit/utilities": "^3.2.2",
+        "@juggle/resize-observer": "^3.4.0",
+        "@portabletext/block-tools": "^1.1.30",
+        "@portabletext/editor": "^1.53.0",
+        "@portabletext/react": "^3.2.1",
+        "@portabletext/toolkit": "^2.0.17",
         "@rexxars/react-json-inspector": "^9.0.1",
-        "@sanity/asset-utils": "^2.0.6",
+        "@sanity/asset-utils": "^2.2.1",
         "@sanity/bifur-client": "^0.4.1",
-        "@sanity/cli": "3.92.0",
-        "@sanity/client": "^7.5.0",
-        "@sanity/color": "^3.0.0",
+        "@sanity/cli": "3.93.0",
+        "@sanity/client": "^7.6.0",
+        "@sanity/color": "^3.0.6",
         "@sanity/comlink": "^3.0.5",
-        "@sanity/diff": "3.92.0",
-        "@sanity/diff-match-patch": "^3.1.1",
+        "@sanity/diff": "3.93.0",
+        "@sanity/diff-match-patch": "^3.2.0",
         "@sanity/diff-patch": "^5.0.0",
-        "@sanity/eventsource": "^5.0.0",
+        "@sanity/eventsource": "^5.0.2",
         "@sanity/export": "^3.44.0",
         "@sanity/icons": "^3.7.0",
         "@sanity/id-utils": "^1.0.0",
@@ -18649,27 +18737,27 @@
         "@sanity/insert-menu": "^1.1.12",
         "@sanity/logos": "^2.2.0",
         "@sanity/message-protocol": "^0.13.0",
-        "@sanity/migrate": "3.92.0",
-        "@sanity/mutator": "3.92.0",
+        "@sanity/migrate": "3.93.0",
+        "@sanity/mutator": "3.93.0",
         "@sanity/presentation-comlink": "^1.0.21",
         "@sanity/preview-url-secret": "^2.1.11",
-        "@sanity/schema": "3.92.0",
+        "@sanity/schema": "3.93.0",
         "@sanity/sdk": "0.0.0-alpha.25",
         "@sanity/telemetry": "^0.8.0",
-        "@sanity/types": "3.92.0",
+        "@sanity/types": "3.93.0",
         "@sanity/ui": "^2.15.18",
-        "@sanity/util": "3.92.0",
+        "@sanity/util": "3.93.0",
         "@sanity/uuid": "^3.0.2",
         "@sentry/react": "^8.33.0",
-        "@tanstack/react-table": "^8.16.0",
-        "@tanstack/react-virtual": "^3.11.2",
+        "@tanstack/react-table": "^8.21.3",
+        "@tanstack/react-virtual": "^3.13.10",
         "@types/react-is": "^19.0.0",
         "@types/shallow-equals": "^1.0.0",
         "@types/speakingurl": "^13.0.3",
         "@types/tar-stream": "^3.1.3",
         "@types/use-sync-external-store": "^1.5.0",
         "@types/which": "^3.0.4",
-        "@vitejs/plugin-react": "^4.5.1",
+        "@vitejs/plugin-react": "^4.5.2",
         "@xstate/react": "^5.0.5",
         "archiver": "^7.0.0",
         "arrify": "^2.0.1",
@@ -18684,18 +18772,18 @@
         "date-fns": "^2.26.1",
         "debug": "^4.3.4",
         "esbuild": "0.25.5",
-        "esbuild-register": "^3.5.0",
+        "esbuild-register": "^3.6.0",
         "execa": "^2.0.0",
         "exif-component": "^1.0.1",
         "fast-deep-equal": "3.1.3",
         "form-data": "^4.0.0",
-        "framer-motion": "^12.6.3",
+        "framer-motion": "^12.18.1",
         "get-it": "^8.6.9",
         "get-random-values-esm": "1.0.2",
         "groq-js": "^1.17.0",
         "gunzip-maybe": "^1.4.2",
         "history": "^5.3.0",
-        "i18next": "^23.2.7",
+        "i18next": "^23.16.8",
         "import-fresh": "^3.3.0",
         "is-hotkey-esm": "^1.0.0",
         "is-tar": "^1.0.0",
@@ -18731,7 +18819,7 @@
         "react-i18next": "14.0.2",
         "react-is": "^18.2.0",
         "react-refractor": "^2.1.6",
-        "react-rx": "^4.1.29",
+        "react-rx": "^4.1.30",
         "read-pkg-up": "^7.0.1",
         "refractor": "^3.6.0",
         "resolve-from": "^5.0.0",
@@ -18749,8 +18837,8 @@
         "tar-stream": "^3.1.7",
         "tinyglobby": "^0.2.13",
         "urlpattern-polyfill": "10.1.0",
-        "use-device-pixel-ratio": "^1.1.0",
-        "use-effect-event": "^1.0.2",
+        "use-device-pixel-ratio": "^1.1.2",
+        "use-effect-event": "^2.0.1",
         "use-hot-module-reload": "^2.0.0",
         "use-sync-external-store": "^1.5.0",
         "uuid": "^11.0.5",
@@ -18793,9 +18881,9 @@
       }
     },
     "node_modules/sanity/node_modules/@sanity/client": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/@sanity/client/-/client-7.5.0.tgz",
-      "integrity": "sha512-Hy5jru/ePBlwTjc6dDxq8kqwiDbHb1l01WOQxRDITyqF8/ksa5fDcfmwjfhIBcFKkC222POd5UZ2vBsS4PSu/w==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@sanity/client/-/client-7.6.0.tgz",
+      "integrity": "sha512-bNgqWkKzzbAh2qDKHK0IYgR+7TaRsmk6rCpeX+kwIJ6J8ot8ZnZxzRgwfPmBztOQu8YfahQ6t90giT4uVhQNEg==",
       "license": "MIT",
       "dependencies": {
         "@sanity/eventsource": "^5.0.2",
@@ -18883,6 +18971,15 @@
         "react-dom": "^18 || >=19.0.0-0",
         "react-is": "^18 || >=19.0.0-0",
         "styled-components": "^5.2 || ^6"
+      }
+    },
+    "node_modules/sanity/node_modules/@sanity/ui/node_modules/use-effect-event": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/use-effect-event/-/use-effect-event-1.0.2.tgz",
+      "integrity": "sha512-9c8AAmtQja4LwJXI0EQPhQCip6dmrcSe0FMcTUZBeGh/XTCOLgw3Qbt0JdUT8Rcrm/ZH+Web7MIcMdqgQKdXJg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.3 || ^19.0.0-0"
       }
     },
     "node_modules/sanity/node_modules/@sanity/visual-editing-types": {
@@ -19114,6 +19211,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/sanity/node_modules/use-effect-event": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/use-effect-event/-/use-effect-event-2.0.1.tgz",
+      "integrity": "sha512-76rGQGL83WpjyqrYNsQXA9U7y68HNfeGecBz7q8jvEGXucnh0oUedjxHuOmwVucv8kzpHOYx6OlrLAuQ66fvbg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.3 || ^19.0.0-0"
+      }
+    },
     "node_modules/sanity/node_modules/uuid": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
@@ -19237,6 +19343,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/sha256-uint8array": {
+      "version": "0.10.7",
+      "resolved": "https://registry.npmjs.org/sha256-uint8array/-/sha256-uint8array-0.10.7.tgz",
+      "integrity": "sha512-1Q6JQU4tX9NqsDGodej6pkrUVQVNapLZnvkwIhddH/JqzBZF1fSaxSWNY6sziXBE8aEa2twtGkXUrwzGeZCMpQ==",
+      "license": "MIT"
     },
     "node_modules/shallow-clone": {
       "version": "3.0.1",
@@ -20277,25 +20389,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/terser": {
-      "version": "5.39.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.39.0.tgz",
-      "integrity": "sha512-LBAhFyLho16harJoWMg/nZsQYgTrg5jXOn2nCYjRUcZZEdE3qa2zb8QEDRUGVZBW4rlazf2fxkg8tztybTaqWw==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/source-map": "^0.3.3",
-        "acorn": "^8.8.2",
-        "commander": "^2.20.0",
-        "source-map-support": "~0.5.20"
-      },
-      "bin": {
-        "terser": "bin/terser"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/text-decoder": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.3.tgz",
@@ -20397,20 +20490,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
-      }
-    },
-    "node_modules/tinyglobby/node_modules/fdir": {
-      "version": "6.4.4",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.4.tgz",
-      "integrity": "sha512-1NZP+GK4GfuAv3PqKvxQRDMjdSRZjnkq7KfhlNrCNNlZ0ygQFpebfrnfnq/W7fpUnAv9aGWmY1zKx7FYL3gwhg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "picomatch": "^3 || ^4"
-      },
-      "peerDependenciesMeta": {
-        "picomatch": {
-          "optional": true
-        }
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
@@ -20730,7 +20809,7 @@
       "version": "5.6.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
       "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
-      "devOptional": true,
+      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -21189,20 +21268,6 @@
       },
       "peerDependenciesMeta": {
         "vite": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/vite/node_modules/fdir": {
-      "version": "6.4.4",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.4.tgz",
-      "integrity": "sha512-1NZP+GK4GfuAv3PqKvxQRDMjdSRZjnkq7KfhlNrCNNlZ0ygQFpebfrnfnq/W7fpUnAv9aGWmY1zKx7FYL3gwhg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "picomatch": "^3 || ^4"
-      },
-      "peerDependenciesMeta": {
-        "picomatch": {
           "optional": true
         }
       }
@@ -21763,13 +21828,13 @@
       "dependencies": {
         "@sanity/assist": "^3.2.0",
         "@sanity/icons": "^3.5.0",
-        "@sanity/vision": "^3.92.0",
+        "@sanity/vision": "^3.93.0",
         "date-fns": "^3.6.0",
         "pluralize-esm": "^9.0.5",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "rxjs": "^7.8.1",
-        "sanity": "^3.92.0",
+        "sanity": "^3.93.0",
         "sanity-plugin-asset-source-unsplash": "^3.0.1",
         "styled-components": "^6.1.18"
       },

--- a/studio/package.json
+++ b/studio/package.json
@@ -22,13 +22,13 @@
   "dependencies": {
     "@sanity/assist": "^3.2.0",
     "@sanity/icons": "^3.5.0",
-    "@sanity/vision": "^3.92.0",
+    "@sanity/vision": "^3.93.0",
     "date-fns": "^3.6.0",
     "pluralize-esm": "^9.0.5",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "rxjs": "^7.8.1",
-    "sanity": "^3.92.0",
+    "sanity": "^3.93.0",
     "sanity-plugin-asset-source-unsplash": "^3.0.1",
     "styled-components": "^6.1.18"
   },

--- a/studio/src/schemaTypes/documents/page.ts
+++ b/studio/src/schemaTypes/documents/page.ts
@@ -54,6 +54,7 @@ export const page = defineType({
         { type: 'callToAction' },
         { type: 'infoSection' },
         { type: 'stepperBlock' },
+        { type: 'pricingBlock' },
       ],
       options: {
         insertMenu: {

--- a/studio/src/schemaTypes/documents/page.ts
+++ b/studio/src/schemaTypes/documents/page.ts
@@ -46,6 +46,7 @@ export const page = defineType({
       type: 'array',
       of: [
         { type: 'pageHero' },
+        { type: 'heroBlock' },
         { type: 'valueProposition' },
         { type: 'testimonialBlock' },
         { type: 'featureModules' },

--- a/studio/src/schemaTypes/index.ts
+++ b/studio/src/schemaTypes/index.ts
@@ -15,6 +15,8 @@ import { faqBlock } from './objects/faqBlock'
 import { blockHeader } from './objects/blockHeader'
 import { stepperStep } from './objects/stepperStep'
 import { stepperBlock } from './objects/stepperBlock'
+import { pricingPlan } from './objects/pricingPlan'
+import { pricingBlock } from './objects/pricingBlock'
 
 // Export an array of all the schema types.  This is used in the Sanity Studio configuration. https://www.sanity.io/docs/schema-types
 
@@ -39,4 +41,6 @@ export const schemaTypes = [
   blockHeader,
   stepperStep,
   stepperBlock,
+  pricingPlan,
+  pricingBlock,
 ]

--- a/studio/src/schemaTypes/index.ts
+++ b/studio/src/schemaTypes/index.ts
@@ -17,6 +17,7 @@ import { stepperStep } from './objects/stepperStep'
 import { stepperBlock } from './objects/stepperBlock'
 import { pricingPlan } from './objects/pricingPlan'
 import { pricingBlock } from './objects/pricingBlock'
+import { heroBlock } from './objects/heroBlock'
 
 // Export an array of all the schema types.  This is used in the Sanity Studio configuration. https://www.sanity.io/docs/schema-types
 
@@ -43,4 +44,5 @@ export const schemaTypes = [
   stepperBlock,
   pricingPlan,
   pricingBlock,
+  heroBlock,
 ]

--- a/studio/src/schemaTypes/objects/blockHeader.ts
+++ b/studio/src/schemaTypes/objects/blockHeader.ts
@@ -36,16 +36,6 @@ export const blockHeader = defineType({
         }),
         defineField({ name: 'icon', type: 'string', title: 'Icon' }),
       ],
-      validation: (Rule) =>
-        Rule.custom((btn) => {
-          if (!btn) return true
-          const { label, url } = btn as any
-          const urlEmpty = !url || Object.values(url).every((v) => !v)
-          if (!label && urlEmpty) return true
-          if (label && urlEmpty) return 'URL is required when label is provided'
-          if (!label && !urlEmpty) return 'Label is required when URL is provided'
-          return true
-        }),
     }),
     defineField({
       name: 'secondaryButton',
@@ -67,16 +57,6 @@ export const blockHeader = defineType({
         }),
         defineField({ name: 'icon', type: 'string', title: 'Icon' }),
       ],
-      validation: (Rule) =>
-        Rule.custom((btn) => {
-          if (!btn) return true
-          const { label, url } = btn as any
-          const urlEmpty = !url || Object.values(url).every((v) => !v)
-          if (!label && urlEmpty) return true
-          if (label && urlEmpty) return 'URL is required when label is provided'
-          if (!label && !urlEmpty) return 'Label is required when URL is provided'
-          return true
-        }),
     }),
   ],
   preview: {

--- a/studio/src/schemaTypes/objects/blockHeader.ts
+++ b/studio/src/schemaTypes/objects/blockHeader.ts
@@ -26,7 +26,7 @@ export const blockHeader = defineType({
           name: 'url',
           type: 'link',
           title: 'URL',
-          validation: (Rule) => Rule.required(),
+          initialValue: { linkType: '' },
         }),
         defineField({
           name: 'variant',
@@ -39,10 +39,11 @@ export const blockHeader = defineType({
       validation: (Rule) =>
         Rule.custom((btn) => {
           if (!btn) return true
-          const { label, url } = btn
-          if ((label && !url) || (!label && url)) {
-            return 'Both label and URL are required if button is provided'
-          }
+          const { label, url } = btn as any
+          const urlEmpty = !url || Object.values(url).every((v) => !v)
+          if (!label && urlEmpty) return true
+          if (label && urlEmpty) return 'URL is required when label is provided'
+          if (!label && !urlEmpty) return 'Label is required when URL is provided'
           return true
         }),
     }),
@@ -52,7 +53,12 @@ export const blockHeader = defineType({
       type: 'object',
       fields: [
         defineField({ name: 'label', type: 'string', title: 'Label' }),
-        defineField({ name: 'url', type: 'link', title: 'URL' }),
+        defineField({
+          name: 'url',
+          type: 'link',
+          title: 'URL',
+          initialValue: { linkType: '' },
+        }),
         defineField({
           name: 'variant',
           type: 'string',
@@ -64,10 +70,11 @@ export const blockHeader = defineType({
       validation: (Rule) =>
         Rule.custom((btn) => {
           if (!btn) return true
-          const { label, url } = btn
-          if ((label && !url) || (!label && url)) {
-            return 'Both label and URL are required if button is provided'
-          }
+          const { label, url } = btn as any
+          const urlEmpty = !url || Object.values(url).every((v) => !v)
+          if (!label && urlEmpty) return true
+          if (label && urlEmpty) return 'URL is required when label is provided'
+          if (!label && !urlEmpty) return 'Label is required when URL is provided'
           return true
         }),
     }),

--- a/studio/src/schemaTypes/objects/heroBlock.ts
+++ b/studio/src/schemaTypes/objects/heroBlock.ts
@@ -1,0 +1,111 @@
+import { defineField, defineType } from 'sanity'
+import { PlayIcon } from '@sanity/icons'
+import { 
+  BACKGROUND_THEME_OPTIONS
+} from '../../lib/shared-constants'
+
+export const heroBlock = defineType({
+  name: 'heroBlock',
+  title: 'Hero Block',
+  type: 'object',
+  icon: PlayIcon,
+  fields: [
+    // Header Section
+    defineField({
+      name: 'header',
+      title: 'Header Content',
+      type: 'blockHeader',
+      validation: (Rule) => Rule.required(),
+    }),
+
+    // Header Alignment
+    defineField({
+      name: 'headerAlignment',
+      title: 'Header Alignment',
+      type: 'string',
+      options: {
+        list: [
+          { title: 'Left', value: 'left' },
+          { title: 'Center', value: 'center' },
+          { title: 'Right', value: 'right' },
+        ],
+        layout: 'radio',
+      },
+      initialValue: 'center',
+    }),
+
+    // Background Theme
+    defineField({
+      name: 'backgroundTheme',
+      title: 'Background Theme',
+      type: 'string',
+      options: {
+        list: BACKGROUND_THEME_OPTIONS,
+        layout: 'radio',
+      },
+      initialValue: 'white',
+    }),
+
+    // Layout Variant
+    defineField({
+      name: 'layout',
+      title: 'Layout',
+      type: 'string',
+      options: {
+        list: [
+          { title: 'Header Only', value: 'headerOnly' },
+          { title: 'Two Column - Image Left', value: 'twoColumnImageLeft' },
+          { title: 'Two Column - Image Right', value: 'twoColumnImageRight' },
+          { title: 'Image Full Width', value: 'imageFullWidth' },
+          { title: 'Image Contained', value: 'imageContained' },
+        ],
+        layout: 'radio',
+      },
+      initialValue: 'headerOnly',
+    }),
+
+    // Image (conditional)
+    defineField({
+      name: 'image',
+      title: 'Hero Image',
+      type: 'image',
+      options: { hotspot: true },
+      hidden: ({ parent }) => parent?.layout === 'headerOnly',
+      validation: (Rule) =>
+        Rule.custom((value, context) => {
+          const parent = context.parent as { layout?: string }
+          if (parent?.layout && parent.layout !== 'headerOnly' && !value) {
+            return 'Image is required for this layout variant'
+          }
+          return true
+        }),
+    }),
+
+    // Image Containment (conditional)
+    defineField({
+      name: 'imageContained',
+      title: 'Contained Image',
+      type: 'boolean',
+      description: 'Add 80px padding around the image',
+      hidden: ({ parent }) => 
+        !parent?.layout || 
+        !['twoColumnImageLeft', 'twoColumnImageRight'].includes(parent.layout),
+      initialValue: false,
+    }),
+  ],
+  preview: {
+    select: {
+      heading: 'header.heading',
+      layout: 'layout',
+      backgroundTheme: 'backgroundTheme',
+      image: 'image',
+    },
+    prepare({ heading, layout, backgroundTheme, image }) {
+      return {
+        title: heading || 'Hero Block',
+        subtitle: `${layout} • ${backgroundTheme} background`,
+        media: image,
+      }
+    },
+  },
+}) 

--- a/studio/src/schemaTypes/objects/pricingBlock.ts
+++ b/studio/src/schemaTypes/objects/pricingBlock.ts
@@ -1,0 +1,48 @@
+import { defineField, defineType } from 'sanity'
+import { ComponentIcon } from '@sanity/icons'
+
+export const pricingBlock = defineType({
+  name: 'pricingBlock',
+  title: 'Pricing Block',
+  type: 'object',
+  icon: ComponentIcon,
+  fields: [
+    defineField({
+      name: 'header',
+      title: 'Header Section',
+      type: 'blockHeader',
+    }),
+    defineField({
+      name: 'layout',
+      title: 'Layout Variant',
+      type: 'string',
+      options: {
+        list: [
+          { title: 'Three Column', value: 'threeColumn' },
+          { title: 'Two Column', value: 'twoColumn' },
+        ],
+        layout: 'radio',
+      },
+      initialValue: 'threeColumn',
+    }),
+    defineField({
+      name: 'plans',
+      title: 'Pricing Plans',
+      type: 'array',
+      of: [{ type: 'pricingPlan' }],
+      validation: (Rule) => Rule.min(2).max(3),
+    }),
+  ],
+  preview: {
+    select: {
+      heading: 'header.heading',
+      planCount: 'plans.length',
+    },
+    prepare({ heading, planCount }) {
+      return {
+        title: heading || 'Pricing Block',
+        subtitle: `${planCount || 0} plan${planCount === 1 ? '' : 's'}`,
+      }
+    },
+  },
+}) 

--- a/studio/src/schemaTypes/objects/pricingPlan.ts
+++ b/studio/src/schemaTypes/objects/pricingPlan.ts
@@ -1,0 +1,126 @@
+import { defineField, defineType } from 'sanity'
+
+export const pricingPlan = defineType({
+  name: 'pricingPlan',
+  title: 'Pricing Plan',
+  type: 'object',
+  fields: [
+    defineField({
+      name: 'name',
+      title: 'Plan Name',
+      type: 'string',
+    }),
+    defineField({
+      name: 'price',
+      title: 'Monthly Price (USD)',
+      type: 'number',
+      description: 'Numeric value, displayed as $price per month',
+    }),
+    defineField({
+      name: 'description',
+      title: 'Description',
+      type: 'string',
+      description: 'Optional short descriptor displayed above the price',
+    }),
+    defineField({
+      name: 'backgroundColor',
+      title: 'Background Color',
+      type: 'string',
+      options: {
+        list: [
+          { title: 'Dark (Brand Secondary)', value: 'brandSecondary' },
+          { title: 'Lavender', value: 'lavender100' },
+          { title: 'Bright Yellow', value: 'brightYellow300' },
+        ],
+        layout: 'radio',
+      },
+      initialValue: 'brandSecondary',
+    }),
+    defineField({
+      name: 'features',
+      title: 'Features',
+      type: 'array',
+      of: [
+        {
+          type: 'object',
+          name: 'featureItem',
+          fields: [
+            defineField({
+              name: 'icon',
+              title: 'Icon',
+              type: 'string',
+              description: 'Lucide icon name (defaults to "Check")',
+            }),
+            defineField({
+              name: 'text',
+              title: 'Text',
+              type: 'string',
+              validation: (Rule) => Rule.required(),
+            }),
+          ],
+          preview: {
+            select: { title: 'text', subtitle: 'icon' },
+          },
+        },
+      ],
+      description: 'List of features with optional icons.',
+    }),
+    defineField({
+      name: 'ctaButton',
+      title: 'CTA Button',
+      type: 'object',
+      fields: [
+        defineField({
+          name: 'label',
+          title: 'Button Label',
+          type: 'string',
+        }),
+        defineField({
+          name: 'url',
+          title: 'Button URL',
+          type: 'url',
+        }),
+        defineField({
+          name: 'icon',
+          title: 'Icon',
+          type: 'string',
+          description: 'Lucide icon name (optional)',
+        }),
+        defineField({
+          name: 'target',
+          title: 'Link Target',
+          type: 'string',
+          options: {
+            list: [
+              { title: 'New Tab', value: '_blank' },
+              { title: 'Same Tab', value: '_self' },
+            ],
+            layout: 'radio',
+          },
+          initialValue: '_blank',
+        }),
+      ],
+      validation: (Rule) =>
+        Rule.custom((btn) => {
+          if (!btn) return true
+          const { label, url } = btn
+          if ((label && !url) || (!label && url)) {
+            return 'Provide both label and URL or leave both blank'
+          }
+          return true
+        }),
+    }),
+  ],
+  preview: {
+    select: {
+      title: 'name',
+      subtitle: 'price',
+    },
+    prepare({ title, subtitle }) {
+      return {
+        title: title || 'Untitled Plan',
+        subtitle: subtitle ? `$${subtitle}/month` : 'Price not set',
+      }
+    },
+  },
+}) 


### PR DESCRIPTION
Implemented new **PricingBlock** component. Features responsive 2/3-card layouts with fixed 48px gaps, equal card heights, and custom CSS module breakpoints (954px for 2-cards, 1406px for 3-cards) to prevent awkward 2+1 card splits.

**Key Refactoring:**
- **LinkButton**: Added `fullWidth` prop for pricing card CTAs to span full card width
- **ValuePropDefaultColumn**: Updated to use new `fullWidth` LinkButton prop for consistency  
- **Design tokens**: Added `PricingCardBackground` enum for card color theming

**Implementation:** Created PricingBlock.tsx, PricingCard.tsx, scoped CSS module, Sanity schemas (pricingBlock/pricingPlan), integrated with BlockRenderer and page builder. Maintains design system consistency while solving complex responsive layout requirements.