### PR TITLE
Redirecto to Overview instead of Application (Ashby Platform)

### DIFF
--- a/src/ui/JobOpeningsCard.tsx
+++ b/src/ui/JobOpeningsCard.tsx
@@ -59,7 +59,7 @@ export function JobOpeningsCard(props: JobOpeningsCardProps) {
 					)}
 				</div>
 				{props.href ? (
-					<Anchor href={props.href} target='_blank' rel='noopener noreferrer' className={cta()}>
+					<Anchor href={props.href.replace('/application', '')} target='_blank' rel='noopener noreferrer' className={cta()}>
 						<span>Learn more</span>
 						<IconResolver icon='arrow-right' className={ctaArrow()} />
 					</Anchor>


### PR DESCRIPTION
Fix link behavior in JobOpeningsCard component by removing `'/application'` from href prop for external links. This send the user to the overview section instead of the application section.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI link change limited to `JobOpeningsCard`; risk is mainly incorrect URL rewriting if `'/application'` appears unexpectedly in the href.
> 
> **Overview**
> Updates `JobOpeningsCard` so the "Learn more" CTA opens the job *overview* page by stripping `'/application'` from the provided `href` before rendering the external `Anchor`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9aa4449381f2cde320b4aa2ed4f45f60067eb829. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->