### PR TITLE
Enhance blog section page with newsletter block integration

### DIFF
--- a/src/app/blog/section/[slug]/page.tsx
+++ b/src/app/blog/section/[slug]/page.tsx
@@ -1,8 +1,8 @@
 import type { Metadata, ResolvingMetadata } from 'next';
 import { notFound } from 'next/navigation';
-import { categoriesQuery } from '~/sanity/groq';
+import { categoriesQuery, goodpartyOrg_allArticlesQuery } from '~/sanity/groq';
 import { sanityFetch } from '~/sanity/sanityClient';
-import { PageSections } from '~/PageSections';
+import { PageSections, type Sections } from '~/PageSections';
 import { StructureMetaData } from '~/components/StructureMetadata';
 import type { Params } from '~/lib/types';
 import { BlogHero } from '~/ui/BlogHero';
@@ -11,18 +11,20 @@ import { FeaturedBlogBlock } from '~/ui/FeaturedBlogBlock';
 import type { SanityImage } from '~/ui/types';
 import { resolveBlogCard } from '~/ui/_lib/resolveBlogCard';
 import { BlogBlock } from '~/ui/BlogBlock';
-import { CTABlock } from '~/ui/CTABlock';
 import { BlogTopicTagsBlock } from '~/ui/BlogTopicTagsBlock';
+import { NewsletterBlockSection } from '~/PageSections/NewsletterBlockSection';
 import { client } from '~/lib/client';
+
+type NewsletterBlockSectionType = Extract<Sections, { _type: 'component_newsletterBlock' }>;
 
 export async function generateStaticParams() {
 	const entries = await client.fetch<Array<string>>('*[_type=="categories"][0..99].tagOverview.field_slug');
 	return entries.filter(Boolean).map(entry => ({
-		categories: entry,
+		slug: entry,
 	}));
 }
 
-export default async function Page(props: any) {
+export default async function Page(props: Params) {
 	const slug = (await props.params)['slug'];
 	const page = await sanityFetch({
 		query: categoriesQuery,
@@ -36,13 +38,29 @@ export default async function Page(props: any) {
 	}
 	const { articles } = await getCachedArticles();
 
+	const categoryNewsletterSection =
+		(page.pageSections?.list_pageSections?.find((section: Sections) => section?._type === 'component_newsletterBlock') as
+			| NewsletterBlockSectionType
+			| undefined);
+
+	const newsletterSectionFromHome = await sanityFetch({
+		query: goodpartyOrg_allArticlesQuery,
+		tags: ['goodpartyOrg_allArticles'],
+	});
+
+	const newsletterSection =
+		categoryNewsletterSection ??
+		(newsletterSectionFromHome?.pageSections?.list_pageSections?.find((section: Sections) => section?._type === 'component_newsletterBlock') as
+			| NewsletterBlockSectionType
+			| undefined);
+
 	return (
 		<>
 			<BlogHero
 				articles={articles}
 				title={page.tagOverview?.field_name}
 				copy={page.tagOverview?.field_pageSubtitle}
-				categories={page.categories?.filter(item => item.title && item.href) as { _id: string; title: string; href: string }[]}
+				categories={page.categories?.filter((item): item is { _id: string; title: string; href: string } => Boolean(item.title && item.href))}
 			/>
 			{page.featuredArticle?.editorialOverview?.field_editorialTitle && page.featuredArticle.href && (
 				<FeaturedBlogBlock
@@ -61,17 +79,7 @@ export default async function Page(props: any) {
 			{page.categoryRelatedArticles?.articles && page.categoryRelatedArticles?.articles.length > 0 && (
 				<BlogBlock items={page.categoryRelatedArticles?.articles.slice(0, 3).map(resolveBlogCard).filter(Boolean)} allItemsCount={3} />
 			)}
-			<CTABlock
-				label={'Hardcoded label'}
-				title={'Hardcoded title'}
-				copy={'Hardcoded copy. This component is hardcoded and is not a part of the page sections array.'}
-				caption={'Hardcoded caption'}
-				color={'lavender'}
-				form={{
-					provider: 'Hubspot',
-					formId: '5d84452a-01df-422b-9734-580148677d2c',
-				}}
-			/>
+			{newsletterSection ? <NewsletterBlockSection {...newsletterSection} /> : null}
 			{page.categoryRelatedArticles?.articles && page.categoryRelatedArticles?.articles.length > 3 && (
 				<BlogBlock
 					items={page.categoryRelatedArticles?.articles.slice(3).map(resolveBlogCard).filter(Boolean)}
@@ -88,7 +96,9 @@ export default async function Page(props: any) {
 					)
 					.filter(Boolean)}
 			/>
-			<PageSections pageSections={page.pageSections?.list_pageSections} />
+			<PageSections
+				pageSections={page.pageSections?.list_pageSections?.filter((section: Sections) => section._type !== 'component_newsletterBlock')}
+			/>
 		</>
 	);
 }

--- a/src/app/blog/section/[slug]/page.tsx
+++ b/src/app/blog/section/[slug]/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata, ResolvingMetadata } from 'next';
 import { notFound } from 'next/navigation';
-import { categoriesQuery, goodpartyOrg_allArticlesQuery } from '~/sanity/groq';
+import { categoriesQuery, goodpartyOrg_homeQuery } from '~/sanity/groq';
 import { sanityFetch } from '~/sanity/sanityClient';
 import { PageSections, type Sections } from '~/PageSections';
 import { StructureMetaData } from '~/components/StructureMetadata';
@@ -43,10 +43,12 @@ export default async function Page(props: Params) {
 			| NewsletterBlockSectionType
 			| undefined);
 
-	const newsletterSectionFromHome = await sanityFetch({
-		query: goodpartyOrg_allArticlesQuery,
-		tags: ['goodpartyOrg_allArticles'],
-	});
+	const newsletterSectionFromHome = categoryNewsletterSection
+		? null
+		: await sanityFetch({
+				query: goodpartyOrg_homeQuery,
+				tags: ['goodpartyOrg_home'],
+			});
 
 	const newsletterSection =
 		categoryNewsletterSection ??


### PR DESCRIPTION
- Added support for a newsletter block section by fetching data from the home page and category-specific sections.
- Updated the page component to conditionally render the newsletter block if available.
- Refactored the categories parameter to use 'slug' for better clarity.
- Removed hardcoded CTA block to streamline the component structure.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds an additional Sanity fetch and conditional rendering path on blog section pages, which could impact performance/caching behavior and section ordering. Changes are localized to the category section route with no auth or sensitive data handling.
> 
> **Overview**
> Blog section (category) pages now **support a CMS-driven newsletter signup block**: the route looks for a `component_newsletterBlock` in the category’s `pageSections` and falls back to the same block pulled from the global `goodpartyOrg_allArticles` page.
> 
> The previous hardcoded `CTABlock` on the section page is removed, the newsletter block is rendered once via `NewsletterBlockSection`, and `PageSections` is filtered to avoid double-rendering it. Minor typing/param cleanup includes using `Params` for `Page`, returning `{ slug }` from `generateStaticParams`, and tightening the `BlogHero` categories filter with a type guard.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 15d261316a6532f44a6b6b0b92a65d4607450091. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->