### PR TITLE
Implement resolveButtonHref function for button action handling

### DIFF
--- a/src/PageSections/CTACardsBlockSection.tsx
+++ b/src/PageSections/CTACardsBlockSection.tsx
@@ -1,10 +1,9 @@
 import type { Sections } from '~/PageSections';
 
-import type { ButtonType } from '~/lib/buttonTransformer';
+import { isButtonType, transformButton } from '~/lib/buttonTransformer';
 
 import { resolveBg } from '~/ui/_lib/resolveBg';
 import { resolveComponentColor } from '~/ui/_lib/resolveComponentColor';
-import { resolveCTALink } from '~/ui/_lib/resolveCTALink';
 import { CTACardBlock } from '~/ui/CTACardBlock';
 import { stegaClean } from 'next-sanity';
 
@@ -13,19 +12,26 @@ export function CTACardsBlockSection(section: Extract<Sections, { _type: 'compon
 		? resolveBg(stegaClean(section.ctaCardsBlockDesignSettings.field_blockColorCreamMidnight))
 		: 'cream';
 
+	const cardOneCta = section.ctaCardOne?.ctaActionWithShared;
+	const cardTwoCta = section.ctaCardTwo?.ctaActionWithShared;
+	const cardOneHref =
+		cardOneCta && isButtonType(cardOneCta) ? transformButton(cardOneCta)?.href : undefined;
+	const cardTwoHref =
+		cardTwoCta && isButtonType(cardTwoCta) ? transformButton(cardTwoCta)?.href : undefined;
+
 	return (
 		<section id={stegaClean(section.componentSettings?.field_anchorId)} data-section='CTA Cards Block'>
 			<CTACardBlock
 				backgroundColor={backgroundColor}
 				card1={{
 					color: resolveComponentColor(stegaClean(section.ctaCardOne?.field_componentColor6ColorsInverse), backgroundColor),
-					href: resolveCTALink(section.ctaCardOne?.ctaActionWithShared as unknown as ButtonType),
+					href: cardOneHref,
 					label: section.ctaCardOne?.field_label,
 					title: section.ctaCardOne?.ctaActionWithShared?.text ?? undefined,
 				}}
 				card2={{
 					color: resolveComponentColor(stegaClean(section.ctaCardTwo?.field_componentColor6ColorsInverse), backgroundColor),
-					href: resolveCTALink(section.ctaCardTwo?.ctaActionWithShared as unknown as ButtonType),
+					href: cardTwoHref,
 					label: section.ctaCardTwo?.field_label,
 					title: section.ctaCardTwo?.ctaActionWithShared?.text ?? undefined,
 				}}

--- a/src/PageSections/ClaimProfileBlockSection.tsx
+++ b/src/PageSections/ClaimProfileBlockSection.tsx
@@ -1,9 +1,8 @@
 import type { SectionOverrides, Sections } from '~/PageSections';
+import { isButtonType, transformButton } from '~/lib/buttonTransformer';
 import { ClaimProfileBlock } from '~/ui/ClaimProfileBlock';
 import { resolveBg } from '~/ui/_lib/resolveBg';
-import { resolveCTALink } from '~/ui/_lib/resolveCTALink';
 import { stegaClean } from 'next-sanity';
-import type { ButtonType } from '~/lib/buttonTransformer';
 
 type Props = Extract<Sections, { _type: 'component_claimProfileBlock' }> & {
 	claimProfileOverride?: SectionOverrides['component_claimProfileBlock'];
@@ -15,6 +14,10 @@ export function ClaimProfileBlockSection({ claimProfileOverride, ...section }: P
 		: 'cream';
 
 	const ctaButton = section.ctaAction;
+	const claimButton =
+		ctaButton && isButtonType(ctaButton)
+			? transformButton(ctaButton)
+			: undefined;
 	const exampleCard = section.claimProfileBlockContent?.exampleCard;
 
 	return (
@@ -26,11 +29,13 @@ export function ClaimProfileBlockSection({ claimProfileOverride, ...section }: P
 				backgroundColor={backgroundColor}
 				headline={section.claimProfileBlockContent?.field_headline}
 				body={section.claimProfileBlockContent?.field_body}
-				claimButton={{
-					buttonType: 'internal',
-					href: resolveCTALink(ctaButton as unknown as ButtonType),
-					label: ctaButton?.text || 'View Claims',
-				}}
+				claimButton={
+					claimButton ?? {
+						buttonType: 'internal',
+						href: '/',
+						label: ctaButton?.text || 'View Claims',
+					}
+				}
 				exampleCard={{
 					name: claimProfileOverride?.candidateName ?? exampleCard?.field_name ?? 'Firstname Lastname',
 					partyAffiliation: claimProfileOverride?.partyAffiliation ?? exampleCard?.field_partyAffiliation,

--- a/src/PageSections/ElectionsPositionHeroSection.tsx
+++ b/src/PageSections/ElectionsPositionHeroSection.tsx
@@ -2,11 +2,10 @@ import { stegaClean } from 'next-sanity';
 
 import type { Sections } from '~/PageSections';
 
-import { isButtonType } from '~/lib/buttonTransformer';
+import { isButtonType, transformButton } from '~/lib/buttonTransformer';
 
 import { primaryButtonStyleType } from '~/ui/_lib/designTypesStore';
 import { resolveBg } from '~/ui/_lib/resolveBg';
-import { resolveCTALink } from '~/ui/_lib/resolveCTALink';
 import { ElectionsPositionHero } from '~/ui/ElectionsPositionHero';
 
 // Mock office data type - will be replaced with real data source
@@ -57,7 +56,23 @@ export function ElectionsPositionHeroSection(props: ElectionsPositionHeroSection
 
 	const rawCta = section.ctaAction;
 	const ctaData = rawCta && isButtonType(rawCta) ? rawCta : null;
-	const ctaHref = ctaData ? resolveCTALink(ctaData) : undefined;
+	const fromSanity = ctaData ? transformButton(ctaData) : undefined;
+	const cta = fromSanity
+		? {
+				...fromSanity,
+				buttonProps: {
+					...fromSanity.buttonProps,
+					styleType: primaryButtonStyleType,
+				},
+			}
+		: {
+				buttonType: 'internal' as const,
+				href: '/run',
+				label: ctaData?.text ?? 'Primary CTA',
+				buttonProps: {
+					styleType: primaryButtonStyleType,
+				},
+			};
 
 	return (
 		<section id={stegaClean(section.componentSettings?.field_anchorId)} data-section='Elections Position Hero'>
@@ -69,14 +84,7 @@ export function ElectionsPositionHeroSection(props: ElectionsPositionHeroSection
 				cityName={data.cityName}
 				electionDate={data.electionDate}
 				filingDate={data.filingDate}
-				cta={{
-					buttonType: 'internal',
-					href: ctaHref ?? '/run',
-					label: ctaData?.text ?? 'Primary CTA',
-					buttonProps: {
-						styleType: primaryButtonStyleType,
-					},
-				}}
+				cta={cta}
 			/>
 		</section>
 	);

--- a/src/lib/buttonTransformer.tsx
+++ b/src/lib/buttonTransformer.tsx
@@ -9,7 +9,7 @@ export type ButtonType = Exclude<ButtonsType, null | undefined>[number];
 
 /**
  * Type guard for raw CTA/button data from Sanity (e.g. ctaAction, ctaActionWithShared).
- * Ensures the value has the minimal shape expected by resolveCTALink and transformButtons.
+ * Ensures the value has the minimal shape expected by transformButton and transformButtons.
  */
 export function isButtonType(value: unknown): value is ButtonType {
 	if (value === null || typeof value !== 'object' || Array.isArray(value)) {
@@ -51,6 +51,100 @@ export function resolveButtonHref(button: ButtonType): string | undefined {
 	}
 }
 
+export function transformButton(button: ButtonType): ComponentButtonProps | undefined {
+	const action = stegaClean(button.action);
+	const href = resolveButtonHref(button);
+
+	switch (action) {
+		case 'Internal':
+			if (!href) return undefined;
+			return {
+				_key: button._key,
+				formId: (button as { formId?: string }).formId,
+				label: button.text ?? button.link.title ?? button.link.name,
+				buttonType: 'internal',
+				href,
+				buttonProps: {
+					styleType: resolveHierarchy(button.hierarchy),
+				},
+			};
+		case 'Contact':
+			if (!href) return undefined;
+			return {
+				_key: button._key,
+				formId: (button as { formId?: string }).formId,
+				label: button.text ?? button.link.title ?? button.link.name,
+				buttonType: 'contact',
+				href,
+				buttonProps: {
+					styleType: resolveHierarchy(button.hierarchy),
+				},
+			};
+		case 'External':
+			if (!href) return undefined;
+			return {
+				_key: button._key,
+				formId: (button as { formId?: string }).formId,
+				label: button.text ?? button.field_externalLink,
+				buttonType: 'external',
+				href,
+				buttonProps: {
+					styleType: resolveHierarchy(button.hierarchy),
+				},
+			};
+		case 'Anchor':
+			if (!href) return undefined;
+			return {
+				_key: button._key,
+				formId: (button as { formId?: string }).formId,
+				label: button.text,
+				buttonType: 'anchor',
+				href,
+				buttonProps: {
+					styleType: resolveHierarchy(button.hierarchy),
+				},
+			};
+		case 'Download':
+			if (!href) return undefined;
+			return {
+				_key: button._key,
+				formId: (button as { formId?: string }).formId,
+				label: button.text ?? button.ref_download.name,
+				buttonType: 'download',
+				href,
+				buttonProps: {
+					styleType: resolveHierarchy(button.hierarchy),
+				},
+			};
+		case 'LogIn':
+			if (!href) return undefined;
+			return {
+				_key: button._key,
+				formId: (button as { formId?: string }).formId,
+				label: button.text ?? 'Login',
+				buttonType: 'external',
+				href,
+				buttonProps: {
+					styleType: resolveHierarchy(button.hierarchy),
+				},
+			};
+		case 'SignUp':
+			if (!href) return undefined;
+			return {
+				_key: button._key,
+				formId: (button as { formId?: string }).formId,
+				label: button.text ?? 'Sign up',
+				buttonType: 'external',
+				href,
+				buttonProps: {
+					styleType: resolveHierarchy(button.hierarchy),
+				},
+			};
+		default:
+			return undefined;
+	}
+}
+
 export function transformButtons(buttons?: ButtonsType): ComponentButtonProps[] | undefined {
 	if (!buttons) {
 		return undefined;
@@ -61,101 +155,9 @@ export function transformButtons(buttons?: ButtonsType): ComponentButtonProps[] 
 		if (!button) {
 			continue;
 		}
-		const action = stegaClean(button.action);
-		const href = resolveButtonHref(button);
-
-		switch (action) {
-			case 'Internal':
-				if (href)
-					transformedButtons.push({
-						_key: button._key,
-						formId: (button as { formId?: string }).formId,
-						label: button.text ?? button.link.title ?? button.link.name,
-						buttonType: 'internal',
-						href,
-						buttonProps: {
-							styleType: resolveHierarchy(button.hierarchy),
-						},
-					});
-				break;
-			case 'Contact':
-				if (href)
-					transformedButtons.push({
-						_key: button._key,
-						formId: (button as { formId?: string }).formId,
-						label: button.text ?? button.link.title ?? button.link.name,
-						buttonType: 'contact',
-						href,
-						buttonProps: {
-							styleType: resolveHierarchy(button.hierarchy),
-						},
-					});
-				break;
-			case 'External':
-				if (href)
-					transformedButtons.push({
-						_key: button._key,
-						formId: (button as { formId?: string }).formId,
-						label: button.text ?? button.field_externalLink,
-						buttonType: 'external',
-						href,
-						buttonProps: {
-							styleType: resolveHierarchy(button.hierarchy),
-						},
-					});
-				break;
-			case 'Anchor':
-				if (href)
-					transformedButtons.push({
-						_key: button._key,
-						formId: (button as { formId?: string }).formId,
-						label: button.text,
-						buttonType: 'anchor',
-						href,
-						buttonProps: {
-							styleType: resolveHierarchy(button.hierarchy),
-						},
-					});
-				break;
-			case 'Download':
-				if (href)
-					transformedButtons.push({
-						_key: button._key,
-						formId: (button as { formId?: string }).formId,
-						label: button.text ?? button.ref_download.name,
-						buttonType: 'download',
-						href,
-						buttonProps: {
-							styleType: resolveHierarchy(button.hierarchy),
-						},
-					});
-				break;
-			case 'LogIn':
-				if (href)
-					transformedButtons.push({
-						_key: button._key,
-						formId: (button as { formId?: string }).formId,
-						label: button.text ?? 'Login',
-						buttonType: 'external',
-						href,
-						buttonProps: {
-							styleType: resolveHierarchy(button.hierarchy),
-						},
-					});
-				break;
-			case 'SignUp':
-				if (href)
-					transformedButtons.push({
-						_key: button._key,
-						formId: (button as { formId?: string }).formId,
-						label: button.text ?? 'Sign up',
-						buttonType: 'external',
-						href,
-						buttonProps: {
-							styleType: resolveHierarchy(button.hierarchy),
-						},
-					});
-				break;
+		const transformed = transformButton(button);
+		if (transformed) {
+			transformedButtons.push(transformed);
 		}
 	}
 	return transformedButtons;

--- a/src/lib/buttonTransformer.tsx
+++ b/src/lib/buttonTransformer.tsx
@@ -29,6 +29,28 @@ function resolveHierarchy(
 	return 'ghost';
 }
 
+export function resolveButtonHref(button: ButtonType): string | undefined {
+	const action = stegaClean(button.action);
+
+	switch (action) {
+		case 'Internal':
+		case 'Contact':
+			return button.link && 'href' in button.link ? (button.link.href as string | undefined) ?? undefined : undefined;
+		case 'External':
+			return button.field_externalLink ?? undefined;
+		case 'Anchor':
+			return button.anchor ?? undefined;
+		case 'Download':
+			return button.ref_download?.file?.url ?? undefined;
+		case 'LogIn':
+			return 'https://app.goodparty.org/login';
+		case 'SignUp':
+			return 'https://app.goodparty.org/sign-up';
+		default:
+			return undefined;
+	}
+}
+
 export function transformButtons(buttons?: ButtonsType): ComponentButtonProps[] | undefined {
 	if (!buttons) {
 		return undefined;
@@ -39,95 +61,100 @@ export function transformButtons(buttons?: ButtonsType): ComponentButtonProps[] 
 		if (!button) {
 			continue;
 		}
-		switch (stegaClean(button.action)) {
+		const action = stegaClean(button.action);
+		const href = resolveButtonHref(button);
+
+		switch (action) {
 			case 'Internal':
-				if (button.link && 'href' in button.link && button.link.href)
+				if (href)
 					transformedButtons.push({
 						_key: button._key,
 						formId: (button as { formId?: string }).formId,
 						label: button.text ?? button.link.title ?? button.link.name,
 						buttonType: 'internal',
-						href: button.link.href,
+						href,
 						buttonProps: {
 							styleType: resolveHierarchy(button.hierarchy),
 						},
 					});
 				break;
 			case 'Contact':
-				if (button.link && 'href' in button.link && button.link.href)
+				if (href)
 					transformedButtons.push({
 						_key: button._key,
 						formId: (button as { formId?: string }).formId,
 						label: button.text ?? button.link.title ?? button.link.name,
 						buttonType: 'contact',
-						href: button.link.href,
+						href,
 						buttonProps: {
 							styleType: resolveHierarchy(button.hierarchy),
 						},
 					});
 				break;
 			case 'External':
-				if (button.field_externalLink)
+				if (href)
 					transformedButtons.push({
 						_key: button._key,
 						formId: (button as { formId?: string }).formId,
 						label: button.text ?? button.field_externalLink,
 						buttonType: 'external',
-						href: button.field_externalLink,
+						href,
 						buttonProps: {
 							styleType: resolveHierarchy(button.hierarchy),
 						},
 					});
 				break;
 			case 'Anchor':
-				if (button.anchor)
+				if (href)
 					transformedButtons.push({
 						_key: button._key,
 						formId: (button as { formId?: string }).formId,
 						label: button.text,
 						buttonType: 'anchor',
-						href: button.anchor,
+						href,
 						buttonProps: {
 							styleType: resolveHierarchy(button.hierarchy),
 						},
 					});
 				break;
 			case 'Download':
-				if (button.ref_download && button.ref_download.file?.url)
+				if (href)
 					transformedButtons.push({
 						_key: button._key,
 						formId: (button as { formId?: string }).formId,
 						label: button.text ?? button.ref_download.name,
 						buttonType: 'download',
-						href: button.ref_download.file?.url,
+						href,
 						buttonProps: {
 							styleType: resolveHierarchy(button.hierarchy),
 						},
 					});
 				break;
 			case 'LogIn':
-				transformedButtons.push({
-					_key: button._key,
-					formId: (button as { formId?: string }).formId,
-					label: button.text ?? 'Login',
-					buttonType: 'external',
-					href: 'https://app.goodparty.org/login',
+				if (href)
+					transformedButtons.push({
+						_key: button._key,
+						formId: (button as { formId?: string }).formId,
+						label: button.text ?? 'Login',
+						buttonType: 'external',
+						href,
 						buttonProps: {
 							styleType: resolveHierarchy(button.hierarchy),
 						},
 					});
 				break;
 			case 'SignUp':
-				transformedButtons.push({
-					_key: button._key,
-					formId: (button as { formId?: string }).formId,
-					label: button.text ?? 'Sign up',
-					buttonType: 'external',
-					href: 'https://app.goodparty.org/sign-up',
-					buttonProps: {
-						styleType: resolveHierarchy(button.hierarchy),
-					},
-				});
+				if (href)
+					transformedButtons.push({
+						_key: button._key,
+						formId: (button as { formId?: string }).formId,
+						label: button.text ?? 'Sign up',
+						buttonType: 'external',
+						href,
+						buttonProps: {
+							styleType: resolveHierarchy(button.hierarchy),
+						},
+					});
 				break;
 		}
 	}

--- a/src/sanity/utils/handleReplacements.ts
+++ b/src/sanity/utils/handleReplacements.ts
@@ -5,16 +5,45 @@ function checkPrimary(item: any,primaryLanguage:string) {
     : item;
 }
 
+function isSafeMedia(value: unknown): boolean {
+  if (!value || typeof value !== 'object') return false;
+
+  const obj = value as { asset?: unknown };
+
+  if ('asset' in obj) {
+    const asset = obj.asset as any;
+
+    if (asset && typeof asset === 'object') {
+      if ('_ref' in asset && typeof asset._ref === 'string') {
+        return true;
+      }
+      if ('metadata' in asset && asset.metadata && typeof asset.metadata === 'object') {
+        const metadata = asset.metadata as { dimensions?: { width?: number; height?: number } };
+        if (metadata.dimensions && typeof metadata.dimensions.width === 'number' && typeof metadata.dimensions.height === 'number') {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  return true;
+}
+
 function checkReturnI18n(obj: {
   title?: unknown;
   subtitle?: unknown;
   media?: unknown;
 },primaryLanguage:string) {
-  return {
+  const result = {
     title: checkPrimary(obj.title,primaryLanguage),
     subtitle: checkPrimary(obj.subtitle,primaryLanguage),
     media: checkPrimary(obj.media,primaryLanguage),
   };
+  if (!isSafeMedia(result.media)) {
+    result.media = undefined;
+  }
+  return result;
 }
 export function handleReplacements(
   i: Record<string, unknown>,

--- a/src/ui/_lib/resolveCTALink.ts
+++ b/src/ui/_lib/resolveCTALink.ts
@@ -1,9 +1,8 @@
 import type { ButtonType } from '~/lib/buttonTransformer';
+import { resolveButtonHref } from '~/lib/buttonTransformer';
 
 export function resolveCTALink(cta?: ButtonType) {
 	if (!cta) return;
 
-	if (cta.link && 'href' in cta.link && cta.link.href) return cta.link.href;
-
-	return undefined;
+	return resolveButtonHref(cta);
 }

--- a/src/ui/_lib/resolveCTALink.ts
+++ b/src/ui/_lib/resolveCTALink.ts
@@ -1,8 +1,0 @@
-import type { ButtonType } from '~/lib/buttonTransformer';
-import { resolveButtonHref } from '~/lib/buttonTransformer';
-
-export function resolveCTALink(cta?: ButtonType) {
-	if (!cta) return;
-
-	return resolveButtonHref(cta);
-}


### PR DESCRIPTION
- Added resolveButtonHref function to streamline href resolution based on button action types (Internal, External, Anchor, Download, LogIn, SignUp).
- Updated transformButtons function to utilize resolveButtonHref for improved href management and code clarity.
- Refactored resolveCTALink to leverage the new resolveButtonHref function for consistent link resolution.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how CTA/button URLs are derived across multiple action types and adds stricter sanitization that can drop `media` from Sanity-derived previews, potentially affecting navigation and rendering in content-driven sections.
> 
> **Overview**
> **Centralizes button/CTA link resolution** by introducing `resolveButtonHref` and updating `transformButtons` and `resolveCTALink` to use it, expanding supported actions to include `Anchor`, `Download`, `LogIn`, and `SignUp`.
> 
> **Hardens Sanity i18n preview replacements** by validating `media` via `isSafeMedia` and clearing it when the value doesn’t look like a safe Sanity asset reference/metadata object.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 41dc4dfd7b0827b094cfa195a79c4b72889d5dde. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->