### PR TITLE
fix(blog): editorial body spacing; Typography prose; iframe React props

### DIFF
--- a/src/RichTextContentSections/index.tsx
+++ b/src/RichTextContentSections/index.tsx
@@ -3,7 +3,6 @@ import { ComponentErrorBoundary } from '~/ui/ComponentErrorBoundary';
 import type { ArticleQueryResult } from 'sanity.types';
 import { ImageCTAGroup } from '~/RichTextContentSections/ImageCTAGroup';
 import { CTASectionGroup } from '~/RichTextContentSections/CTASectionGroup';
-import { VideoSectionGroup } from '~/RichTextContentSections/VideoSectionGroup';
 import { TableSectionGroup } from '~/RichTextContentSections/TableSectionGroup';
 import { ImageContentSectionGroup } from '~/RichTextContentSections/ImageContentSectionGroup';
 import { InlineQuoteSectionGroup } from '~/RichTextContentSections/InlineQuoteSectionGroup';
@@ -11,7 +10,7 @@ import { ButtonSectionGroup } from '~/RichTextContentSections/ButtonSectionGroup
 import { FAQsSectionGroup } from '~/RichTextContentSections/FAQsSectionGroup';
 import { block, marks, list, listItem } from '~/ui/RichData';
 import { CalloutSectionGroup } from '~/RichTextContentSections/CalloutSectionGroup';
-import { Typography } from '~/ui/Typography';
+import { Typography, type TypographyStackSpacing } from '~/ui/Typography';
 
 export type ArticleSections = NonNullable<
 	NonNullable<NonNullable<NonNullable<ArticleQueryResult>['contentSections']>['block_editorialContentSections']>[number]
@@ -19,6 +18,7 @@ export type ArticleSections = NonNullable<
 
 interface Props {
 	contentSections?: ArticleSections[] | null;
+	stackSpacing?: TypographyStackSpacing;
 }
 
 export function RichTextContentSections(props: Props) {
@@ -26,8 +26,11 @@ export function RichTextContentSections(props: Props) {
 		return null;
 	}
 
+	const stackSpacing = props.stackSpacing ?? 'default';
+	const isEditorial = stackSpacing === 'editorial';
+
 	return (
-		<Typography as='article' data-section='RichTextContentSection'>
+		<Typography as='article' data-section='RichTextContentSection' stackSpacing={stackSpacing}>
 			<PortableText
 				value={props.contentSections}
 				components={{
@@ -54,10 +57,10 @@ export function RichTextContentSections(props: Props) {
 										height='315'
 										src='https://www.youtube.com/embed/k5CyDlFUE-k?si=7xXhw9-t3Bnv9P4C'
 										title='YouTube video player'
-										frameborder='0'
+										frameBorder={0}
 										allow='accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share'
-										referrerpolicy='strict-origin-when-cross-origin'
-										allowfullscreen
+										referrerPolicy='strict-origin-when-cross-origin'
+										allowFullScreen
 									></iframe>
 								</ComponentErrorBoundary>
 							);
@@ -109,7 +112,7 @@ export function RichTextContentSections(props: Props) {
 					block: block({ isInline: false }),
 					list: list(),
 					listItem: listItem(),
-					hardBreak: () => false,
+					hardBreak: () => (isEditorial ? <br /> : false),
 				}}
 			/>
 		</Typography>

--- a/src/RichTextContentSections/index.tsx
+++ b/src/RichTextContentSections/index.tsx
@@ -10,7 +10,8 @@ import { ButtonSectionGroup } from '~/RichTextContentSections/ButtonSectionGroup
 import { FAQsSectionGroup } from '~/RichTextContentSections/FAQsSectionGroup';
 import { block, marks, list, listItem } from '~/ui/RichData';
 import { CalloutSectionGroup } from '~/RichTextContentSections/CalloutSectionGroup';
-import { Typography, type TypographyStackSpacing } from '~/ui/Typography';
+import { Typography } from '~/ui/Typography';
+import { TypographyStackSpacing } from '~/types/ui';
 
 export type ArticleSections = NonNullable<
 	NonNullable<NonNullable<NonNullable<ArticleQueryResult>['contentSections']>['block_editorialContentSections']>[number]
@@ -26,8 +27,8 @@ export function RichTextContentSections(props: Props) {
 		return null;
 	}
 
-	const stackSpacing = props.stackSpacing ?? 'default';
-	const isEditorial = stackSpacing === 'editorial';
+	const stackSpacing = props.stackSpacing ?? TypographyStackSpacing.DEFAULT;
+	const isEditorial = stackSpacing === TypographyStackSpacing.EDITORIAL;
 
 	return (
 		<Typography as='article' data-section='RichTextContentSection' stackSpacing={stackSpacing}>

--- a/src/app/blog/article/[slug]/page.tsx
+++ b/src/app/blog/article/[slug]/page.tsx
@@ -129,7 +129,10 @@ export default async function Page(props: any) {
 						: undefined
 				}
 			>
-				<RichTextContentSections contentSections={page.contentSections?.block_editorialContentSections} />
+				<RichTextContentSections
+					stackSpacing='editorial'
+					contentSections={page.contentSections?.block_editorialContentSections}
+				/>
 				<div className='flex flex-col gap-12 pt-12'>
 					<BlogArticleTags tags={resolveEditorialContentTags(page.editorialContentTags)} />
 					<Author

--- a/src/app/blog/article/[slug]/page.tsx
+++ b/src/app/blog/article/[slug]/page.tsx
@@ -12,6 +12,7 @@ import { BlogArticleHero } from '~/ui/BlogArticleHero';
 import type { SanityImage } from '~/ui/types';
 
 import { RichTextContentSections } from '~/RichTextContentSections';
+import { TypographyStackSpacing } from '~/types/ui';
 import { BlogArticleTags } from '~/ui/BlogArticleTags';
 import { resolveEditorialContentTags } from '~/ui/_lib/resolveEditorialContentTags';
 import { EditorialLayout } from '~/components/EditorialLayout';
@@ -130,7 +131,7 @@ export default async function Page(props: any) {
 				}
 			>
 				<RichTextContentSections
-					stackSpacing='editorial'
+					stackSpacing={TypographyStackSpacing.EDITORIAL}
 					contentSections={page.contentSections?.block_editorialContentSections}
 				/>
 				<div className='flex flex-col gap-12 pt-12'>

--- a/src/types/ui.ts
+++ b/src/types/ui.ts
@@ -4,3 +4,10 @@ export const LinkTarget = {
 } as const;
 
 export type LinkTarget = (typeof LinkTarget)[keyof typeof LinkTarget];
+
+export const TypographyStackSpacing = {
+	DEFAULT: 'default',
+	EDITORIAL: 'editorial',
+} as const;
+
+export type TypographyStackSpacing = (typeof TypographyStackSpacing)[keyof typeof TypographyStackSpacing];

--- a/src/ui/Typography.tsx
+++ b/src/ui/Typography.tsx
@@ -1,6 +1,7 @@
 import { type ComponentProps, type PropsWithChildren } from 'react';
 import { cn, tv } from './_lib/utils.ts';
 import { styles as textStyles, type StyleTypes } from './Text.tsx';
+import { TypographyStackSpacing } from '~/types/ui';
 
 const proseShared =
 	"[&_:empty:not([class]):not(use):not(path)]:hidden [&>:first-child]:!mt-0 [&>:last-child]:!mb-0 [&>h1]:text-heading-xl! [&>h2]:text-heading-lg! [&>h3]:text-heading-md! [&>h4]:text-heading-sm! [&>h5]:text-heading-xs! [&>h6]:text-subtitle-1! quote [&_blockquote:not([class])>div]:before:content-(--quote-open) [&_blockquote:not([class])>div]:after:content-(--quote-close) [&_blockquote:not([class])>div]:border-l [&_blockquote:not([class])>div]:border-border-primary [&_blockquote:not([class])>div]:pl-7 [&_ul:not([class])]:pl-[calc(var(--container-padding)+1.125rem)] [&_ul:not([class])]:list-disc [&_ul:not([class])_ul]:mt-2 [&_ul:not([class])_li]:mb-[0.5em] [&_ol:not([class])]:list-none [&_ol:not([class])]:[counter-reset:section] [&_ol:not([class])_ol]:pl-8 [&_ol:not([class])_ol]:mt-2 [&_ol:not([class])_li]:mb-[0.5em] [&_ol:not([class])_li]:[counter-increment:section] [&_ol:not([class])_li]:before:[content:counters(section,'.')] [&_ol:not([class])_li]:before:mr-3 [&_ol:not([class])_li]:before:font-medium [&_p:not([class])]:break-words [&_a:not([class])]:underline [&_a:not([class])]:decoration-1 [&_a:not([class])]:underline-offset-4 [&_a:not([class])]:hover:no-underline";
@@ -21,11 +22,11 @@ const styles = tv({
 		type: textStyles.variants.type,
 	},
 	defaultVariants: {
-		stackSpacing: 'default',
+		stackSpacing: TypographyStackSpacing.DEFAULT,
 	},
 });
 
-export type TypographyStackSpacing = 'default' | 'editorial';
+export type { TypographyStackSpacing };
 
 export type TypographyProps = ComponentProps<any> & {
 	as: keyof JSX.IntrinsicElements;
@@ -37,7 +38,7 @@ export type TypographyProps = ComponentProps<any> & {
 export function Typography({
 	as: El = 'div',
 	styleType = 'default',
-	stackSpacing = 'default',
+	stackSpacing = TypographyStackSpacing.DEFAULT,
 	className,
 	...props
 }: PropsWithChildren<TypographyProps>) {

--- a/src/ui/Typography.tsx
+++ b/src/ui/Typography.tsx
@@ -2,26 +2,49 @@ import { type ComponentProps, type PropsWithChildren } from 'react';
 import { cn, tv } from './_lib/utils.ts';
 import { styles as textStyles, type StyleTypes } from './Text.tsx';
 
+const proseShared =
+	"[&_:empty:not([class]):not(use):not(path)]:hidden [&>:first-child]:!mt-0 [&>:last-child]:!mb-0 [&>h1]:text-heading-xl! [&>h2]:text-heading-lg! [&>h3]:text-heading-md! [&>h4]:text-heading-sm! [&>h5]:text-heading-xs! [&>h6]:text-subtitle-1! quote [&_blockquote:not([class])>div]:before:content-(--quote-open) [&_blockquote:not([class])>div]:after:content-(--quote-close) [&_blockquote:not([class])>div]:border-l [&_blockquote:not([class])>div]:border-border-primary [&_blockquote:not([class])>div]:pl-7 [&_ul:not([class])]:pl-[calc(var(--container-padding)+1.125rem)] [&_ul:not([class])]:list-disc [&_ul:not([class])_ul]:mt-2 [&_ul:not([class])_li]:mb-[0.5em] [&_ol:not([class])]:list-none [&_ol:not([class])]:[counter-reset:section] [&_ol:not([class])_ol]:pl-8 [&_ol:not([class])_ol]:mt-2 [&_ol:not([class])_li]:mb-[0.5em] [&_ol:not([class])_li]:[counter-increment:section] [&_ol:not([class])_li]:before:[content:counters(section,'.')] [&_ol:not([class])_li]:before:mr-3 [&_ol:not([class])_li]:before:font-medium [&_p:not([class])]:break-words [&_a:not([class])]:underline [&_a:not([class])]:decoration-1 [&_a:not([class])]:underline-offset-4 [&_a:not([class])]:hover:no-underline";
+
 const styles = tv({
 	slots: {
-		base: "[&>*+*]:mt-12 [&_:empty:not([class]):not(use):not(path)]:hidden [&>:first-child]:!mt-0 [&>:last-child]:!mb-0 [&>h1]:text-heading-xl! [&>h2]:text-heading-lg! [&>h3]:text-heading-md! [&>h4]:text-heading-sm! [&>h5]:text-heading-xs! [&>h6]:text-subtitle-1! quote [&_blockquote:not([class])>div]:before:content-(--quote-open) [&_blockquote:not([class])>div]:after:content-(--quote-close) [&_blockquote:not([class])>div]:border-l [&_blockquote:not([class])>div]:border-border-primary [&_blockquote:not([class])>div]:pl-7 [&_ul:not([class])]:pl-[calc(var(--container-padding)+1.125rem)] [&_ul:not([class])]:list-disc [&_ul:not([class])_ul]:mt-2 [&_ul:not([class])_li]:mb-[0.5em] [&_ol:not([class])]:list-none [&_ol:not([class])]:[counter-reset:section] [&_ol:not([class])_ol]:pl-8 [&_ol:not([class])_ol]:mt-2 [&_ol:not([class])_li]:mb-[0.5em] [&_ol:not([class])_li]:[counter-increment:section] [&_ol:not([class])_li]:before:[content:counters(section,'.')] [&_ol:not([class])_li]:before:mr-3 [&_ol:not([class])_li]:before:font-medium [&_p:not([class])]:break-words [&_a:not([class])]:underline [&_a:not([class])]:decoration-1 [&_a:not([class])]:underline-offset-4 [&_a:not([class])]:hover:no-underline",
+		base: '',
 	},
 	variants: {
+		stackSpacing: {
+			default: {
+				base: `${proseShared} [&>*+*]:mt-12`,
+			},
+			editorial: {
+				base: `${proseShared} [&>*+*]:mt-6 [&>h2+p]:mt-4 [&>h3+p]:mt-4`,
+			},
+		},
 		type: textStyles.variants.type,
 	},
+	defaultVariants: {
+		stackSpacing: 'default',
+	},
 });
+
+export type TypographyStackSpacing = 'default' | 'editorial';
 
 export type TypographyProps = ComponentProps<any> & {
 	as: keyof JSX.IntrinsicElements;
 	className?: string;
 	styleType?: 'default' | StyleTypes;
+	stackSpacing?: TypographyStackSpacing;
 };
 
-export function Typography({ as: El = 'div', styleType = 'default', className, ...props }: PropsWithChildren<TypographyProps>) {
-	const { base } = styles({ type: styleType });
+export function Typography({
+	as: El = 'div',
+	styleType = 'default',
+	stackSpacing = 'default',
+	className,
+	...props
+}: PropsWithChildren<TypographyProps>) {
+	const { base } = styles({ type: styleType, stackSpacing });
 
 	return (
-		<El {...props} className={cn(base(), props.className)}>
+		<El {...props} className={cn(base(), className)}>
 			{props.children}
 		</El>
 	);


### PR DESCRIPTION
- Tighter stack spacing and soft line breaks on article pages only
- Keep prose utilities bundled per Typography stackSpacing variant
- Use frameBorder, referrerPolicy, allowFullScreen on embedded iframe

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared `Typography` styling and rich-text rendering behavior; regressions could affect spacing/line-breaks across pages that use these components, though the new behavior is gated behind the new `stackSpacing` variant.
> 
> **Overview**
> Adds a `stackSpacing` variant to `Typography` (`default` vs `editorial`) to control prose vertical rhythm, including tighter spacing for headings/paragraphs in editorial contexts.
> 
> Updates `RichTextContentSections` to accept/pass through `stackSpacing` and to render PortableText `hardBreak`s as real `<br />` only for the `editorial` variant. Blog article pages opt into `stackSpacing='editorial'`, and the embedded video iframe props are corrected to React-cased attributes (`frameBorder`, `referrerPolicy`, `allowFullScreen`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50ee38665b7ceaabb31ae7cca6e34134844d0807. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->