### PR TITLE
[feature] Introduce an env for the sanity preview URL

### DIFF
--- a/sites.ts
+++ b/sites.ts
@@ -6,6 +6,6 @@ export const sites = {
 		icon: Logo,
 		url: process.env.NODE_ENV === 'development'
 			? 'http://localhost:3009'
-			: process.env.NEXT_PUBLIC_PREVIEW_URL || 'https://gp-marketing-git-develop-good-party.vercel.app',
+			: process.env.VERCEL_URL || process.env.NEXT_PUBLIC_PREVIEW_URL || 'https://gp-marketing-git-develop-good-party.vercel.app',
 	},
 };

--- a/sites.ts
+++ b/sites.ts
@@ -6,8 +6,6 @@ export const sites = {
 		icon: Logo,
 		url: process.env.NODE_ENV === 'development'
 			? 'http://localhost:3009'
-			: process.env['VERCEL_ENV'] === 'production'
-				? process.env['VERCEL_PROJECT_PRODUCTION_URL']
-				: process.env['VERCEL_URL'],
+			: process.env.NEXT_PUBLIC_PREVIEW_URL || 'https://gp-marketing-git-develop-good-party.vercel.app',
 	},
 };


### PR DESCRIPTION
A new env `NEXT_PUBLIC_PREVIEW_URL` should be added in Vercel for each environment.

For now this will fallback to `https://gp-marketing-git-develop-good-party.vercel.app` if the environment does not declare this env.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches preview URL resolution to NEXT_PUBLIC_PREVIEW_URL with a default fallback, replacing Vercel-specific env branching in sites.ts.
> 
> - **Config**:
>   - Update `sites.ts` `goodpartyOrg.url` logic:
>     - In non-development, use `process.env.NEXT_PUBLIC_PREVIEW_URL` or fallback to `https://gp-marketing-git-develop-good-party.vercel.app`.
>     - Removes `VERCEL_ENV`/`VERCEL_PROJECT_PRODUCTION_URL`/`VERCEL_URL` branching.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 749b25829d504cb492a68bf66a7acc7686686739. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->