### PR TITLE
Fix Jobs Schema formart

### DIFF
--- a/src/lib/electionsHelpers.test.ts
+++ b/src/lib/electionsHelpers.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 import {
+	buildFAQSchema,
+	buildJobPostingSchema,
 	buildRaceSlug,
 	findCityForDistrictName,
 	formatElectionDateFromApi,
@@ -11,7 +13,7 @@ import {
 	slugifyPositionName,
 	stripCountySuffix,
 } from './electionsHelpers';
-import type { PlaceItem, PlaceWithFacts } from '~/types/elections';
+import type { PlaceItem, PlaceWithFacts, RaceDetail } from '~/types/elections';
 
 function placeItem(id: string, name: string, slug: string, state: string): PlaceItem {
 	return { id, name, slug, state };
@@ -263,5 +265,179 @@ describe('formatFilingPeriodFromRace', () => {
 		const result = formatFilingPeriodFromRace(undefined, '2026-02-01');
 		expect(result).toMatch(/Until/);
 		expect(result).toMatch(/February 1, 2026/);
+	});
+});
+
+function minimalRace(overrides: Partial<RaceDetail> = {}): RaceDetail {
+	return {
+		id: 1,
+		slug: 'az/governor',
+		name: 'Governor',
+		state: 'AZ',
+		...overrides,
+	};
+}
+
+const jobPostingBaseParams = {
+	officeName: 'Governor',
+	stateName: 'Arizona',
+	pageUrl: 'https://goodparty.org/elections/az/position/governor',
+};
+
+describe('buildJobPostingSchema', () => {
+	test('returns null when filingDateStart and electionDate are both missing', () => {
+		expect(buildJobPostingSchema({ race: minimalRace(), ...jobPostingBaseParams })).toBeNull();
+	});
+
+	test('includes datePosted from filingDateStart', () => {
+		const schema = buildJobPostingSchema({
+			race: minimalRace({ filingDateStart: '2026-01-15T00:00:00Z' }),
+			...jobPostingBaseParams,
+		});
+		expect(schema).not.toBeNull();
+		expect((schema as Record<string, unknown>).datePosted).toBe('2026-01-15');
+	});
+
+	test('includes datePosted from electionDate when filing start missing', () => {
+		const schema = buildJobPostingSchema({
+			race: minimalRace({ electionDate: '2026-11-03' }),
+			...jobPostingBaseParams,
+		});
+		expect(schema).not.toBeNull();
+		expect((schema as Record<string, unknown>).datePosted).toBe('2026-11-03');
+	});
+
+	test('filingDateStart takes precedence over electionDate', () => {
+		const schema = buildJobPostingSchema({
+			race: minimalRace({
+				filingDateStart: '2026-01-01',
+				electionDate: '2026-11-03',
+			}),
+			...jobPostingBaseParams,
+		});
+		expect((schema as Record<string, unknown>).datePosted).toBe('2026-01-01');
+	});
+
+	test('sets validThrough from filingDateEnd', () => {
+		const schema = buildJobPostingSchema({
+			race: minimalRace({
+				filingDateStart: '2026-01-01',
+				filingDateEnd: '2026-02-01T12:00:00Z',
+			}),
+			...jobPostingBaseParams,
+		});
+		expect((schema as Record<string, unknown>).validThrough).toBe('2026-02-01');
+	});
+
+	test('parses single dollar salary', () => {
+		const schema = buildJobPostingSchema({
+			race: minimalRace({ filingDateStart: '2026-01-01', salary: '$50,000' }),
+			...jobPostingBaseParams,
+		});
+		const baseSalary = (schema as Record<string, unknown>).baseSalary as Record<string, unknown>;
+		expect(baseSalary['@type']).toBe('MonetaryAmount');
+		const value = baseSalary.value as Record<string, unknown>;
+		expect(value.value).toBe(50000);
+	});
+
+	test('parses salary range', () => {
+		const schema = buildJobPostingSchema({
+			race: minimalRace({ filingDateStart: '2026-01-01', salary: '$50,000 - $75,000' }),
+			...jobPostingBaseParams,
+		});
+		const value = ((schema as Record<string, unknown>).baseSalary as Record<string, unknown>).value as Record<string, unknown>;
+		expect(value.minValue).toBe(50000);
+		expect(value.maxValue).toBe(75000);
+	});
+
+	test('uses HOUR unit when hourly cues present', () => {
+		const schema = buildJobPostingSchema({
+			race: minimalRace({ filingDateStart: '2026-01-01', salary: '$25/hr' }),
+			...jobPostingBaseParams,
+		});
+		const value = ((schema as Record<string, unknown>).baseSalary as Record<string, unknown>).value as Record<string, unknown>;
+		expect(value.unitText).toBe('HOUR');
+		expect(value.value).toBe(25);
+	});
+
+	test('does not treat year 2024 as salary amount', () => {
+		const schema = buildJobPostingSchema({
+			race: minimalRace({
+				filingDateStart: '2026-01-01',
+				salary: 'Salary effective 2024: $50,000',
+			}),
+			...jobPostingBaseParams,
+		});
+		const value = ((schema as Record<string, unknown>).baseSalary as Record<string, unknown>).value as Record<string, unknown>;
+		expect(value.value).toBe(50000);
+		expect(value.minValue).toBeUndefined();
+	});
+
+	test('maps Full-Time employment to FULL_TIME', () => {
+		const schema = buildJobPostingSchema({
+			race: minimalRace({ filingDateStart: '2026-01-01', employmentType: 'Full-Time' }),
+			...jobPostingBaseParams,
+		});
+		expect((schema as Record<string, unknown>).employmentType).toBe('FULL_TIME');
+	});
+
+	test('maps unknown employment to OTHER', () => {
+		const schema = buildJobPostingSchema({
+			race: minimalRace({ filingDateStart: '2026-01-01', employmentType: 'Rotating shift' }),
+			...jobPostingBaseParams,
+		});
+		expect((schema as Record<string, unknown>).employmentType).toBe('OTHER');
+	});
+
+	test('omits baseSalary when salary unparseable', () => {
+		const schema = buildJobPostingSchema({
+			race: minimalRace({ filingDateStart: '2026-01-01', salary: 'TBD' }),
+			...jobPostingBaseParams,
+		});
+		expect((schema as Record<string, unknown>).baseSalary).toBeUndefined();
+	});
+
+	test('wraps fallback description in paragraph HTML', () => {
+		const schema = buildJobPostingSchema({
+			race: minimalRace({ filingDateStart: '2026-01-01' }),
+			officeName: 'Mayor',
+			stateName: 'Arizona',
+			countyName: 'Maricopa County',
+			pageUrl: 'https://example.com/elections',
+		}) as Record<string, unknown>;
+		const desc = String(schema.description);
+		expect(desc.startsWith('<p>')).toBe(true);
+		expect(desc.endsWith('</p>')).toBe(true);
+		expect(desc).toContain('elected public office');
+	});
+
+	test('escapes angle brackets in plain positionDescription', () => {
+		const schema = buildJobPostingSchema({
+			race: minimalRace({
+				filingDateStart: '2026-01-01',
+				positionDescription: 'Use <script>x</script> carefully',
+			}),
+			...jobPostingBaseParams,
+		}) as Record<string, unknown>;
+		expect(String(schema.description)).toContain('&lt;script&gt;');
+	});
+
+	test('passes through API HTML when closing tag present', () => {
+		const raw = '<p>Hello</p>';
+		const schema = buildJobPostingSchema({
+			race: minimalRace({
+				filingDateStart: '2026-01-01',
+				positionDescription: raw,
+			}),
+			...jobPostingBaseParams,
+		}) as Record<string, unknown>;
+		expect(schema.description).toBe(raw);
+	});
+});
+
+describe('buildFAQSchema', () => {
+	test('uses FAQPage as root @type', () => {
+		const schema = buildFAQSchema([{ title: 'Q?', copy: 'A.' }]) as Record<string, unknown>;
+		expect(schema['@type']).toBe('FAQPage');
 	});
 });

--- a/src/lib/electionsHelpers.test.ts
+++ b/src/lib/electionsHelpers.test.ts
@@ -360,17 +360,34 @@ describe('buildJobPostingSchema', () => {
 		expect(value.value).toBe(25);
 	});
 
-	test('does not treat year 2024 as salary amount', () => {
+	test('parses bare integer salary (no $ prefix)', () => {
 		const schema = buildJobPostingSchema({
-			race: minimalRace({
-				filingDateStart: '2026-01-01',
-				salary: 'Salary effective 2024: $50,000',
-			}),
+			race: minimalRace({ filingDateStart: '2026-01-01', salary: '147175' }),
 			...jobPostingBaseParams,
 		});
 		const value = ((schema as Record<string, unknown>).baseSalary as Record<string, unknown>).value as Record<string, unknown>;
-		expect(value.value).toBe(50000);
-		expect(value.minValue).toBeUndefined();
+		expect(value.value).toBe(147175);
+		expect(value.unitText).toBe('YEAR');
+	});
+
+	test('picks annual amount from mixed annual+per-diem string', () => {
+		const schema = buildJobPostingSchema({
+			race: minimalRace({ filingDateStart: '2026-01-01', salary: '$7,200/year + $221/day' }),
+			...jobPostingBaseParams,
+		});
+		const value = ((schema as Record<string, unknown>).baseSalary as Record<string, unknown>).value as Record<string, unknown>;
+		expect(value.value).toBe(7200);
+		expect(value.unitText).toBe('YEAR');
+	});
+
+	test('extracts salary embedded in prose', () => {
+		const schema = buildJobPostingSchema({
+			race: minimalRace({ filingDateStart: '2026-01-01', salary: 'The base salary was $141,000/year in 2011 (NRS 223.050).' }),
+			...jobPostingBaseParams,
+		});
+		const value = ((schema as Record<string, unknown>).baseSalary as Record<string, unknown>).value as Record<string, unknown>;
+		expect(value.value).toBe(141000);
+		expect(value.unitText).toBe('YEAR');
 	});
 
 	test('maps Full-Time employment to FULL_TIME', () => {

--- a/src/lib/electionsHelpers.test.ts
+++ b/src/lib/electionsHelpers.test.ts
@@ -439,7 +439,7 @@ describe('buildJobPostingSchema', () => {
 		expect(String(schema.description)).toContain('&lt;script&gt;');
 	});
 
-	test('passes through API HTML when closing tag present', () => {
+	test('passes through API HTML starting with block tag', () => {
 		const raw = '<p>Hello</p>';
 		const schema = buildJobPostingSchema({
 			race: minimalRace({
@@ -449,6 +449,29 @@ describe('buildJobPostingSchema', () => {
 			...jobPostingBaseParams,
 		}) as Record<string, unknown>;
 		expect(schema.description).toBe(raw);
+	});
+
+	test('strips script tags from API HTML', () => {
+		const schema = buildJobPostingSchema({
+			race: minimalRace({
+				filingDateStart: '2026-01-01',
+				positionDescription: '<p>Safe</p><script>alert(1)</script>',
+			}),
+			...jobPostingBaseParams,
+		}) as Record<string, unknown>;
+		expect(String(schema.description)).not.toContain('<script>');
+		expect(String(schema.description)).toContain('<p>Safe</p>');
+	});
+
+	test('escapes ampersands in plain positionDescription', () => {
+		const schema = buildJobPostingSchema({
+			race: minimalRace({
+				filingDateStart: '2026-01-01',
+				positionDescription: 'Salary & benefits',
+			}),
+			...jobPostingBaseParams,
+		}) as Record<string, unknown>;
+		expect(String(schema.description)).toContain('&amp;');
 	});
 });
 

--- a/src/lib/electionsHelpers.ts
+++ b/src/lib/electionsHelpers.ts
@@ -271,6 +271,121 @@ export function buildPositionPageSchema(params: {
 	};
 }
 
+function mapPositionEmploymentType(type: string): string {
+	const normalized = type.toLowerCase().replace(/[^a-z]/g, '');
+	if (normalized.includes('fulltime')) return 'FULL_TIME';
+	if (normalized.includes('parttime')) return 'PART_TIME';
+	if (normalized.includes('volunteer')) return 'VOLUNTEER';
+	if (normalized.includes('contract')) return 'CONTRACTOR';
+	if (normalized.includes('temporary')) return 'TEMPORARY';
+	if (normalized.includes('intern')) return 'INTERN';
+	if (normalized.includes('perdiem')) return 'PER_DIEM';
+	return 'OTHER';
+}
+
+function parseSalaryString(salary: string): object | null {
+	const amounts = [...salary.matchAll(/\$?\s*([\d,]+(?:\.\d{2})?)/g)]
+		.map(m => parseFloat(m[1]!.replace(/,/g, '')))
+		.filter(n => !Number.isNaN(n));
+
+	if (amounts.length === 0) return null;
+
+	const isHourly = /\/\s*h(ou)?r|per\s*hour|hourly/i.test(salary);
+	const unitText = isHourly ? 'HOUR' : 'YEAR';
+
+	const value: Record<string, unknown> = {
+		'@type': 'QuantitativeValue',
+		unitText,
+	};
+
+	if (amounts.length === 1) {
+		value.value = amounts[0];
+	} else {
+		value.minValue = Math.min(...amounts);
+		value.maxValue = Math.max(...amounts);
+	}
+
+	return {
+		'@type': 'MonetaryAmount',
+		currency: 'USD',
+		value,
+	};
+}
+
+/**
+ * Builds Schema.org JobPosting JSON-LD for elections position pages (Google Job Postings rich results).
+ */
+export function buildJobPostingSchema(params: {
+	race: RaceDetail;
+	officeName: string;
+	stateName: string;
+	countyName?: string;
+	cityName?: string;
+	pageUrl: string;
+}): object {
+	const { race, officeName, stateName, countyName, cityName, pageUrl } = params;
+
+	const locationParts = [cityName, countyName, stateName].filter(Boolean);
+	const locationName = locationParts.join(', ');
+
+	const description =
+		race.positionDescription ||
+		`${officeName} is an elected public office position in ${locationName}. ` +
+			`Learn about eligibility, filing deadlines, and how to run for this office.`;
+
+	const orgName = cityName
+		? `City of ${cityName}`
+		: countyName
+			? countyName
+			: `State of ${stateName}`;
+
+	const addressLocality = cityName ?? countyName ?? stateName;
+
+	const schema: Record<string, unknown> = {
+		'@context': 'https://schema.org',
+		'@type': 'JobPosting',
+		title: officeName,
+		url: pageUrl,
+		description,
+		directApply: false,
+		hiringOrganization: {
+			'@type': 'GovernmentOrganization',
+			name: orgName,
+		},
+		jobLocation: {
+			'@type': 'Place',
+			address: {
+				'@type': 'PostalAddress',
+				addressLocality,
+				addressRegion: race.state,
+				addressCountry: 'US',
+			},
+		},
+	};
+
+	const datePosted = race.filingDateStart?.slice(0, 10) || race.electionDate?.slice(0, 10);
+	if (datePosted) {
+		schema.datePosted = datePosted;
+	}
+
+	if (race.filingDateEnd) {
+		schema.validThrough = race.filingDateEnd.slice(0, 10);
+	}
+
+	if (race.employmentType) {
+		schema.employmentType = mapPositionEmploymentType(race.employmentType);
+	}
+
+	if (race.salary) {
+		const baseSalary = parseSalaryString(race.salary);
+		if (baseSalary) {
+			schema.baseSalary = baseSalary;
+		}
+	}
+
+	return schema;
+}
+
 /**
  * Builds a Schema.org BreadcrumbList JSON-LD object from breadcrumb items.
  */

--- a/src/lib/electionsHelpers.ts
+++ b/src/lib/electionsHelpers.ts
@@ -271,45 +271,62 @@ export function buildPositionPageSchema(params: {
 	};
 }
 
+const EMPLOYMENT_TYPE_MAP: Record<string, string> = {
+	'full-time': 'FULL_TIME',
+	'full time': 'FULL_TIME',
+	'part-time': 'PART_TIME',
+	'part time': 'PART_TIME',
+	volunteer: 'VOLUNTEER',
+	contract: 'CONTRACTOR',
+	contractor: 'CONTRACTOR',
+	temporary: 'TEMPORARY',
+	temp: 'TEMPORARY',
+	intern: 'INTERN',
+	internship: 'INTERN',
+	'per diem': 'PER_DIEM',
+	'per-diem': 'PER_DIEM',
+};
+
 function mapPositionEmploymentType(type: string): string {
-	const normalized = type.toLowerCase().replace(/[^a-z]/g, '');
-	if (normalized.includes('fulltime')) return 'FULL_TIME';
-	if (normalized.includes('parttime')) return 'PART_TIME';
-	if (normalized.includes('volunteer')) return 'VOLUNTEER';
-	if (normalized.includes('contract')) return 'CONTRACTOR';
-	if (normalized.includes('temporary')) return 'TEMPORARY';
-	if (normalized.includes('intern')) return 'INTERN';
-	if (normalized.includes('perdiem')) return 'PER_DIEM';
-	return 'OTHER';
+	return EMPLOYMENT_TYPE_MAP[type.toLowerCase().trim()] ?? 'OTHER';
 }
 
 function parseSalaryString(salary: string): object | null {
-	const amounts = [...salary.matchAll(/\$\s*([\d,]+(?:\.\d{2})?)/g)]
-		.map(m => parseFloat(m[1]!.replace(/,/g, '')))
-		.filter(n => !Number.isNaN(n));
-
-	if (amounts.length === 0) return null;
-
-	const isHourly = /\/\s*h(ou)?r|per\s*hour|hourly/i.test(salary);
-	const unitText = isHourly ? 'HOUR' : 'YEAR';
-
-	const value: Record<string, unknown> = {
-		'@type': 'QuantitativeValue',
-		unitText,
-	};
-
-	if (amounts.length === 1) {
-		value.value = amounts[0];
-	} else {
-		value.minValue = Math.min(...amounts);
-		value.maxValue = Math.max(...amounts);
+	function makeResult(unitText: 'HOUR' | 'YEAR', amounts: number[]): object {
+		const value: Record<string, unknown> = { '@type': 'QuantitativeValue', unitText };
+		if (amounts.length === 1) {
+			value.value = amounts[0];
+		} else {
+			value.minValue = Math.min(...amounts);
+			value.maxValue = Math.max(...amounts);
+		}
+		return { '@type': 'MonetaryAmount', currency: 'USD', value };
 	}
 
-	return {
-		'@type': 'MonetaryAmount',
-		currency: 'USD',
-		value,
-	};
+	// 1. Explicit annual amounts — handles "$95,000/year", "$14,400 / year", prose with embedded salary.
+	//    Stops at the first 1–2 matches so per-diem noise ("$7,200/year + $221/day") is ignored.
+	const yearAmounts = [...salary.matchAll(/\$\s*([\d,]+(?:\.\d{2})?)\s*(?:\/\s*(?:year|yr)\b|per\s+year\b|annually\b)/gi)]
+		.map(m => parseFloat(m[1]!.replace(/,/g, '')));
+	if (yearAmounts.length >= 1 && yearAmounts.length <= 2) return makeResult('YEAR', yearAmounts);
+
+	// 2. Explicit hourly amounts — handles "$25/hr", "$25/hour".
+	const hourAmounts = [...salary.matchAll(/\$\s*([\d,]+(?:\.\d{2})?)\s*(?:\/\s*h(?:ou)?r\b|per\s+hour\b|hourly\b)/gi)]
+		.map(m => parseFloat(m[1]!.replace(/,/g, '')));
+	if (hourAmounts.length >= 1 && hourAmounts.length <= 2) return makeResult('HOUR', hourAmounts);
+
+	// 3. Bare integer with no other text — handles "147175".
+	const bareMatch = /^\s*([\d,]+)\s*$/.exec(salary);
+	if (bareMatch) {
+		const n = parseFloat(bareMatch[1]!.replace(/,/g, ''));
+		if (!isNaN(n)) return makeResult('YEAR', [n]);
+	}
+
+	// 4. Generic $ amounts with no explicit unit — handles "$50,000" and "$50,000 - $75,000".
+	const genericAmounts = [...salary.matchAll(/\$\s*([\d,]+(?:\.\d{2})?)/g)]
+		.map(m => parseFloat(m[1]!.replace(/,/g, '')));
+	if (genericAmounts.length === 1 || genericAmounts.length === 2) return makeResult('YEAR', genericAmounts);
+
+	return null;
 }
 
 function escapeHtmlForJobPosting(text: string): string {
@@ -329,8 +346,8 @@ function buildJobPostingDescription(
 ): string {
 	if (positionDescription?.trim()) {
 		const raw = positionDescription.trim();
-		// Trusted API HTML: leading markup only (avoid treating "text </script>" as HTML).
-		if (raw.startsWith('<') && raw.includes('</')) {
+		// Pass through API HTML only when it starts with a known safe block tag.
+		if (/^<(p|ul|ol|h[1-6]|div|section|article)\b/i.test(raw)) {
 			return raw;
 		}
 		return `<p>${escapeHtmlForJobPosting(raw)}</p>`;

--- a/src/lib/electionsHelpers.ts
+++ b/src/lib/electionsHelpers.ts
@@ -223,8 +223,8 @@ export function placeToFactsCards(place: PlaceWithFacts | null): FactsCardProps[
 
 /**
  * Builds a Schema.org WebPage JSON-LD object with GovernmentOffice for position pages.
- * Uses WebPage + GovernmentOffice instead of JobPosting because these pages describe
- * candidacy opportunities for elected office, not employment job postings.
+ * Describes the page and the elected office. JobPosting JSON-LD is emitted separately
+ * (see buildJobPostingSchema) for Google Job Postings rich results.
  */
 export function buildPositionPageSchema(params: {
 	race: RaceDetail;
@@ -284,7 +284,7 @@ function mapPositionEmploymentType(type: string): string {
 }
 
 function parseSalaryString(salary: string): object | null {
-	const amounts = [...salary.matchAll(/\$?\s*([\d,]+(?:\.\d{2})?)/g)]
+	const amounts = [...salary.matchAll(/\$\s*([\d,]+(?:\.\d{2})?)/g)]
 		.map(m => parseFloat(m[1]!.replace(/,/g, '')))
 		.filter(n => !Number.isNaN(n));
 
@@ -312,8 +312,38 @@ function parseSalaryString(salary: string): object | null {
 	};
 }
 
+function escapeHtmlForJobPosting(text: string): string {
+	return text
+		.replace(/&/g, '&amp;')
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;');
+}
+
+/**
+ * JobPosting description as HTML: trusted API markup when present, else escaped plain text in `<p>`.
+ */
+function buildJobPostingDescription(
+	positionDescription: string | undefined,
+	officeName: string,
+	locationName: string,
+): string {
+	if (positionDescription?.trim()) {
+		const raw = positionDescription.trim();
+		// Trusted API HTML: leading markup only (avoid treating "text </script>" as HTML).
+		if (raw.startsWith('<') && raw.includes('</')) {
+			return raw;
+		}
+		return `<p>${escapeHtmlForJobPosting(raw)}</p>`;
+	}
+	const plain =
+		`${officeName} is an elected public office position in ${locationName}. ` +
+		`Learn about eligibility, filing deadlines, and how to run for this office.`;
+	return `<p>${escapeHtmlForJobPosting(plain)}</p>`;
+}
+
 /**
  * Builds Schema.org JobPosting JSON-LD for elections position pages (Google Job Postings rich results).
+ * Returns null when filingDateStart and electionDate are both missing (required datePosted); omit schema until the elections API backfills dates.
  */
 export function buildJobPostingSchema(params: {
 	race: RaceDetail;
@@ -322,16 +352,18 @@ export function buildJobPostingSchema(params: {
 	countyName?: string;
 	cityName?: string;
 	pageUrl: string;
-}): object {
+}): object | null {
 	const { race, officeName, stateName, countyName, cityName, pageUrl } = params;
+
+	const datePosted = race.filingDateStart?.slice(0, 10) || race.electionDate?.slice(0, 10);
+	if (!datePosted) {
+		return null;
+	}
 
 	const locationParts = [cityName, countyName, stateName].filter(Boolean);
 	const locationName = locationParts.join(', ');
 
-	const description =
-		race.positionDescription ||
-		`${officeName} is an elected public office position in ${locationName}. ` +
-			`Learn about eligibility, filing deadlines, and how to run for this office.`;
+	const description = buildJobPostingDescription(race.positionDescription, officeName, locationName);
 
 	const orgName = cityName
 		? `City of ${cityName}`
@@ -347,6 +379,7 @@ export function buildJobPostingSchema(params: {
 		title: officeName,
 		url: pageUrl,
 		description,
+		datePosted,
 		directApply: false,
 		hiringOrganization: {
 			'@type': 'GovernmentOrganization',
@@ -362,11 +395,6 @@ export function buildJobPostingSchema(params: {
 			},
 		},
 	};
-
-	const datePosted = race.filingDateStart?.slice(0, 10) || race.electionDate?.slice(0, 10);
-	if (datePosted) {
-		schema.datePosted = datePosted;
-	}
 
 	if (race.filingDateEnd) {
 		schema.validThrough = race.filingDateEnd.slice(0, 10);
@@ -413,7 +441,7 @@ export function buildFAQSchema(
 ): object {
 	return {
 		'@context': 'https://schema.org',
-		'@type': 'Question',
+		'@type': 'FAQPage',
 		mainEntity: items.map(item => ({
 			'@type': 'Question',
 			name: item.title,

--- a/src/lib/electionsHelpers.ts
+++ b/src/lib/electionsHelpers.ts
@@ -307,12 +307,14 @@ function parseSalaryString(salary: string): object | null {
 	//    Stops at the first 1–2 matches so per-diem noise ("$7,200/year + $221/day") is ignored.
 	const yearAmounts = [...salary.matchAll(/\$\s*([\d,]+(?:\.\d{2})?)\s*(?:\/\s*(?:year|yr)\b|per\s+year\b|annually\b)/gi)]
 		.map(m => parseFloat(m[1]!.replace(/,/g, '')));
-	if (yearAmounts.length >= 1 && yearAmounts.length <= 2) return makeResult('YEAR', yearAmounts);
+	if (yearAmounts.length > 2) return null;
+	if (yearAmounts.length >= 1) return makeResult('YEAR', yearAmounts);
 
 	// 2. Explicit hourly amounts — handles "$25/hr", "$25/hour".
 	const hourAmounts = [...salary.matchAll(/\$\s*([\d,]+(?:\.\d{2})?)\s*(?:\/\s*h(?:ou)?r\b|per\s+hour\b|hourly\b)/gi)]
 		.map(m => parseFloat(m[1]!.replace(/,/g, '')));
-	if (hourAmounts.length >= 1 && hourAmounts.length <= 2) return makeResult('HOUR', hourAmounts);
+	if (hourAmounts.length > 2) return null;
+	if (hourAmounts.length >= 1) return makeResult('HOUR', hourAmounts);
 
 	// 3. Bare integer with no other text — handles "147175".
 	const bareMatch = /^\s*([\d,]+)\s*$/.exec(salary);
@@ -348,7 +350,7 @@ function buildJobPostingDescription(
 		const raw = positionDescription.trim();
 		// Pass through API HTML only when it starts with a known safe block tag.
 		if (/^<(p|ul|ol|h[1-6]|div|section|article)\b/i.test(raw)) {
-			return raw;
+			return raw.replace(/<(script|iframe|object)[^>]*>[\s\S]*?<\/\1>/gi, '').replace(/\s+on\w+="[^"]*"/gi, '');
 		}
 		return `<p>${escapeHtmlForJobPosting(raw)}</p>`;
 	}
@@ -394,7 +396,7 @@ export function buildJobPostingSchema(params: {
 		'@context': 'https://schema.org',
 		'@type': 'JobPosting',
 		title: officeName,
-		url: pageUrl,
+		sameAs: pageUrl,
 		description,
 		datePosted,
 		directApply: false,

--- a/src/ui/PageSchema.tsx
+++ b/src/ui/PageSchema.tsx
@@ -1,5 +1,12 @@
+function schemaToSafeJsonLdString(schema: object): string {
+	return JSON.stringify(schema).replace(/</g, '\\u003c').replace(/>/g, '\\u003e');
+}
+
 export function PageSchema({ schema }: { schema?: object }) {
 	return schema ? (
-		<script type='application/ld+json' dangerouslySetInnerHTML={{ __html: JSON.stringify(schema) }} />
+		<script
+			type='application/ld+json'
+			dangerouslySetInnerHTML={{ __html: schemaToSafeJsonLdString(schema) }}
+		/>
 	) : null;
 }

--- a/src/ui/PageSchema.tsx
+++ b/src/ui/PageSchema.tsx
@@ -1,4 +1,5 @@
-function schemaToSafeJsonLdString(schema: object): string {
+// Escape < and > so a value containing "</script>" can't break out of the <script> tag.
+function toJsonLdString(schema: object): string {
 	return JSON.stringify(schema).replace(/</g, '\\u003c').replace(/>/g, '\\u003e');
 }
 
@@ -6,7 +7,7 @@ export function PageSchema({ schema }: { schema?: object }) {
 	return schema ? (
 		<script
 			type='application/ld+json'
-			dangerouslySetInnerHTML={{ __html: schemaToSafeJsonLdString(schema) }}
+			dangerouslySetInnerHTML={{ __html: toJsonLdString(schema) }}
 		/>
 	) : null;
 }

--- a/src/ui/PositionPageContent.tsx
+++ b/src/ui/PositionPageContent.tsx
@@ -123,6 +123,7 @@ export function PositionPageContent(props: PositionPageContentProps) {
 			})
 		: undefined;
 
+	// Omit JobPosting when the elections API has no filing or election date (required datePosted).
 	const jobPostingSchema = race
 		? buildJobPostingSchema({
 				race,
@@ -131,7 +132,7 @@ export function PositionPageContent(props: PositionPageContentProps) {
 				countyName,
 				cityName,
 				pageUrl,
-			})
+			}) ?? undefined
 		: undefined;
 
 	const breadcrumbSchema = buildBreadcrumbSchema(breadcrumbs, toAbsoluteUrl);

--- a/src/ui/PositionPageContent.tsx
+++ b/src/ui/PositionPageContent.tsx
@@ -14,7 +14,13 @@ import {
 	POSITION_PAGE_TWO_UP_CARD,
 } from '~/constants/positionPageStaticSections';
 import { primaryButtonStyleType, secondaryButtonStyleType } from '~/ui/_lib/designTypesStore';
-import { buildPositionPageSchema, buildBreadcrumbSchema, buildFAQSchema, buildDynamicFAQItems } from '~/lib/electionsHelpers';
+import {
+	buildPositionPageSchema,
+	buildJobPostingSchema,
+	buildBreadcrumbSchema,
+	buildFAQSchema,
+	buildDynamicFAQItems,
+} from '~/lib/electionsHelpers';
 import { toAbsoluteUrl } from '~/lib/url';
 import { PageSchema } from '~/ui/PageSchema';
 
@@ -117,6 +123,17 @@ export function PositionPageContent(props: PositionPageContentProps) {
 			})
 		: undefined;
 
+	const jobPostingSchema = race
+		? buildJobPostingSchema({
+				race,
+				officeName,
+				stateName,
+				countyName,
+				cityName,
+				pageUrl,
+			})
+		: undefined;
+
 	const breadcrumbSchema = buildBreadcrumbSchema(breadcrumbs, toAbsoluteUrl);
 
 	const faqItems = race
@@ -127,6 +144,7 @@ export function PositionPageContent(props: PositionPageContentProps) {
 	return (
 		<>
 			<PageSchema schema={positionPageSchema} />
+			<PageSchema schema={jobPostingSchema} />
 			<PageSchema schema={breadcrumbSchema} />
 			<PageSchema schema={faqSchema} />
 			<BreadcrumbBlock backgroundColor="midnight" breadcrumbs={breadcrumbs} />


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes structured-data emitted on position pages (adds JobPosting, fixes FAQ root type) and adjusts JSON-LD/HTML handling, which can affect SEO indexing and introduces new sanitization/parsing paths.
> 
> **Overview**
> Adds a new `buildJobPostingSchema` JSON-LD generator for election position pages (including `datePosted`/`validThrough`, employment type mapping, and salary parsing), and renders it alongside the existing position `WebPage` schema.
> 
> Fixes FAQ structured data to use `FAQPage` as the root `@type`, and hardens JSON-LD rendering by escaping `<`/`>` in `PageSchema` to prevent script-tag breakouts. Includes extensive new tests around JobPosting date selection, salary parsing, and description sanitization/escaping.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit af7ecd138edcf98ab4f95229840183d9c1915456. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->