### PR TITLE
Feat/click to flip

### DIFF
--- a/src/PageSections/TeamValuesBlockSection.tsx
+++ b/src/PageSections/TeamValuesBlockSection.tsx
@@ -2,7 +2,6 @@ import { stegaClean } from 'next-sanity';
 
 import type { Sections } from '~/PageSections';
 
-import { resolveButtonHref, type ButtonType } from '~/lib/buttonTransformer';
 import { transformButtons } from '~/lib/buttonTransformer';
 import { resolveBg } from '~/ui/_lib/resolveBg';
 import { resolveComponentColor } from '~/ui/_lib/resolveComponentColor';
@@ -22,15 +21,11 @@ export function TeamValuesBlockSection(section: Extract<Sections, { _type: 'comp
 				? resolveComponentColor(stegaClean(item.field_componentColor6Colors))
 				: undefined;
 
-			const href = item.ctaActionWithShared?.action
-				? resolveButtonHref(item.ctaActionWithShared as unknown as ButtonType)
-				: undefined;
-
 			return {
 				icon: item.field_icon,
 				heading: item.field_title,
+				backCopy: (item as { field_backCopy?: string }).field_backCopy,
 				color: rawColor as TeamValuesCardColor | undefined,
-				href,
 			};
 		}) ?? [];
 

--- a/src/sanity/schema/groups/teamValuesCard.ts
+++ b/src/sanity/schema/groups/teamValuesCard.ts
@@ -28,6 +28,13 @@ export const teamValuesCard = {
 			type: 'field_componentColor6Colors',
 		},
 		{
+			title: 'Back Copy',
+			name: 'field_backCopy',
+			type: 'text',
+			rows: 5,
+			description: 'Content displayed on the back of the card after it is flipped.',
+		},
+		{
 			title: 'Link',
 			name: 'ctaActionWithShared',
 			type: 'ctaActionWithShared',

--- a/src/ui/TeamValuesBlock.stories.tsx
+++ b/src/ui/TeamValuesBlock.stories.tsx
@@ -14,11 +14,36 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 const defaultCards: TeamValuesCardProps[] = [
-	{ heading: 'Compassion', icon: 'heart-handshake', color: 'waxflower', href: '/values/compassion' },
-	{ heading: 'Integrity', icon: 'shield-check', color: 'blue', href: '/values/integrity' },
-	{ heading: 'Innovation', icon: 'lightbulb', color: 'lavender', href: '/values/innovation' },
-	{ heading: 'Community', icon: 'users', color: 'halo-green', href: '/values/community' },
-	{ heading: 'Transparency', icon: 'eye', color: 'bright-yellow', href: '/values/transparency' },
+	{
+		heading: 'Compassion',
+		icon: 'heart-handshake',
+		color: 'waxflower',
+		backCopy: 'We lead with empathy and listen first, centering people in every decision we make.',
+	},
+	{
+		heading: 'Integrity',
+		icon: 'shield-check',
+		color: 'blue',
+		backCopy: 'We act with honesty and accountability, even when it is difficult or inconvenient.',
+	},
+	{
+		heading: 'Innovation',
+		icon: 'lightbulb',
+		color: 'lavender',
+		backCopy: 'We challenge assumptions and test new ideas to deliver better outcomes over time.',
+	},
+	{
+		heading: 'Community',
+		icon: 'users',
+		color: 'halo-green',
+		backCopy: 'We collaborate with and for people, building trust through shared purpose and action.',
+	},
+	{
+		heading: 'Transparency',
+		icon: 'eye',
+		color: 'bright-yellow',
+		backCopy: 'We communicate clearly about what we know, what we do not, and why choices are made.',
+	},
 ];
 
 export const Default: Story = {
@@ -72,6 +97,14 @@ export const NoButtons: Story = {
 			copy: 'These core values guide everything we do.',
 		},
 		cards: defaultCards,
+	},
+	parameters: Default.parameters,
+};
+
+export const MissingBackCopyFallback: Story = {
+	args: {
+		...Default.args,
+		cards: defaultCards.map((card, index) => (index === 0 ? { ...card, backCopy: undefined } : card)),
 	},
 	parameters: Default.parameters,
 };

--- a/src/ui/TeamValuesBlock.tsx
+++ b/src/ui/TeamValuesBlock.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import type { backgroundTypeValues } from './_lib/designTypesStore.ts';
 import { cn, tv } from './_lib/utils.ts';
 import { useState } from 'react';

--- a/src/ui/TeamValuesBlock.tsx
+++ b/src/ui/TeamValuesBlock.tsx
@@ -1,16 +1,15 @@
 import type { backgroundTypeValues } from './_lib/designTypesStore.ts';
 import { cn, tv } from './_lib/utils.ts';
+import { useState } from 'react';
 
-import { Anchor } from './Anchor.tsx';
 import { CircleIcon } from './CircleIcon.tsx';
 import { Container } from './Container.tsx';
 import { FadeIn } from './FadeIn.tsx';
 import { HeaderBlock, type HeaderBlockProps } from './HeaderBlock.tsx';
-import { IconResolver, type IconType } from './IconResolver.tsx';
+import { type IconType } from './IconResolver.tsx';
 import { Text } from './Text.tsx';
 
-const cardColors = ['waxflower', 'blue', 'lavender', 'halo-green', 'bright-yellow'] as const;
-export type TeamValuesCardColor = (typeof cardColors)[number];
+export type TeamValuesCardColor = 'waxflower' | 'blue' | 'lavender' | 'halo-green' | 'bright-yellow';
 
 const blockStyles = tv({
 	slots: {
@@ -29,74 +28,89 @@ const blockStyles = tv({
 
 const cardStyles = tv({
 	slots: {
-		card: [
-			'group/card relative rounded-3xl p-6 flex flex-col items-start',
-			'gap-20 md:gap-40 flex-1',
-			'transition-transform duration-normal ease-smooth hover:-translate-y-1',
+		cardButton: [
+			'group/card relative w-full flex-1 rounded-3xl text-left cursor-pointer',
+			'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-midnight-900 focus-visible:ring-offset-4',
 		],
+		cardInner: [
+			'relative rounded-3xl p-6',
+			'transition-transform duration-normal ease-smooth hover:-translate-y-1',
+			'min-h-64',
+		],
+		face: [
+			'absolute inset-0 rounded-3xl p-6 flex flex-col items-start',
+		],
+		frontFace: 'justify-between',
+		backFace: 'justify-center',
 		top: 'flex flex-col gap-4 items-start',
-		bottom: 'flex flex-col items-start w-full',
-		arrowRow: 'flex items-center justify-end w-full',
 	},
 	variants: {
 		color: {
-			waxflower: { card: 'bg-waxflower-200' },
-			blue: { card: 'bg-blue-200' },
-			lavender: { card: 'bg-lavender-200' },
-			'halo-green': { card: 'bg-halo-green-200' },
-			'bright-yellow': { card: 'bg-bright-yellow-200' },
+			waxflower: { face: 'bg-waxflower-200' },
+			blue: { face: 'bg-blue-200' },
+			lavender: { face: 'bg-lavender-200' },
+			'halo-green': { face: 'bg-halo-green-200' },
+			'bright-yellow': { face: 'bg-bright-yellow-200' },
 		},
 	},
 });
 
 export type TeamValuesCardProps = {
+	backCopy?: string;
 	className?: string;
 	color?: TeamValuesCardColor;
 	heading?: string;
-	href?: string;
 	icon?: IconType;
+	isFlipped?: boolean;
+	onToggle?(): void;
 };
 
 export function TeamValuesCard(props: TeamValuesCardProps) {
 	const color = props.color ?? 'waxflower';
-	const { card, top, bottom, arrowRow } = cardStyles({ color });
-
-	const content = (
-		<>
-			<div className={top()}>
-				<CircleIcon icon={props.icon ?? 'heart-handshake'} iconBg='cream' />
-				{props.heading && (
-					<Text as='h3' styleType='heading-sm'>
-						{props.heading}
-					</Text>
-				)}
-			</div>
-			<div className={bottom()}>
-				<div className={arrowRow()}>
-					<IconResolver icon='arrow-right' />
-				</div>
-			</div>
-		</>
-	);
-
-	if (props.href) {
-		return (
-			<Anchor
-				href={props.href}
-				className={cn(
-					card(),
-					'before:content-[""] before:absolute before:inset-0 before:rounded-3xl',
-					props.className,
-				)}
-			>
-				{content}
-			</Anchor>
-		);
-	}
+	const { cardButton, cardInner, face, frontFace, backFace, top } = cardStyles({ color });
+	const isFlipped = props.isFlipped ?? false;
+	const ariaLabel = props.heading
+		? `${isFlipped ? 'Hide' : 'Show'} ${props.heading} details`
+		: isFlipped
+			? 'Hide details'
+			: 'Show details';
 
 	return (
-		<div className={cn(card(), props.className)}>
-			{content}
+		<div className={cn('w-full [perspective:1200px]', props.className)}>
+			<button
+				type='button'
+				className={cardButton()}
+				onClick={() => props.onToggle?.()}
+				aria-pressed={isFlipped}
+				aria-label={ariaLabel}
+			>
+				<div
+					className={cardInner()}
+					style={{
+						transformStyle: 'preserve-3d',
+						transform: isFlipped ? 'rotateY(180deg)' : 'rotateY(0deg)',
+					}}
+				>
+					<div className={cn(face(), frontFace())} style={{ backfaceVisibility: 'hidden' }}>
+						<div className={top()}>
+							<CircleIcon icon={props.icon ?? 'heart-handshake'} iconBg='cream' />
+							{props.heading && (
+								<Text as='h3' styleType='heading-sm'>
+									{props.heading}
+								</Text>
+							)}
+						</div>
+					</div>
+					<div
+						className={cn(face(), backFace())}
+						style={{ backfaceVisibility: 'hidden', transform: 'rotateY(180deg)' }}
+					>
+						<Text as='p' styleType='body-2'>
+							{props.backCopy ?? props.heading ?? ''}
+						</Text>
+					</div>
+				</div>
+			</button>
 		</div>
 	);
 }
@@ -111,6 +125,7 @@ export type TeamValuesBlockProps = {
 export function TeamValuesBlock(props: TeamValuesBlockProps) {
 	const backgroundColor = props.backgroundColor ?? 'cream';
 	const { base, wrapper, cardsContainer } = blockStyles({ backgroundColor });
+	const [activeCardIndex, setActiveCardIndex] = useState<number | null>(null);
 
 	return (
 		<article className={cn(base(), props.className)} data-component='TeamValuesBlock'>
@@ -122,7 +137,12 @@ export function TeamValuesBlock(props: TeamValuesBlockProps) {
 					<FadeIn delay={0.1}>
 						<div className={cardsContainer()}>
 							{props.cards.map((card, index) => (
-								<TeamValuesCard key={index} {...card} />
+								<TeamValuesCard
+									key={index}
+									{...card}
+									isFlipped={activeCardIndex === index}
+									onToggle={() => setActiveCardIndex(current => (current === index ? null : index))}
+								/>
 							))}
 						</div>
 					</FadeIn>

--- a/src/ui/TeamValuesBlock.tsx
+++ b/src/ui/TeamValuesBlock.tsx
@@ -15,7 +15,7 @@ const blockStyles = tv({
 	slots: {
 		base: 'py-(--container-padding)',
 		wrapper: 'flex flex-col gap-10',
-		cardsContainer: 'flex gap-4 max-md:flex-col md:items-center',
+		cardsContainer: 'grid gap-4 grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5 items-stretch',
 	},
 	variants: {
 		backgroundColor: {
@@ -29,11 +29,11 @@ const blockStyles = tv({
 const cardStyles = tv({
 	slots: {
 		cardButton: [
-			'group/card relative w-full flex-1 rounded-3xl text-left cursor-pointer',
+			'group/card relative w-full h-full rounded-3xl text-left cursor-pointer',
 			'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-midnight-900 focus-visible:ring-offset-4',
 		],
 		cardInner: [
-			'relative rounded-3xl p-6',
+			'relative rounded-3xl p-6 h-full',
 			'transition-transform duration-normal ease-smooth hover:-translate-y-1',
 			'min-h-64',
 		],
@@ -91,11 +91,15 @@ export function TeamValuesCard(props: TeamValuesCardProps) {
 						transform: isFlipped ? 'rotateY(180deg)' : 'rotateY(0deg)',
 					}}
 				>
-					<div className={cn(face(), frontFace())} style={{ backfaceVisibility: 'hidden' }}>
+					<div
+						className={cn(face(), frontFace())}
+						style={{ backfaceVisibility: 'hidden', WebkitBackfaceVisibility: 'hidden' }}
+					>
 						<div className={top()}>
 							<CircleIcon icon={props.icon ?? 'heart-handshake'} iconBg='cream' />
 							{props.heading && (
-								<Text as='h3' styleType='heading-sm'>
+								// Keep value names whole and on one line; adjust grid min width before allowing wrap fallback.
+								<Text as='h3' styleType='heading-sm' className='whitespace-nowrap break-normal'>
 									{props.heading}
 								</Text>
 							)}
@@ -103,7 +107,11 @@ export function TeamValuesCard(props: TeamValuesCardProps) {
 					</div>
 					<div
 						className={cn(face(), backFace())}
-						style={{ backfaceVisibility: 'hidden', transform: 'rotateY(180deg)' }}
+						style={{
+							backfaceVisibility: 'hidden',
+							WebkitBackfaceVisibility: 'hidden',
+							transform: 'rotateY(180deg)',
+						}}
 					>
 						<Text as='p' styleType='body-2'>
 							{props.backCopy ?? props.heading ?? ''}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate UI behavior change: replaces card links with click-to-flip stateful interaction and introduces new CMS field; risk is mainly UX/accessibility regressions and content migration needs for existing cards.
> 
> **Overview**
> Updates the Team Values Block cards from link-style tiles to **click-to-flip cards** that reveal new “back copy” text on the reverse side, with a single active card managed via local state.
> 
> Adds `field_backCopy` to the Sanity `teamValuesCard` schema and wires it through `TeamValuesBlockSection` into `TeamValuesBlock`, updates layout/styling to a responsive grid, and adjusts Storybook examples (including a missing-back-copy fallback case).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c37a9d435818d857c255f2f5fdfa4bbcfc1e7c6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->