### PR TITLE
Enhance blog article page with related articles section

### DIFF
--- a/src/app/blog/article/[slug]/page.tsx
+++ b/src/app/blog/article/[slug]/page.tsx
@@ -83,6 +83,10 @@ export default async function Page(props: any) {
 		url: articleUrl,
 	};
 
+	const relatedArticles = (page.relatedArticles?.list_relatedArticles ?? [])
+		.map(resolveBlogCard)
+		.filter((item): item is BlogCardProps => item != null);
+
 	return (
 		<>
 			<PageSchema schema={articleSchema} />
@@ -135,13 +139,8 @@ export default async function Page(props: any) {
 					/>
 				</div>
 			</EditorialLayout>
-			{page.relatedArticles?.list_relatedArticles && page.relatedArticles.list_relatedArticles.length > 0 && (
-				<BlogBlock
-					header={{ title: 'Related Articles' }}
-					items={page.relatedArticles.list_relatedArticles
-						.map(resolveBlogCard)
-						.filter((item): item is BlogCardProps => item != null)}
-				/>
+			{relatedArticles.length > 0 && (
+				<BlogBlock header={{ title: 'Related Articles' }} items={relatedArticles} />
 			)}
 		</>
 	);

--- a/src/app/blog/article/[slug]/page.tsx
+++ b/src/app/blog/article/[slug]/page.tsx
@@ -22,6 +22,8 @@ import { format } from 'date-fns';
 import { stegaClean } from 'next-sanity';
 import { PageSchema } from '~/ui/PageSchema';
 import { DEFAULT_SHARE_IMAGE, getBaseUrl, getSanityImageUrl } from '~/lib/url';
+import { BlogBlock } from '~/ui/BlogBlock';
+import { resolveBlogCard } from '~/ui/_lib/resolveBlogCard';
 
 export async function generateStaticParams() {
 	const entries = await client.fetch<Array<{ slug: string }>>('*[_type == "article"][0..99].editorialOverview.field_slug');
@@ -132,6 +134,12 @@ export default async function Page(props: any) {
 					/>
 				</div>
 			</EditorialLayout>
+			{page.relatedArticles?.list_relatedArticles && page.relatedArticles.list_relatedArticles.length > 0 && (
+				<BlogBlock
+					header={{ title: 'Related Articles' }}
+					items={page.relatedArticles.list_relatedArticles.map(resolveBlogCard).filter(Boolean)}
+				/>
+			)}
 		</>
 	);
 }

--- a/src/app/blog/article/[slug]/page.tsx
+++ b/src/app/blog/article/[slug]/page.tsx
@@ -23,6 +23,7 @@ import { stegaClean } from 'next-sanity';
 import { PageSchema } from '~/ui/PageSchema';
 import { DEFAULT_SHARE_IMAGE, getBaseUrl, getSanityImageUrl } from '~/lib/url';
 import { BlogBlock } from '~/ui/BlogBlock';
+import type { BlogCardProps } from '~/ui/BlogCard';
 import { resolveBlogCard } from '~/ui/_lib/resolveBlogCard';
 
 export async function generateStaticParams() {
@@ -137,7 +138,9 @@ export default async function Page(props: any) {
 			{page.relatedArticles?.list_relatedArticles && page.relatedArticles.list_relatedArticles.length > 0 && (
 				<BlogBlock
 					header={{ title: 'Related Articles' }}
-					items={page.relatedArticles.list_relatedArticles.map(resolveBlogCard).filter(Boolean)}
+					items={page.relatedArticles.list_relatedArticles
+						.map(resolveBlogCard)
+						.filter((item): item is BlogCardProps => item != null)}
 				/>
 			)}
 		</>

--- a/src/ui/_lib/resolveBlogCard.ts
+++ b/src/ui/_lib/resolveBlogCard.ts
@@ -1,12 +1,27 @@
 import type { BlogCardProps } from '~/ui/BlogCard';
 import type { SanityImage } from '~/ui/types';
-import type { TopicsQueryResult } from '~/sanity/groq';
+import type { ArticleQueryResult, CategoriesQueryResult, TopicsQueryResult } from 'sanity.types';
 import { format } from 'date-fns';
 import { stegaClean } from 'next-sanity';
 
-export function resolveBlogCard(
-	item: NonNullable<NonNullable<NonNullable<TopicsQueryResult>['topicRelatedArticles']>['articles']>[number],
-): BlogCardProps | undefined {
+type TopicRelatedArticle = NonNullable<NonNullable<NonNullable<TopicsQueryResult>['topicRelatedArticles']>['articles']>[number];
+type CategoryRelatedArticle = NonNullable<NonNullable<NonNullable<CategoriesQueryResult>['categoryRelatedArticles']>['articles']>[number];
+type ArticleRelatedArticleListItem = NonNullable<
+	NonNullable<NonNullable<NonNullable<ArticleQueryResult>['relatedArticles']>['list_relatedArticles']>
+>[number];
+
+export type ResolveBlogCardSource = TopicRelatedArticle | CategoryRelatedArticle | ArticleRelatedArticleListItem;
+
+function resolveBlogCardCategoryLabel(category: ResolveBlogCardSource['category']): string | undefined {
+	if (category == null) return undefined;
+	if (typeof category === 'string') return category;
+	if (typeof category === 'object' && 'tagOverview' in category) {
+		return category.tagOverview?.field_name ?? undefined;
+	}
+	return undefined;
+}
+
+export function resolveBlogCard(item: ResolveBlogCardSource): BlogCardProps | undefined {
 	return item.href && item.editorialOverview?.field_editorialTitle
 		? {
 				author: item.editorialOverview?.ref_author?.personOverview?.field_personName
@@ -27,7 +42,7 @@ export function resolveBlogCard(
 					: undefined,
 				href: item.href,
 				image: item.editorialAssets?.img_featuredImage as unknown as SanityImage,
-				label: item.category ?? undefined,
+				label: resolveBlogCardCategoryLabel(item.category),
 				title: item.editorialOverview?.field_editorialTitle,
 			}
 		: undefined;

--- a/src/ui/_lib/resolveBlogCard.ts
+++ b/src/ui/_lib/resolveBlogCard.ts
@@ -14,8 +14,9 @@ export type ResolveBlogCardSource = TopicRelatedArticle | CategoryRelatedArticle
 
 function resolveBlogCardCategoryLabel(category: ResolveBlogCardSource['category']): string | undefined {
 	if (category == null) return undefined;
+	// Topic/category listing queries project `category` via articleCardGroq as tagOverview.field_name (string); article list_relatedArticles uses relatedArticlesGroq (categories document).
 	if (typeof category === 'string') return category;
-	if (typeof category === 'object' && 'tagOverview' in category) {
+	if (category !== null && typeof category === 'object' && !Array.isArray(category) && 'tagOverview' in category) {
 		return category.tagOverview?.field_name ?? undefined;
 	}
 	return undefined;


### PR DESCRIPTION
- Added a new BlogBlock component to display related articles if available.
- Updated resolveBlogCard function to handle different article types and improve category label resolution.

<img width="1895" height="979" alt="image" src="https://github.com/user-attachments/assets/7dfccdca-2894-4d04-8a03-2071264a6ddf" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/data-shaping change that reuses existing `BlogBlock`; main risk is incorrect card labeling/type assumptions affecting how related article cards render.
> 
> **Overview**
> Adds a **Related Articles** section to the blog article page by mapping `page.relatedArticles.list_relatedArticles` into `BlogCard` items and rendering a `BlogBlock` when any are present.
> 
> Extends `resolveBlogCard` to accept related-article items from topic, category, and article queries, and improves category label resolution to handle both string and category-document shapes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8a918a09ab1bc74a16dfd77f60074aaab475a7f0. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->