### PR TITLE
Replace Amplitude script loading with `useEffect` hook

### DIFF
--- a/src/ui/Amplitude.tsx
+++ b/src/ui/Amplitude.tsx
@@ -5,8 +5,13 @@ import { useEffect } from 'react';
 const AMPLITUDE_API_KEY = process.env['NEXT_PUBLIC_AMPLITUDE_API_KEY'];
 const EXPERIMENT_DEPLOYMENT_KEY = process.env['NEXT_PUBLIC_AMPLITUDE_EXPERIMENT_DEPLOYMENT_KEY'];
 
+/** Prevents double `init` on Strict Mode remount or duplicate script `load` handlers. */
+let amplitudeClientBooted = false;
+
 function boot() {
 	if (typeof window === 'undefined' || !window.amplitude || !AMPLITUDE_API_KEY) return;
+	if (amplitudeClientBooted) return;
+	amplitudeClientBooted = true;
 
 	if (window.sessionReplay?.plugin) {
 		window.amplitude.add?.(window.sessionReplay.plugin({ sampleRate: 1 }));
@@ -35,6 +40,11 @@ function boot() {
 	}
 }
 
+function findInjectedAmplitudeScript(apiKey: string) {
+	const suffix = `/script/${apiKey}.js`;
+	return [...document.scripts].find((s) => s.src.endsWith(suffix));
+}
+
 export function Amplitude() {
 	useEffect(() => {
 		if (!AMPLITUDE_API_KEY) return;
@@ -42,6 +52,13 @@ export function Amplitude() {
 		// GTM (or another tag) already loaded the Amplitude snippet — skip injecting a second script.
 		if (window.amplitude) {
 			boot();
+			return;
+		}
+
+		// Strict Mode runs effects twice before `window.amplitude` exists; reuse the first script tag.
+		const existing = findInjectedAmplitudeScript(AMPLITUDE_API_KEY);
+		if (existing) {
+			existing.addEventListener('load', boot, { once: true });
 			return;
 		}
 

--- a/src/ui/Amplitude.tsx
+++ b/src/ui/Amplitude.tsx
@@ -1,46 +1,56 @@
 'use client';
 
-import Script from 'next/script';
+import { useEffect } from 'react';
 
 const AMPLITUDE_API_KEY = process.env['NEXT_PUBLIC_AMPLITUDE_API_KEY'];
 const EXPERIMENT_DEPLOYMENT_KEY = process.env['NEXT_PUBLIC_AMPLITUDE_EXPERIMENT_DEPLOYMENT_KEY'];
 
-export function Amplitude() {
-	if (!AMPLITUDE_API_KEY) return null;
+function boot() {
+	if (typeof window === 'undefined' || !window.amplitude || !AMPLITUDE_API_KEY) return;
 
-	return (
-		<Script
-			id='amplitude-sdk'
-			src={`https://cdn.amplitude.com/script/${AMPLITUDE_API_KEY}.js`}
-			strategy='afterInteractive'
-			onLoad={() => {
-				if (typeof window !== 'undefined' && window.amplitude) {
-					if (window.sessionReplay?.plugin) {
-						window.amplitude.add?.(window.sessionReplay.plugin({ sampleRate: 1 }));
-					}
-					window.amplitude.init(AMPLITUDE_API_KEY, {
-						fetchRemoteConfig: true,
-						autocapture: true,
-						transport: 'beacon',
-					});
-					if (EXPERIMENT_DEPLOYMENT_KEY) {
-						import('@amplitude/experiment-js-client')
-							.then(({ Experiment }) => {
-								const experiment = Experiment.initializeWithAmplitudeAnalytics(
-									EXPERIMENT_DEPLOYMENT_KEY,
-								);
-								window.experiment = experiment;
-								void experiment.fetch().finally(() => {
-									window.dispatchEvent(new Event('experiment:ready'));
-								});
-							})
-							.catch((err: unknown) => {
-								console.error('[Amplitude] Experiment SDK failed to load', err);
-								window.dispatchEvent(new Event('experiment:ready'));
-							});
-					}
-				}
-			}}
-		/>
-	);
+	if (window.sessionReplay?.plugin) {
+		window.amplitude.add?.(window.sessionReplay.plugin({ sampleRate: 1 }));
+	}
+	window.amplitude.init(AMPLITUDE_API_KEY, {
+		fetchRemoteConfig: true,
+		autocapture: true,
+		transport: 'beacon',
+	});
+
+	if (EXPERIMENT_DEPLOYMENT_KEY) {
+		import('@amplitude/experiment-js-client')
+			.then(({ Experiment }) => {
+				const experiment = Experiment.initializeWithAmplitudeAnalytics(
+					EXPERIMENT_DEPLOYMENT_KEY,
+				);
+				window.experiment = experiment;
+				void experiment.fetch().finally(() => {
+					window.dispatchEvent(new Event('experiment:ready'));
+				});
+			})
+			.catch((err: unknown) => {
+				console.warn('[Amplitude] Experiment SDK failed to load', err);
+				window.dispatchEvent(new Event('experiment:ready'));
+			});
+	}
+}
+
+export function Amplitude() {
+	useEffect(() => {
+		if (!AMPLITUDE_API_KEY) return;
+
+		// GTM (or another tag) already loaded the Amplitude snippet — skip injecting a second script.
+		if (window.amplitude) {
+			boot();
+			return;
+		}
+
+		const script = document.createElement('script');
+		script.src = `https://cdn.amplitude.com/script/${AMPLITUDE_API_KEY}.js`;
+		script.async = true;
+		script.onload = boot;
+		document.head.appendChild(script);
+	}, []);
+
+	return null;
 }


### PR DESCRIPTION
- Removed the direct script injection in the Amplitude component and replaced it with a useEffect hook to manage script loading.
- Introduced a boot function to initialize Amplitude and handle experiment SDK loading.
- Ensured that the script is only added if it hasn't been loaded already, improving performance and preventing duplicate script tags.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes client-side analytics bootstrapping and experiment SDK readiness signaling, which could impact tracking/feature flag behavior if the script load order differs or `window.amplitude` is prepopulated by GTM.
> 
> **Overview**
> Refactors `src/ui/Amplitude.tsx` to **stop using `next/script`** and instead load/initialize Amplitude via a `useEffect`-driven flow.
> 
> Adds a shared `boot()` initializer and **avoids injecting a second Amplitude script** when `window.amplitude` is already present (e.g., loaded by GTM), while keeping Experiment SDK lazy-loading and switching the failure log from `console.error` to `console.warn`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e1b0d8803c6d132906e900aee2be9bf8b5c6686. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->