### PR TITLE
implement redirect middleware and cache invalidation

### DIFF
--- a/src/app/api/redirects/route.ts
+++ b/src/app/api/redirects/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from 'next/server';
+import { sanityClient } from '~/sanity/sanityClient';
+
+interface RedirectEntry {
+	field_fromUrl?: string;
+	field_toUrl?: string;
+	field_permanentRedirect?: boolean;
+}
+
+const QUERY = `*[_type=="goodpartyOrg_redirects"][0].list_redirects[]{field_fromUrl,field_toUrl,field_permanentRedirect}`;
+
+function normalizePath(path: string): string {
+	return path.endsWith('/') && path.length > 1 ? path.slice(0, -1) : path;
+}
+
+export async function GET() {
+	const entries = await sanityClient.fetch<RedirectEntry[] | null>(QUERY, undefined, {
+		next: { tags: ['goodpartyOrg_redirects'] },
+	});
+
+	const map: Record<string, { to: string; permanent: boolean }> = {};
+
+	if (entries) {
+		for (const entry of entries) {
+			if (entry.field_fromUrl && entry.field_toUrl) {
+				map[normalizePath(entry.field_fromUrl)] = {
+					to: entry.field_toUrl,
+					permanent: entry.field_permanentRedirect ?? false,
+				};
+			}
+		}
+	}
+
+	return NextResponse.json(map);
+}

--- a/src/app/api/revalidate/route.ts
+++ b/src/app/api/revalidate/route.ts
@@ -3,6 +3,7 @@ import { revalidatePath, revalidateTag } from 'next/cache';
 import { type NextRequest, NextResponse } from 'next/server';
 import { parseBody } from 'next-sanity/webhook';
 import { revalidateSecret } from '~/lib/env';
+import { invalidateRedirectCache } from '~/middleware';
 
 const CUSTOM_SECRET_HEADER = 'x-sanity-webhook-secret';
 const HMAC_KEY = 'safeCompare';
@@ -61,6 +62,7 @@ function getPathsToRevalidate(_type: string, payload: Record<string, unknown>): 
 		goodpartyOrg_glossary: ['/political-terms'],
 		goodpartyOrg_404Page: ['/'],
 		goodpartyOrg_allComponents: ['/all'],
+		goodpartyOrg_redirects: ['/'],
 		quoteCollections: ['/elections'],
 	};
 
@@ -114,6 +116,10 @@ export async function POST(req: NextRequest) {
 
 	try {
 		revalidateTag(_type);
+
+		if (_type === 'goodpartyOrg_redirects') {
+			invalidateRedirectCache();
+		}
 
 		const paths = getPathsToRevalidate(_type, payload);
 		for (const path of paths) {

--- a/src/app/api/revalidate/route.ts
+++ b/src/app/api/revalidate/route.ts
@@ -3,7 +3,6 @@ import { revalidatePath, revalidateTag } from 'next/cache';
 import { type NextRequest, NextResponse } from 'next/server';
 import { parseBody } from 'next-sanity/webhook';
 import { revalidateSecret } from '~/lib/env';
-import { invalidateRedirectCache } from '~/middleware';
 
 const CUSTOM_SECRET_HEADER = 'x-sanity-webhook-secret';
 const HMAC_KEY = 'safeCompare';
@@ -116,10 +115,6 @@ export async function POST(req: NextRequest) {
 
 	try {
 		revalidateTag(_type);
-
-		if (_type === 'goodpartyOrg_redirects') {
-			invalidateRedirectCache();
-		}
 
 		const paths = getPathsToRevalidate(_type, payload);
 		for (const path of paths) {

--- a/src/app/api/revalidate/route.ts
+++ b/src/app/api/revalidate/route.ts
@@ -61,7 +61,6 @@ function getPathsToRevalidate(_type: string, payload: Record<string, unknown>): 
 		goodpartyOrg_glossary: ['/political-terms'],
 		goodpartyOrg_404Page: ['/'],
 		goodpartyOrg_allComponents: ['/all'],
-		goodpartyOrg_redirects: ['/'],
 		quoteCollections: ['/elections'],
 	};
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,79 @@
+import { type NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@sanity/client';
+
+interface RedirectEntry {
+	field_fromUrl?: string;
+	field_toUrl?: string;
+	field_permanentRedirect?: boolean;
+}
+
+const client = createClient({
+	projectId: '3rbseux7',
+	dataset: 'production',
+	apiVersion: '2025-10-08',
+	useCdn: true,
+});
+
+const QUERY = `*[_type=="goodpartyOrg_redirects"][0].list_redirects[]{field_fromUrl,field_toUrl,field_permanentRedirect}`;
+
+let redirectMap: Map<string, { to: string; permanent: boolean }> | null = null;
+let refreshPromise: Promise<void> | null = null;
+
+async function loadRedirects(): Promise<Map<string, { to: string; permanent: boolean }>> {
+	const entries = await client.fetch<RedirectEntry[] | null>(QUERY);
+	const map = new Map<string, { to: string; permanent: boolean }>();
+	if (entries) {
+		for (const entry of entries) {
+			if (entry.field_fromUrl && entry.field_toUrl) {
+				map.set(normalizePath(entry.field_fromUrl), {
+					to: entry.field_toUrl,
+					permanent: entry.field_permanentRedirect ?? false,
+				});
+			}
+		}
+	}
+	return map;
+}
+
+function normalizePath(path: string): string {
+	return path.endsWith('/') && path.length > 1 ? path.slice(0, -1) : path;
+}
+
+async function getRedirectMap(): Promise<Map<string, { to: string; permanent: boolean }>> {
+	if (redirectMap) return redirectMap;
+
+	if (!refreshPromise) {
+		refreshPromise = loadRedirects().then((map) => {
+			redirectMap = map;
+			refreshPromise = null;
+		});
+	}
+	await refreshPromise;
+	return redirectMap!;
+}
+
+export function invalidateRedirectCache(): void {
+	redirectMap = null;
+}
+
+export async function middleware(request: NextRequest): Promise<NextResponse | undefined> {
+	const pathname = normalizePath(request.nextUrl.pathname);
+	const map = await getRedirectMap();
+	const match = map.get(pathname);
+
+	if (match) {
+		const destination = match.to.startsWith('http')
+			? match.to
+			: new URL(match.to, request.url).toString();
+
+		return NextResponse.redirect(destination, match.permanent ? 308 : 307);
+	}
+
+	return undefined;
+}
+
+export const config = {
+	matcher: [
+		'/((?!_next/static|_next/image|favicon\\.ico|api/|studio).*)',
+	],
+};

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,5 +1,6 @@
 import { type NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@sanity/client';
+import { dataset, projectId } from '~/lib/env';
 
 interface RedirectEntry {
 	field_fromUrl?: string;
@@ -8,8 +9,8 @@ interface RedirectEntry {
 }
 
 const client = createClient({
-	projectId: '3rbseux7',
-	dataset: 'production',
+	projectId,
+	dataset,
 	apiVersion: '2025-10-08',
 	useCdn: true,
 });

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,76 +1,25 @@
 import { type NextRequest, NextResponse } from 'next/server';
-import { createClient } from '@sanity/client';
-import { dataset, projectId } from '~/lib/env';
 
-interface RedirectEntry {
-	field_fromUrl?: string;
-	field_toUrl?: string;
-	field_permanentRedirect?: boolean;
-}
-
-const client = createClient({
-	projectId,
-	dataset,
-	apiVersion: '2025-10-08',
-	useCdn: true,
-});
-
-const QUERY = `*[_type=="goodpartyOrg_redirects"][0].list_redirects[]{field_fromUrl,field_toUrl,field_permanentRedirect}`;
-
-let redirectMap: Map<string, { to: string; permanent: boolean }> | null = null;
-let refreshPromise: Promise<void> | null = null;
-
-async function loadRedirects(): Promise<Map<string, { to: string; permanent: boolean }>> {
-	const entries = await client.fetch<RedirectEntry[] | null>(QUERY);
-	const map = new Map<string, { to: string; permanent: boolean }>();
-	if (entries) {
-		for (const entry of entries) {
-			if (entry.field_fromUrl && entry.field_toUrl) {
-				map.set(normalizePath(entry.field_fromUrl), {
-					to: entry.field_toUrl,
-					permanent: entry.field_permanentRedirect ?? false,
-				});
-			}
-		}
-	}
-	return map;
-}
+type RedirectMap = Record<string, { to: string; permanent: boolean }>;
 
 function normalizePath(path: string): string {
 	return path.endsWith('/') && path.length > 1 ? path.slice(0, -1) : path;
 }
 
-async function getRedirectMap(): Promise<Map<string, { to: string; permanent: boolean }>> {
-	if (redirectMap) return redirectMap;
-
-	if (!refreshPromise) {
-		refreshPromise = loadRedirects()
-			.then((map) => {
-				redirectMap = map;
-			})
-			.finally(() => {
-				refreshPromise = null;
-			});
-	}
-
-	try {
-		await refreshPromise;
-	} catch {
-		// Fetch failed after retries/timeouts: fail open so the site stays up; next request can retry.
-		return new Map();
-	}
-
-	return redirectMap ?? new Map();
-}
-
-export function invalidateRedirectCache(): void {
-	redirectMap = null;
-}
-
 export async function middleware(request: NextRequest): Promise<NextResponse | undefined> {
+	const origin = request.nextUrl.origin;
+
+	let map: RedirectMap;
+	try {
+		const res = await fetch(`${origin}/api/redirects`);
+		if (!res.ok) return undefined;
+		map = (await res.json()) as RedirectMap;
+	} catch {
+		return undefined;
+	}
+
 	const pathname = normalizePath(request.nextUrl.pathname);
-	const map = await getRedirectMap();
-	const match = map.get(pathname);
+	const match = map[pathname];
 
 	if (match) {
 		const destination = match.to.startsWith('http')
@@ -84,7 +33,5 @@ export async function middleware(request: NextRequest): Promise<NextResponse | u
 }
 
 export const config = {
-	matcher: [
-		'/((?!_next/static|_next/image|favicon\\.ico|api/|studio).*)',
-	],
+	matcher: ['/((?!_next/static|_next/image|favicon\\.ico|api/|studio).*)'],
 };

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -43,13 +43,23 @@ async function getRedirectMap(): Promise<Map<string, { to: string; permanent: bo
 	if (redirectMap) return redirectMap;
 
 	if (!refreshPromise) {
-		refreshPromise = loadRedirects().then((map) => {
-			redirectMap = map;
-			refreshPromise = null;
-		});
+		refreshPromise = loadRedirects()
+			.then((map) => {
+				redirectMap = map;
+			})
+			.finally(() => {
+				refreshPromise = null;
+			});
 	}
-	await refreshPromise;
-	return redirectMap!;
+
+	try {
+		await refreshPromise;
+	} catch {
+		// Fetch failed after retries/timeouts: fail open so the site stays up; next request can retry.
+		return new Map();
+	}
+
+	return redirectMap ?? new Map();
 }
 
 export function invalidateRedirectCache(): void {


### PR DESCRIPTION
- Added a new middleware to handle URL redirects based on entries fetched from Sanity.
- Introduced a caching mechanism for redirects to optimize performance.
- Integrated cache invalidation in the revalidation API route for 'goodpartyOrg_redirects' type, ensuring updates are reflected immediately.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds request-time redirect logic via Next.js middleware, which can impact all page routing and SEO/status codes if the Sanity redirect data is incorrect or unavailable.
> 
> **Overview**
> Introduces a new `src/middleware.ts` that fetches redirect rules from Sanity (`goodpartyOrg_redirects`), caches them in-memory, and applies 307/308 redirects for matching request paths (with normalization and a fail-open behavior on fetch errors).
> 
> Updates the revalidation webhook route to recognize the `goodpartyOrg_redirects` document type and revalidate `/` when redirect content changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e2d90069ba2d86b97cf2f810e949aa2e96e7e16. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->