### PR TITLE
Update job card URL handling to prioritize jobUrl over applyUrl

### DIFF
--- a/src/lib/ashby.ts
+++ b/src/lib/ashby.ts
@@ -105,6 +105,6 @@ export function ashbyJobToCard(job: AshbyJob): JobOpeningsCardProps {
 		tag: job.department || 'General',
 		location: job.isRemote ? 'Remote (United States)' : job.location,
 		jobType: formatEmploymentType(job.employmentType),
-		href: job.applyUrl,
+		href: job.jobUrl || job.applyUrl,
 	};
 }


### PR DESCRIPTION
- Modified the href property in the ashbyJobToCard function to use job.jobUrl if available, falling back to job.applyUrl otherwise. This change improves the accuracy of job application links.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-field URL selection change with a safe fallback; limited impact to outbound job link behavior.
> 
> **Overview**
> Updates `ashbyJobToCard` to set the job card `href` to `job.jobUrl` when present, falling back to `job.applyUrl` otherwise, so listings link to the canonical job page instead of the application URL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd633500d366117faddfbec53613e22b61c87b21. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->