### PR TITLE
fix(133): stegaClean textSize

### DIFF
--- a/src/ui/_lib/resolveTextSize.ts
+++ b/src/ui/_lib/resolveTextSize.ts
@@ -1,3 +1,5 @@
+import { stegaClean } from 'next-sanity';
+
 import type { Field_textSize } from 'sanity.types';
 
 export const TEXT_SIZE_MAP = {
@@ -20,5 +22,5 @@ export type HeadingStyle = ResolvedTextSize['heading'];
 export type BodyStyle = ResolvedTextSize['body'];
 
 export function resolveTextSize(textSize?: Field_textSize): ResolvedTextSize {
-	return TEXT_SIZE_MAP[textSize ?? 'Medium'];
+	return TEXT_SIZE_MAP[stegaClean(textSize) ?? 'Medium'];
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Sanitizes `textSize` inputs from Sanity before mapping to styles.
> 
> - Import `stegaClean` and apply it in `resolveTextSize` to strip encoded values before indexing `TEXT_SIZE_MAP`
> - Affects `src/ui/_lib/resolveTextSize.ts`; default remains `"Medium"`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4166b57463ce118ca2ed4dd13f1a43cdc95a92ff. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->