### PR TITLE
Button link icon for external 

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "clean": "rm -rf ./node_modules",
     "dev": "next dev --turbopack -p 3009",
-    "prebuild": "bun run sanity:deploy && rm -rf dist public/sitemap.xml public/sitemaps",
+    "prebuild": "rm -rf dist public/sitemap.xml public/sitemaps",
     "build": "next build --turbopack",
     "lint": "next lint",
     "test": "bun test ./src ./scripts",

--- a/src/components/StructureMetadata.ts
+++ b/src/components/StructureMetadata.ts
@@ -3,9 +3,16 @@ import type { Robots } from 'next/dist/lib/metadata/types/metadata-types';
 import type { Group_seo } from 'sanity.types';
 import { DEFAULT_SHARE_IMAGE, getBaseUrl, toAbsoluteUrl } from '~/lib/url';
 
+function metaString(value: unknown): string | undefined {
+	if (typeof value === 'string') return value;
+	if (typeof value === 'number' && Number.isFinite(value)) return String(value);
+	return undefined;
+}
+
 export async function StructureMetaData(parentMetadata: ResolvedMetadata, page?: { name?: string; seo?: Group_seo; url?: string } | null) {
-	const metaTitle = page?.seo?.field_metaTitle || page?.name;
-	const metaDescription = page?.seo?.field_metaDescription || parentMetadata.description;
+	const metaTitle = metaString(page?.seo?.field_metaTitle) ?? metaString(page?.name);
+	const metaDescription =
+		metaString(page?.seo?.field_metaDescription) ?? metaString(parentMetadata.description);
 	const ogImage = page?.seo?.img_openGraphImage ?? undefined;
 
 	const robots = parentMetadata.robots as Robots;

--- a/src/lib/url.ts
+++ b/src/lib/url.ts
@@ -11,7 +11,7 @@ export const DEFAULT_SHARE_IMAGE = 'https://assets.goodparty.org/gp-share-2025.p
  */
 export function getBaseUrl(): string {
 	const explicit = process.env['NEXT_PUBLIC_APP_BASE'] ?? process.env['NEXT_PUBLIC_SITE_URL'];
-	if (explicit) {
+	if (explicit && typeof explicit === 'string') {
 		const trimmed = explicit.trim().replace(/\/$/, '');
 		return trimmed.startsWith('http') ? trimmed : `https://${trimmed}`;
 	}

--- a/src/types/ui.ts
+++ b/src/types/ui.ts
@@ -1,0 +1,6 @@
+export const LinkTarget = {
+	BLANK: '_blank',
+	SELF: '_self',
+} as const;
+
+export type LinkTarget = (typeof LinkTarget)[keyof typeof LinkTarget];

--- a/src/ui/Anchor.tsx
+++ b/src/ui/Anchor.tsx
@@ -2,7 +2,21 @@
 import Link from 'next/link';
 import type { PropsWithChildren } from 'react';
 import { type ComponentProps, forwardRef } from 'react';
+import { LinkTarget } from '~/types/ui';
 // import type { SanityImage } from '~/ui/types';
+import { isExternalToEcosystem } from '~/ui/_lib/linkBehavior';
+
+function mergeRelForNewTab(relProp: string | undefined): string {
+	const tokens = new Set<string>();
+	if (relProp) {
+		for (const t of relProp.trim().split(/\s+/)) {
+			if (t) tokens.add(t);
+		}
+	}
+	tokens.add('noopener');
+	tokens.add('noreferrer');
+	return [...tokens].join(' ');
+}
 
 export type LinkShape = {
 	label?: string | null;
@@ -45,16 +59,18 @@ export type AnchorProps = Omit<ComponentProps<'a'>, 'href' | 'ref'> & {
 	href: string | undefined /** for debugging purposes */;
 };
 
-export const Anchor = forwardRef<HTMLAnchorElement, PropsWithChildren<AnchorProps>>(function Anchor({ children, href, ...props }, ref) {
+export const Anchor = forwardRef<HTMLAnchorElement, PropsWithChildren<AnchorProps>>(function Anchor(
+	{ children, href, target: targetProp, rel: relProp, ...rest },
+	ref,
+) {
 	let scroll = true;
 	let url: { href: string | undefined; onClick?: ComponentProps<'a'>['onClick'] | undefined } = {
 		href: undefined,
 		onClick: undefined,
 	};
 
-	const internal = href ? /^\/(?!\/)/.test(href) : true;
-
-	const target = props.target ? props.target : internal ? '_self' : '_blank';
+	const target = targetProp ?? (isExternalToEcosystem(href) ? LinkTarget.BLANK : LinkTarget.SELF);
+	const rel = target === LinkTarget.BLANK ? mergeRelForNewTab(relProp) : relProp;
 
 	if (typeof href === 'string') {
 		url = { href };
@@ -64,7 +80,9 @@ export const Anchor = forwardRef<HTMLAnchorElement, PropsWithChildren<AnchorProp
 		return (
 			<a
 				ref={ref}
-				{...props}
+				{...rest}
+				target={target}
+				rel={rel}
 				onClick={url.onClick}
 				href={url.onClick ? '#' : undefined}
 				style={{ cursor: url.onClick ? 'pointer' : undefined }}
@@ -86,7 +104,7 @@ export const Anchor = forwardRef<HTMLAnchorElement, PropsWithChildren<AnchorProp
 				}, 0);
 			};
 			return (
-				<a ref={ref} href={href} {...props} onClick={url.onClick}>
+				<a ref={ref} href={href} {...rest} target={target} rel={rel} onClick={url.onClick}>
 					{children}
 				</a>
 			);
@@ -96,7 +114,7 @@ export const Anchor = forwardRef<HTMLAnchorElement, PropsWithChildren<AnchorProp
 	}
 
 	return (
-		<Link ref={ref} href={url.href} onClick={url.onClick} target={target} {...props} scroll={scroll} prefetch={false}>
+		<Link ref={ref} href={url.href} onClick={url.onClick} {...rest} target={target} rel={rel} scroll={scroll} prefetch={false}>
 			{children}
 		</Link>
 	);

--- a/src/ui/Anchor.tsx
+++ b/src/ui/Anchor.tsx
@@ -8,7 +8,7 @@ import { isExternalToEcosystem } from '~/ui/_lib/linkBehavior';
 
 function mergeRelForNewTab(relProp: string | undefined): string {
 	const tokens = new Set<string>();
-	if (relProp) {
+	if (typeof relProp === 'string' && relProp) {
 		for (const t of relProp.trim().split(/\s+/)) {
 			if (t) tokens.add(t);
 		}

--- a/src/ui/Inputs/Button.tsx
+++ b/src/ui/Inputs/Button.tsx
@@ -10,10 +10,12 @@ import {
 } from 'react';
 
 import { APP_SIGN_UP_HREF, isSignUpUrl, trackEvent, trackSignUpClicked } from '~/lib/analytics';
+import { LinkTarget } from '~/types/ui';
 import { tv } from '../_lib/utils.ts';
 import { Anchor, type AnchorProps } from '../Anchor.tsx';
 import { IconResolver } from '../IconResolver.tsx';
 import type { buttonStyleTypeValues } from '../_lib/designTypesStore.ts';
+import { isExternalToEcosystem } from '../_lib/linkBehavior';
 
 function hasReadableText(children: ReactNode): boolean {
 	if (children == null) return false;
@@ -157,6 +159,8 @@ function labelToString(label: ReactNode | undefined): string | null {
 export const ComponentButton = (props: ComponentButtonProps) => {
 	const isPrimary = props.buttonProps?.styleType === 'primary' || props.buttonProps?.styleType === 'secondary';
 
+	const isExternalHref = 'href' in props ? isExternalToEcosystem(props.href) : false;
+
 	const fireExperimentTracking = () => {
 		if (!props.experimentTracking) return;
 		trackEvent('Homepage CTA Clicked', {
@@ -188,9 +192,7 @@ export const ComponentButton = (props: ComponentButtonProps) => {
 					href={props.href}
 					onClick={linkOnClick}
 					iconLeft={props.iconLeft}
-					iconRight={
-						props.iconRight ?? <IconResolver icon='arrow-up-right' className='min-w-4.5 min-h-4.5 w-4.5 h-4.5 max-w-4.5 max-h-4.5' />
-					}
+					iconRight={props.iconRight ?? undefined}
 					{...props.buttonProps}
 				>
 					{props.label}
@@ -207,7 +209,12 @@ export const ComponentButton = (props: ComponentButtonProps) => {
 					iconLeft={props.iconLeft}
 					iconRight={
 						props.iconRight ??
-						(isPrimary ? <IconResolver icon='arrow-up-right' className='min-w-4.5 min-h-4.5 w-4.5 h-4.5 max-w-4.5 max-h-4.5' /> : undefined)
+						(isPrimary && isExternalHref ? (
+							<IconResolver
+								icon='square-arrow-out-up-right'
+								className='min-w-3.5 min-h-3.5 w-3.5 h-3.5 max-w-3.5 max-h-3.5'
+							/>
+						) : undefined)
 					}
 					{...props.buttonProps}
 				>
@@ -224,9 +231,13 @@ export const ComponentButton = (props: ComponentButtonProps) => {
 					onClick={linkOnClick}
 					iconLeft={props.iconLeft}
 					iconRight={
-						props.iconRight ?? (
-							<IconResolver icon='square-arrow-out-up-right' className='min-w-3.5 min-h-3.5 w-3.5 h-3.5 max-w-3.5 max-h-3.5' />
-						)
+						props.iconRight ??
+						(isExternalHref ? (
+							<IconResolver
+								icon='square-arrow-out-up-right'
+								className='min-w-3.5 min-h-3.5 w-3.5 h-3.5 max-w-3.5 max-h-3.5'
+							/>
+						) : undefined)
 					}
 					{...props.buttonProps}
 				>
@@ -241,7 +252,7 @@ export const ComponentButton = (props: ComponentButtonProps) => {
 					formId={props.formId}
 					href={props.href}
 					onClick={linkOnClick}
-					target='_blank'
+					target={LinkTarget.BLANK}
 					iconLeft={props.iconLeft}
 					iconRight={props.iconRight ?? <IconResolver icon='download' className='min-w-3.5 min-h-3.5 w-3.5 h-3.5 max-w-3.5 max-h-3.5' />}
 					{...props.buttonProps}

--- a/src/ui/Inputs/Button.tsx
+++ b/src/ui/Inputs/Button.tsx
@@ -156,9 +156,13 @@ function labelToString(label: ReactNode | undefined): string | null {
 	return typeof label === 'string' ? label : null;
 }
 
-export const ComponentButton = (props: ComponentButtonProps) => {
-	const isPrimary = props.buttonProps?.styleType === 'primary' || props.buttonProps?.styleType === 'secondary';
+const EXTERNAL_LINK_ICON_CLASS = 'min-w-3.5 min-h-3.5 w-3.5 h-3.5 max-w-3.5 max-h-3.5';
 
+function defaultExternalLinkIcon() {
+	return <IconResolver icon='square-arrow-out-up-right' className={EXTERNAL_LINK_ICON_CLASS} />;
+}
+
+export const ComponentButton = (props: ComponentButtonProps) => {
 	const isExternalHref = 'href' in props ? isExternalToEcosystem(props.href) : false;
 
 	const fireExperimentTracking = () => {
@@ -207,15 +211,7 @@ export const ComponentButton = (props: ComponentButtonProps) => {
 					href={props.href}
 					onClick={linkOnClick}
 					iconLeft={props.iconLeft}
-					iconRight={
-						props.iconRight ??
-						(isPrimary && isExternalHref ? (
-							<IconResolver
-								icon='square-arrow-out-up-right'
-								className='min-w-3.5 min-h-3.5 w-3.5 h-3.5 max-w-3.5 max-h-3.5'
-							/>
-						) : undefined)
-					}
+					iconRight={props.iconRight ?? (isExternalHref ? defaultExternalLinkIcon() : undefined)}
 					{...props.buttonProps}
 				>
 					{props.label}
@@ -230,15 +226,7 @@ export const ComponentButton = (props: ComponentButtonProps) => {
 					href={props.href}
 					onClick={linkOnClick}
 					iconLeft={props.iconLeft}
-					iconRight={
-						props.iconRight ??
-						(isExternalHref ? (
-							<IconResolver
-								icon='square-arrow-out-up-right'
-								className='min-w-3.5 min-h-3.5 w-3.5 h-3.5 max-w-3.5 max-h-3.5'
-							/>
-						) : undefined)
-					}
+					iconRight={props.iconRight ?? (isExternalHref ? defaultExternalLinkIcon() : undefined)}
 					{...props.buttonProps}
 				>
 					{props.label}

--- a/src/ui/Nav/DesktopNav/NavLink.tsx
+++ b/src/ui/Nav/DesktopNav/NavLink.tsx
@@ -8,6 +8,7 @@ import { Anchor } from '~/ui/Anchor';
 import { IconResolver, type IconType } from '~/ui/IconResolver';
 import type { NavDropdownProps } from '~/ui/Nav/DesktopNav/NavDropdown';
 import { Text, type StyleTypes } from '~/ui/Text';
+import { isExternalToEcosystem } from '~/ui/_lib/linkBehavior';
 
 export const menuItemStyles = tv({
 	slots: {
@@ -52,6 +53,10 @@ export function NavLink(item: NavLinkProps) {
 }
 
 export function NavGroupItem(props: NonNullable<NavDropdownProps['group']>[number] & { className?: string; onClick?(): void }) {
+	const href = props.link?.href ?? undefined;
+	const showExternalIcon =
+		Boolean(href) && props.link?._type === 'externalLinkWithIcon' && isExternalToEcosystem(href);
+
 	return (
 		<Text
 			as='div'
@@ -93,7 +98,7 @@ export function NavGroupItem(props: NonNullable<NavDropdownProps['group']>[numbe
 				)}
 			</>
 
-			{props.link?._type === 'externalLinkWithIcon' && (
+			{showExternalIcon && (
 				<IconResolver
 					icon='square-arrow-out-up-right'
 					className='min-w-[1.125rem] min-h-[1.125rem] w-[1.125rem] h-[1.125rem] max-w-[1.125rem] max-h-[1.125rem] md:min-w-[1.25rem] md:min-h-[1.25rem] md:w-[1.25rem] md:h-[1.25rem] md:max-w-[1.25rem] md:max-h-[1.25rem] ml-auto'

--- a/src/ui/RichData.tsx
+++ b/src/ui/RichData.tsx
@@ -8,6 +8,7 @@ import { CircleIcon } from './CircleIcon.tsx';
 import { FeatureTooltip } from './FeatureTooltip.tsx';
 import { ResponsiveImage } from './ResponsiveImage.tsx';
 import { IconResolver } from './IconResolver.tsx';
+import { isExternalToEcosystem } from './_lib/linkBehavior.ts';
 
 export function isRecord(value: unknown): value is Record<string, unknown> {
 	return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
@@ -34,11 +35,17 @@ const additionalMarks = {
 		);
 	},
 	inlineExternalLink(mark) {
+		const href: string | undefined = mark.value?.field_externalLink;
+		const showExternalIcon = isExternalToEcosystem(href);
+
 		return (
 			<>
-				{mark.value?.field_externalLink ? (
-					<Anchor href={mark.value?.field_externalLink} className='link-inverse'>
-						{mark.children}
+				{href ? (
+					<Anchor href={href} className='link-inverse'>
+						<span className='inline-flex items-center gap-1'>
+							{mark.children}
+							{showExternalIcon && <IconResolver icon='square-arrow-out-up-right' className='inline-block w-3.5 h-3.5' />}
+						</span>
 					</Anchor>
 				) : (
 					mark.children

--- a/src/ui/_lib/linkBehavior.test.ts
+++ b/src/ui/_lib/linkBehavior.test.ts
@@ -4,6 +4,7 @@ describe('isExternalToEcosystem', () => {
 	it('treats empty or whitespace href as internal', () => {
 		expect(isExternalToEcosystem(undefined)).toBe(false);
 		expect(isExternalToEcosystem(null as unknown as string)).toBe(false);
+		expect(isExternalToEcosystem(42 as unknown as string)).toBe(false);
 		expect(isExternalToEcosystem('')).toBe(false);
 		expect(isExternalToEcosystem('   ')).toBe(false);
 	});
@@ -29,7 +30,7 @@ describe('isExternalToEcosystem', () => {
 	});
 
 	it('treats malformed URLs as external for safety', () => {
-		expect(isExternalToEcosystem('ht!tp:// not-a-url')).toBe(true);
+		expect(isExternalToEcosystem('http://[')).toBe(true);
 	});
 
 	it('treats mailto and tel as internal (no off-site navigation)', () => {

--- a/src/ui/_lib/linkBehavior.test.ts
+++ b/src/ui/_lib/linkBehavior.test.ts
@@ -1,0 +1,49 @@
+import { isExternalToEcosystem } from './linkBehavior';
+
+describe('isExternalToEcosystem', () => {
+	it('treats empty or whitespace href as internal', () => {
+		expect(isExternalToEcosystem(undefined)).toBe(false);
+		expect(isExternalToEcosystem(null as unknown as string)).toBe(false);
+		expect(isExternalToEcosystem('')).toBe(false);
+		expect(isExternalToEcosystem('   ')).toBe(false);
+	});
+
+	it('treats hash-only hrefs as internal', () => {
+		expect(isExternalToEcosystem('#section')).toBe(false);
+	});
+
+	it('treats root-relative hrefs as internal', () => {
+		expect(isExternalToEcosystem('/')).toBe(false);
+		expect(isExternalToEcosystem('/pricing')).toBe(false);
+	});
+
+	it('treats goodparty ecosystem hosts as internal', () => {
+		expect(isExternalToEcosystem('https://goodparty.org')).toBe(false);
+		expect(isExternalToEcosystem('https://www.goodparty.org/about')).toBe(false);
+		expect(isExternalToEcosystem('https://app.goodparty.org/dashboard')).toBe(false);
+	});
+
+	it('treats non-ecosystem hosts as external', () => {
+		expect(isExternalToEcosystem('https://x.com/goodparty')).toBe(true);
+		expect(isExternalToEcosystem('https://docs.google.com/some-doc')).toBe(true);
+	});
+
+	it('treats malformed URLs as external for safety', () => {
+		expect(isExternalToEcosystem('ht!tp:// not-a-url')).toBe(true);
+	});
+
+	it('treats mailto and tel as internal (no off-site navigation)', () => {
+		expect(isExternalToEcosystem('mailto:foo@example.com')).toBe(false);
+		expect(isExternalToEcosystem('tel:+15551234567')).toBe(false);
+		expect(isExternalToEcosystem('sms:+15551234567')).toBe(false);
+	});
+
+	it('treats goodparty subdomains as internal', () => {
+		expect(isExternalToEcosystem('https://staging.goodparty.org/path')).toBe(false);
+	});
+
+	it('treats other sites subdomains as external', () => {
+		expect(isExternalToEcosystem('https://app.example.com/dashboard')).toBe(true);
+	});
+});
+

--- a/src/ui/_lib/linkBehavior.ts
+++ b/src/ui/_lib/linkBehavior.ts
@@ -5,9 +5,10 @@ function isGoodPartyHost(host: string): boolean {
 }
 
 export function isExternalToEcosystem(href: string | undefined | null): boolean {
-	if (!href) return false;
+	if (href == null) return false;
 
-	const trimmed = href.trim();
+	const hrefStr = typeof href === 'string' ? href : String(href);
+	const trimmed = hrefStr.trim();
 	if (!trimmed) return false;
 
 	// Fragment-only and root-relative paths are always internal.

--- a/src/ui/_lib/linkBehavior.ts
+++ b/src/ui/_lib/linkBehavior.ts
@@ -1,0 +1,36 @@
+const DEFAULT_ORIGIN = process.env['NEXT_PUBLIC_SITE_URL'] ?? 'https://goodparty.org';
+
+function isGoodPartyHost(host: string): boolean {
+	return host === 'goodparty.org' || host.endsWith('.goodparty.org');
+}
+
+export function isExternalToEcosystem(href: string | undefined | null): boolean {
+	if (!href) return false;
+
+	const trimmed = href.trim();
+	if (!trimmed) return false;
+
+	// Fragment-only and root-relative paths are always internal.
+	if (trimmed.startsWith('#') || trimmed.startsWith('/')) {
+		return false;
+	}
+
+	const lower = trimmed.toLowerCase();
+	if (lower.startsWith('mailto:') || lower.startsWith('tel:') || lower.startsWith('sms:')) {
+		return false;
+	}
+
+	let url: URL;
+	try {
+		url = new URL(trimmed, DEFAULT_ORIGIN);
+	} catch {
+		// Malformed URLs are treated as external to be safe.
+		return true;
+	}
+
+	if (isGoodPartyHost(url.host)) {
+		return false;
+	}
+
+	return true;
+}


### PR DESCRIPTION
Only use external link icons when linking away from the goodparty ecosystem.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared link components (`Anchor`, `ComponentButton`, nav and rich text marks), so regressions could affect navigation behavior site-wide (new-tab targeting and external-link icon display). Adds tests and enforces safer `rel` attributes for new-tab links, reducing security risk.
> 
> **Overview**
> Updates link handling to distinguish *Good Party ecosystem* URLs from truly external destinations via new `isExternalToEcosystem` helper (with unit tests).
> 
> `Anchor` now defaults `target` based on ecosystem detection and automatically adds `noopener noreferrer` when opening in a new tab. External-link icons in `ComponentButton`, desktop nav dropdown items, and rich text external link marks are now shown **only** when the href navigates off the ecosystem.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit db57395b4a7c47c848b0bd692e7ad158ef5aa96c. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->