### PR TITLE
fix(elections): remove state-level facts block and add 50-state regression validation

### DIFF
--- a/scripts/validate-election-pages.test.ts
+++ b/scripts/validate-election-pages.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from 'bun:test';
 import {
+	buildStatePageUrls,
 	buildPageUrls,
 	categorizeResults,
+	checkStatePageFactsContent,
 	checkContent,
 	extractTitleAndDescription,
 	type PageCheckResult,
@@ -255,5 +257,44 @@ describe('buildPageUrls', () => {
 			['AZ', []],
 		]);
 		expect(buildPageUrls(baseUrl, racesByState, 10)).toEqual([]);
+	});
+});
+
+describe('buildStatePageUrls', () => {
+	test('builds lowercase state page URLs', () => {
+		const urls = buildStatePageUrls('https://goodparty.org', ['AZ', 'pa']);
+		expect(urls).toEqual([
+			'https://goodparty.org/elections/az',
+			'https://goodparty.org/elections/pa',
+		]);
+	});
+});
+
+describe('checkStatePageFactsContent', () => {
+	test('flags state pages that include Location Facts block marker', () => {
+		const html = '<section data-section="Location Facts Block"><h2>Oklahoma facts</h2></section>';
+		const invalid = checkStatePageFactsContent('https://goodparty.org/elections/ok', html);
+		expect(invalid).toContain('Location Facts Block section marker found');
+		expect(invalid).toContain('State facts heading found');
+	});
+
+	test('passes clean state page html without facts block', () => {
+		const html = '<main><h2>Counties & Districts in Kansas</h2></main>';
+		const invalid = checkStatePageFactsContent('https://goodparty.org/elections/ks', html);
+		expect(invalid).toEqual([]);
+	});
+
+	test('ignores non-state urls so county/city behavior is unchanged', () => {
+		const html = '<section data-section="Location Facts Block"><h2>Maricopa County facts</h2></section>';
+		const countyInvalid = checkStatePageFactsContent(
+			'https://goodparty.org/elections/az/maricopa-county',
+			html,
+		);
+		const cityInvalid = checkStatePageFactsContent(
+			'https://goodparty.org/elections/az/maricopa-county/phoenix',
+			html,
+		);
+		expect(countyInvalid).toEqual([]);
+		expect(cityInvalid).toEqual([]);
 	});
 });

--- a/scripts/validate-election-pages.test.ts
+++ b/scripts/validate-election-pages.test.ts
@@ -278,6 +278,19 @@ describe('checkStatePageFactsContent', () => {
 		expect(invalid).toContain('State facts heading found');
 	});
 
+	test('flags state facts heading without marker present', () => {
+		const html = '<main><h2>Oklahoma facts</h2></main>';
+		const invalid = checkStatePageFactsContent('https://goodparty.org/elections/ok', html);
+		expect(invalid).not.toContain('Location Facts Block section marker found');
+		expect(invalid).toContain('State facts heading found');
+	});
+
+	test('does not match two-letter code heading (e.g. "OK facts")', () => {
+		const html = '<main><h2>OK facts</h2></main>';
+		const invalid = checkStatePageFactsContent('https://goodparty.org/elections/ok', html);
+		expect(invalid).toEqual([]);
+	});
+
 	test('passes clean state page html without facts block', () => {
 		const html = '<main><h2>Counties & Districts in Kansas</h2></main>';
 		const invalid = checkStatePageFactsContent('https://goodparty.org/elections/ks', html);

--- a/scripts/validate-election-pages.ts
+++ b/scripts/validate-election-pages.ts
@@ -3,7 +3,9 @@
  * Validates election page content for display name regressions (e.g. "buckeye County" for city of Buckeye).
  * Fetches race slugs from Election API, GETs rendered pages, checks title/meta for anti-patterns.
  *
- * Usage: bun run scripts/validate-election-pages.ts [--base-url URL] [--states AZ,AL,CA] [--concurrency N] [--sample N]
+ * Usage:
+ * - bun run scripts/validate-election-pages.ts --mode positions [--base-url URL] [--states AZ,AL,CA] [--concurrency N] [--sample N]
+ * - bun run scripts/validate-election-pages.ts --mode state-pages [--base-url URL] [--states AZ,AL,CA] [--concurrency N]
  */
 
 import { mkdir, writeFile } from 'node:fs/promises';
@@ -14,6 +16,7 @@ const DEFAULT_BASE_URL = 'https://goodparty.org';
 const DEFAULT_CONCURRENCY = 10;
 const DEFAULT_SAMPLE_PER_STATE = 20;
 const DEFAULT_TIMEOUT_MS = 15_000;
+const STATE_FACTS_MARKER = /data-section=["']Location Facts Block["']/i;
 
 const ELECTION_API_BASE =
 	process.env['NEXT_PUBLIC_ELECTION_API_BASE'] ??
@@ -55,12 +58,14 @@ function parseArgs(): {
 	states: string[];
 	concurrency: number;
 	samplePerState: number;
+	mode: 'positions' | 'state-pages';
 } {
 	const args = process.argv.slice(2);
 	let baseUrl = DEFAULT_BASE_URL;
 	let states: string[] = [];
 	let concurrency = DEFAULT_CONCURRENCY;
 	let samplePerState = DEFAULT_SAMPLE_PER_STATE;
+	let mode: 'positions' | 'state-pages' = 'positions';
 
 	for (let i = 0; i < args.length; i++) {
 		const arg = args[i] ?? '';
@@ -73,15 +78,22 @@ function parseArgs(): {
 			concurrency = Number.parseInt(args[++i]!, 10) || DEFAULT_CONCURRENCY;
 		} else if (arg === '--sample' && args[i + 1]) {
 			samplePerState = Number.parseInt(args[++i]!, 10) || DEFAULT_SAMPLE_PER_STATE;
+		} else if (arg === '--mode' && args[i + 1]) {
+			const value = (args[++i] ?? '').toLowerCase();
+			if (value === 'positions' || value === 'state-pages') {
+				mode = value;
+			}
 		}
 	}
 
-	if (states.length === 0) {
+	if (states.length === 0 && mode === 'positions') {
 		const shuffled = [...US_STATE_CODES].sort(() => Math.random() - 0.5);
 		states = shuffled.slice(0, 3).filter(Boolean);
+	} else if (states.length === 0 && mode === 'state-pages') {
+		states = [...US_STATE_CODES];
 	}
 
-	return { baseUrl, states, concurrency, samplePerState };
+	return { baseUrl, states, concurrency, samplePerState, mode };
 }
 
 async function fetchElectionJson<T>(path: string, params: Record<string, string>): Promise<T[]> {
@@ -129,6 +141,10 @@ export function buildPageUrls(
 	return urls;
 }
 
+export function buildStatePageUrls(baseUrl: string, states: string[]): string[] {
+	return states.map((state) => `${baseUrl}/elections/${state.toLowerCase()}`);
+}
+
 export function extractTitleAndDescription(html: string): { title?: string; description?: string } {
 	const titleMatch = html.match(/<title>([^<]*)<\/title>/i);
 	const descMatch = html.match(/<meta\s+name=["']description["']\s+content=["']([^"']*)["']/i);
@@ -143,6 +159,29 @@ export function checkContent(text: string): string[] {
 	for (const re of BAD_PATTERNS) {
 		const match = text.match(re);
 		if (match) invalid.push(match[0] ?? String(re));
+	}
+	return invalid;
+}
+
+export function checkStatePageFactsContent(url: string, html: string): string[] {
+	const invalid: string[] = [];
+	const path = (() => {
+		try {
+			return new URL(url).pathname;
+		} catch {
+			return '';
+		}
+	})();
+	const stateMatch = path.match(/^\/elections\/([a-z]{2})\/?$/i);
+	if (!stateMatch) return invalid;
+	const state = stateMatch[1]!.toUpperCase();
+	if (STATE_FACTS_MARKER.test(html)) {
+		invalid.push('Location Facts Block section marker found');
+	}
+	const factsHeading = new RegExp(`>${state}\\s*facts<`, 'i');
+	const stateNameHeading = new RegExp(`>\\s*[A-Za-z\\s]+\\s+facts\\s*<`, 'i');
+	if (factsHeading.test(html) || stateNameHeading.test(html)) {
+		invalid.push('State facts heading found');
 	}
 	return invalid;
 }
@@ -180,6 +219,7 @@ export function categorizeResults(checked: CheckedPage[]): {
 async function checkPage(
 	url: string,
 	timeoutMs: number,
+	mode: 'positions' | 'state-pages',
 ): Promise<{ result: PageCheckResult; error?: string }> {
 	const start = Date.now();
 	try {
@@ -203,7 +243,9 @@ async function checkPage(
 		const html = await res.text();
 		const { title, description } = extractTitleAndDescription(html);
 		const combined = [title, description].filter(Boolean).join(' ');
-		const invalid = checkContent(combined);
+		const invalid = mode === 'state-pages'
+			? checkStatePageFactsContent(url, html)
+			: checkContent(combined);
 
 		return {
 			result: {
@@ -252,27 +294,34 @@ async function runWithPool<T, R>(
 }
 
 async function main(): Promise<void> {
-	const { baseUrl, states, concurrency, samplePerState } = parseArgs();
+	const { baseUrl, states, concurrency, samplePerState, mode } = parseArgs();
 
 	console.log(`Base URL: ${baseUrl}`);
 	console.log(`States: ${states.join(', ')}`);
-	console.log(`Sample per state: ${samplePerState}`);
-
-	const racesByState = new Map<string, Array<{ slug?: string }>>();
-	for (const state of states) {
-		const races = await fetchElectionJson<{ slug?: string }>('v1/races', {
-			state,
-			raceColumns: 'slug',
-		});
-		racesByState.set(state, races);
+	console.log(`Mode: ${mode}`);
+	if (mode === 'positions') {
+		console.log(`Sample per state: ${samplePerState}`);
 	}
 
-	const urls = buildPageUrls(baseUrl, racesByState, samplePerState);
+	let urls: string[] = [];
+	if (mode === 'positions') {
+		const racesByState = new Map<string, Array<{ slug?: string }>>();
+		for (const state of states) {
+			const races = await fetchElectionJson<{ slug?: string }>('v1/races', {
+				state,
+				raceColumns: 'slug',
+			});
+			racesByState.set(state, races);
+		}
+		urls = buildPageUrls(baseUrl, racesByState, samplePerState);
+	} else {
+		urls = buildStatePageUrls(baseUrl, states);
+	}
 	console.log(`Checking ${urls.length} pages...`);
 
 	const start = Date.now();
 	const checked = await runWithPool(urls, concurrency, url =>
-		checkPage(url, DEFAULT_TIMEOUT_MS),
+		checkPage(url, DEFAULT_TIMEOUT_MS, mode),
 	);
 	const durationMs = Date.now() - start;
 

--- a/scripts/validate-election-pages.ts
+++ b/scripts/validate-election-pages.ts
@@ -11,6 +11,7 @@
 import { mkdir, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { US_STATE_CODES } from '../src/lib/sitemap-entries';
+import { getStateName } from '../src/lib/electionsHelpers';
 
 const DEFAULT_BASE_URL = 'https://goodparty.org';
 const DEFAULT_CONCURRENCY = 10;
@@ -178,9 +179,9 @@ export function checkStatePageFactsContent(url: string, html: string): string[] 
 	if (STATE_FACTS_MARKER.test(html)) {
 		invalid.push('Location Facts Block section marker found');
 	}
-	const factsHeading = new RegExp(`>${state}\\s*facts<`, 'i');
-	const stateNameHeading = new RegExp(`>\\s*[A-Za-z\\s]+\\s+facts\\s*<`, 'i');
-	if (factsHeading.test(html) || stateNameHeading.test(html)) {
+	const stateName = getStateName(state);
+	const factsHeading = new RegExp(`>\\s*${stateName}\\s+facts\\s*<`, 'i');
+	if (factsHeading.test(html)) {
 		invalid.push('State facts heading found');
 	}
 	return invalid;

--- a/src/app/elections/[state]/page.tsx
+++ b/src/app/elections/[state]/page.tsx
@@ -17,12 +17,11 @@ import {
 } from '~/constants/electionsStaticSections';
 import { sanityFetch } from '~/sanity/sanityClient';
 import { quoteCollectionByIdQuery } from '~/sanity/groq';
-import { getStateName, placeToFactsCards } from '~/lib/electionsHelpers';
+import { getStateName } from '~/lib/electionsHelpers';
 import { resolveAuthor } from '~/ui/_lib/resolveAuthor';
 import { resolveTextSize } from '~/ui/_lib/resolveTextSize';
 import { BreadcrumbBlock } from '~/ui/BreadcrumbBlock';
 import { ElectionsLandingWithSearch } from '~/ui/ElectionsLandingWithSearch';
-import { LocationFactsBlock } from '~/ui/LocationFactsBlock';
 import { Carousel } from '~/ui/Carousel';
 import { StepperBlock } from '~/ui/StepperBlock';
 import { ElectionsIndexBlock } from '~/ui/ElectionsIndexBlock';
@@ -111,8 +110,6 @@ export default async function Page({
 		{ href: '', label: stateName },
 	];
 
-	const factsCards = placeToFactsCards(placeData);
-
 	const quoteItems = quoteCollection?.quoteCollectionContent?.list_chooseQuotes ?? [];
 	const carouselCards = quoteItems.map(item => ({
 		copy: item.quote?.field_quote ?? undefined,
@@ -175,13 +172,6 @@ export default async function Page({
 					offices: stateOffices,
 				}}
 			/>
-			{factsCards.length > 0 && (
-				<LocationFactsBlock
-					backgroundColor="cream"
-					header={{ title: `${stateName} facts` }}
-					factsCards={factsCards}
-				/>
-			)}
 			<ElectionsIndexBlock
 				backgroundColor="midnight"
 				stateSlug={state.toLowerCase()}


### PR DESCRIPTION
## Summary
- Remove `LocationFactsBlock` rendering from state-level elections routes (`/elections/[state]`) so state pages never display local facts cards.
- Preserve county/city/district behavior by scoping the change to state routes only.
- Extend election-page validation tooling with a `--mode state-pages` option to validate all state pages for accidental facts-block rendering.
- Add tests for new state-page validation helpers and state URL generation logic.

## Why
State-level facts data from the Elections API is inconsistent for some states, causing incorrect "facts" content to appear on a subset of state pages. Product intent is that the Location Facts block should not appear on state-level pages at all.

## Implementation Details
- Updated state page route component to remove facts block rendering path.
- Added state-page validation mode to the existing election validation script:
  - Builds `/elections/{state}` URLs for all U.S. state codes.
  - Fails when state facts block markers/headings are detected.
  - Writes report output to `.reports/sitemaps/` (same reporting pattern as existing script).
- Added unit tests covering:
  - state page URL generation
  - state facts detection behavior
  - non-state URL pass-through (county/city pages remain out of scope)

## Risk / Impact
- Low risk: behavior change is intentionally limited to state-level elections pages.
- Existing county/city/district facts rendering is unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: removes a state-level UI block and adds a non-production validation mode; behavior is scoped to `/elections/[state]` and a script used in CI/dev tooling.
> 
> **Overview**
> State-level elections pages (`/elections/[state]`) no longer render the `LocationFactsBlock`, preventing inconsistent “state facts” content from appearing on state pages.
> 
> The `scripts/validate-election-pages.ts` tool gains a `--mode state-pages` option that builds `/elections/{state}` URLs (defaulting to all states) and flags pages whose HTML contains the Location Facts block marker or “facts” headings; existing `positions` checks remain the default. Tests were added for `buildStatePageUrls` and `checkStatePageFactsContent` to ensure only state-root URLs are validated and county/city pages are unaffected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0abe8cb5d411010c4121c578914f0cebe07b179. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->