### PR TITLE
Fix county-equivalent name canonicalization for elections pages and city matching

### DIFF
--- a/src/app/elections/[state]/[county]/page.tsx
+++ b/src/app/elections/[state]/[county]/page.tsx
@@ -18,10 +18,10 @@ import {
 import { sanityFetch } from '~/sanity/sanityClient';
 import { quoteCollectionByIdQuery } from '~/sanity/groq';
 import {
+	canonicalizeCountyEquivalentName,
 	getCountySuffixLabel,
 	getStateName,
 	placeToFactsCards,
-	stripCountySuffix,
 } from '~/lib/electionsHelpers';
 import { resolveAuthor } from '~/ui/_lib/resolveAuthor';
 import { resolveTextSize } from '~/ui/_lib/resolveTextSize';
@@ -71,6 +71,9 @@ export default async function Page({
 
 	const countyPlace = counties.find(c => c.slug.toLowerCase() === fullSlug);
 	const isDistrict = placeData != null && isDistrictMtfcc(placeData.mtfcc);
+	const normalizedCounty = countyPlace
+		? canonicalizeCountyEquivalentName(stateCode, countyPlace.name)
+		: null;
 
 	const cityPlaces = isDistrict
 		? []
@@ -85,7 +88,7 @@ export default async function Page({
 
 	const placeName = isDistrict
 		? (placeData?.name ?? county)
-		: (stripCountySuffix(countyPlace!.name) || countyPlace!.name);
+		: (normalizedCounty?.displayName ?? countyPlace!.name);
 	const cities = isDistrict
 		? []
 		: cityPlaces.map(c => ({
@@ -97,7 +100,7 @@ export default async function Page({
 	const breadcrumbs = [
 		{ href: '/elections', label: 'Elections' },
 		{ href: `/elections/${state.toLowerCase()}`, label: stateName },
-		{ href: '', label: isDistrict ? placeName : countyPlace!.name },
+		{ href: '', label: isDistrict ? placeName : (normalizedCounty?.displayName ?? countyPlace!.name) },
 	];
 
 	const factsCards = placeToFactsCards(placeData);
@@ -156,7 +159,7 @@ export default async function Page({
 				listProps={{
 					heading: isDistrict
 						? `Elections in ${placeName}`
-						: `${getCountySuffixLabel(countyPlace!.name)} Elections in ${countyPlace!.name}`,
+						: `${normalizedCounty?.suffixLabel ?? getCountySuffixLabel(countyPlace!.name)} Elections in ${normalizedCounty?.displayName ?? countyPlace!.name}`,
 					headlineLabel: isDistrict ? 'district' : 'county',
 					defaultYear,
 					availableYears,
@@ -166,7 +169,7 @@ export default async function Page({
 			{factsCards.length > 0 && (
 				<LocationFactsBlock
 					backgroundColor="cream"
-					header={{ title: isDistrict ? `${placeName} facts` : `${countyPlace!.name} facts` }}
+					header={{ title: isDistrict ? `${placeName} facts` : `${normalizedCounty?.displayName ?? countyPlace!.name} facts` }}
 					factsCards={factsCards}
 				/>
 			)}
@@ -176,8 +179,8 @@ export default async function Page({
 					stateSlug={fullSlug}
 					elections={cities}
 					header={{
-						title: `Cities in ${countyPlace!.name}`,
-						copy: `Browse elections by city in ${countyPlace!.name}, ${stateName}.`,
+						title: `Cities in ${normalizedCounty?.displayName ?? countyPlace!.name}`,
+						copy: `Browse elections by city in ${normalizedCounty?.displayName ?? countyPlace!.name}, ${stateName}.`,
 						backgroundColor: 'midnight',
 					}}
 					initialDisplayCount={DEFAULT_DISPLAY_COUNT}
@@ -223,9 +226,12 @@ export async function generateMetadata({
 	]);
 	const countyPlace = counties.find(c => c.slug.toLowerCase() === fullSlug);
 	const isDistrict = placeData != null && isDistrictMtfcc(placeData.mtfcc);
+	const normalizedCounty = countyPlace
+		? canonicalizeCountyEquivalentName(stateCode, countyPlace.name)
+		: null;
 	const placeName = isDistrict
 		? (placeData?.name ?? county)
-		: (countyPlace ? stripCountySuffix(countyPlace.name) : county);
+		: (normalizedCounty?.displayName ?? county);
 	return {
 		title: `Elections in ${placeName}, ${stateName} | Good Party`,
 		description: isDistrict

--- a/src/lib/electionsApi.ts
+++ b/src/lib/electionsApi.ts
@@ -220,10 +220,11 @@ export async function getCityPlacesByCounty(params: {
 }): Promise<PlaceItem[]> {
 	const allCities = await getPlacesByState({ state: params.state, mtfcc: CITY_MTFCC });
 	const countyName = countyNameFromSlug(params.countySlug);
+	const normalizedCountyBaseName = canonicalizeCountyEquivalentName(params.state, countyName).baseName;
 	return allCities.filter(
 		p =>
 			normalizeName(canonicalizeCountyEquivalentName(params.state, p.countyName ?? '').baseName) ===
-			normalizeName(countyName),
+			normalizeName(normalizedCountyBaseName),
 	);
 }
 

--- a/src/lib/electionsApi.ts
+++ b/src/lib/electionsApi.ts
@@ -10,6 +10,7 @@ import type {
 	RaceDetail,
 	RaceNode,
 } from '~/types/elections';
+import { canonicalizeCountyEquivalentName } from '~/lib/electionsHelpers';
 
 const BASE_URL =
 	process.env['ELECTIONS_API_BASE_URL'] ?? 'https://election-api.goodparty.org';
@@ -220,7 +221,9 @@ export async function getCityPlacesByCounty(params: {
 	const allCities = await getPlacesByState({ state: params.state, mtfcc: CITY_MTFCC });
 	const countyName = countyNameFromSlug(params.countySlug);
 	return allCities.filter(
-		p => normalizeName(p.countyName ?? '') === normalizeName(countyName),
+		p =>
+			normalizeName(canonicalizeCountyEquivalentName(params.state, p.countyName ?? '').baseName) ===
+			normalizeName(countyName),
 	);
 }
 

--- a/src/lib/electionsHelpers.test.ts
+++ b/src/lib/electionsHelpers.test.ts
@@ -107,6 +107,10 @@ describe('stripCountySuffix', () => {
 		expect(stripCountySuffix('San Juan Municipio')).toBe('San Juan');
 	});
 
+	test('strips Municipality', () => {
+		expect(stripCountySuffix('Anchorage Municipality')).toBe('Anchorage');
+	});
+
 	test('strips City and Borough', () => {
 		expect(stripCountySuffix('Juneau City and Borough')).toBe('Juneau');
 	});
@@ -128,6 +132,7 @@ describe('getCountySuffixLabel', () => {
 	test('returns matched suffix', () => {
 		expect(getCountySuffixLabel('Jefferson Parish')).toBe('Parish');
 		expect(getCountySuffixLabel('Jefferson County')).toBe('County');
+		expect(getCountySuffixLabel('Anchorage Municipality')).toBe('Municipality');
 	});
 
 	test('returns "County" when no suffix match', () => {
@@ -156,11 +161,27 @@ describe('canonicalizeCountyEquivalentName', () => {
 		});
 	});
 
+	test('preserves Alaska municipality naming', () => {
+		expect(canonicalizeCountyEquivalentName('AK', 'Skagway Municipality')).toEqual({
+			displayName: 'Skagway Municipality',
+			baseName: 'Skagway',
+			suffixLabel: 'Municipality',
+		});
+	});
+
 	test('fixes malformed Alaska double suffix', () => {
 		expect(canonicalizeCountyEquivalentName('AK', 'Haines Borough County')).toEqual({
 			displayName: 'Haines Borough',
 			baseName: 'Haines',
 			suffixLabel: 'Borough',
+		});
+	});
+
+	test('fixes malformed Alaska municipality double suffix', () => {
+		expect(canonicalizeCountyEquivalentName('AK', 'Skagway Municipality County')).toEqual({
+			displayName: 'Skagway Municipality',
+			baseName: 'Skagway',
+			suffixLabel: 'Municipality',
 		});
 	});
 

--- a/src/lib/electionsHelpers.test.ts
+++ b/src/lib/electionsHelpers.test.ts
@@ -3,6 +3,7 @@ import {
 	buildFAQSchema,
 	buildJobPostingSchema,
 	buildRaceSlug,
+	canonicalizeCountyEquivalentName,
 	findCityForDistrictName,
 	formatElectionDateFromApi,
 	formatFilingPeriodFromRace,
@@ -135,6 +136,64 @@ describe('getCountySuffixLabel', () => {
 
 	test('returns "County" for empty string', () => {
 		expect(getCountySuffixLabel('')).toBe('County');
+	});
+});
+
+describe('canonicalizeCountyEquivalentName', () => {
+	test('appends County for non-exception states when suffix missing', () => {
+		expect(canonicalizeCountyEquivalentName('AZ', 'Apache')).toEqual({
+			displayName: 'Apache County',
+			baseName: 'Apache',
+			suffixLabel: 'County',
+		});
+	});
+
+	test('preserves Alaska borough naming', () => {
+		expect(canonicalizeCountyEquivalentName('AK', 'Haines Borough')).toEqual({
+			displayName: 'Haines Borough',
+			baseName: 'Haines',
+			suffixLabel: 'Borough',
+		});
+	});
+
+	test('fixes malformed Alaska double suffix', () => {
+		expect(canonicalizeCountyEquivalentName('AK', 'Haines Borough County')).toEqual({
+			displayName: 'Haines Borough',
+			baseName: 'Haines',
+			suffixLabel: 'Borough',
+		});
+	});
+
+	test('preserves Louisiana parish naming', () => {
+		expect(canonicalizeCountyEquivalentName('LA', 'Jefferson Parish')).toEqual({
+			displayName: 'Jefferson Parish',
+			baseName: 'Jefferson',
+			suffixLabel: 'Parish',
+		});
+	});
+
+	test('fixes malformed Louisiana double suffix', () => {
+		expect(canonicalizeCountyEquivalentName('LA', 'Jefferson Parish County')).toEqual({
+			displayName: 'Jefferson Parish',
+			baseName: 'Jefferson',
+			suffixLabel: 'Parish',
+		});
+	});
+
+	test('preserves Puerto Rico municipio naming', () => {
+		expect(canonicalizeCountyEquivalentName('PR', 'San Juan Municipio')).toEqual({
+			displayName: 'San Juan Municipio',
+			baseName: 'San Juan',
+			suffixLabel: 'Municipio',
+		});
+	});
+
+	test('fixes malformed Puerto Rico double suffix', () => {
+		expect(canonicalizeCountyEquivalentName('PR', 'San Juan Municipio County')).toEqual({
+			displayName: 'San Juan Municipio',
+			baseName: 'San Juan',
+			suffixLabel: 'Municipio',
+		});
 	});
 });
 

--- a/src/lib/electionsHelpers.ts
+++ b/src/lib/electionsHelpers.ts
@@ -3,6 +3,76 @@ import type { CandidacyItem, PlaceItem, PlaceWithFacts, RaceDetail } from '~/typ
 import type { FactsCardProps } from '~/ui/FactsCard';
 
 const COUNTY_EQUIV_SUFFIX_RE = /\s+(County|Parish|City and Borough|City and County|Borough|Census Area|Municipio)$/i;
+const COUNTY_EQUIV_TAIL_RE =
+	/\s+(County|Parish|City and Borough|City and County|Borough|Census Area|Municipio)(?:\s+(County|Parish|City and Borough|City and County|Borough|Census Area|Municipio))*$/i;
+
+type CanonicalSuffix =
+	| 'County'
+	| 'Parish'
+	| 'Borough'
+	| 'Census Area'
+	| 'City and Borough'
+	| 'City and County'
+	| 'Municipio';
+
+type CanonicalCountyName = {
+	displayName: string;
+	baseName: string;
+	suffixLabel: CanonicalSuffix;
+};
+
+const SUFFIX_NORMALIZATION: Record<string, CanonicalSuffix> = {
+	county: 'County',
+	parish: 'Parish',
+	borough: 'Borough',
+	'census area': 'Census Area',
+	'city and borough': 'City and Borough',
+	'city and county': 'City and County',
+	municipio: 'Municipio',
+};
+
+function normalizeWhitespace(value: string): string {
+	return value.replace(/\s+/g, ' ').trim();
+}
+
+function toCanonicalSuffix(value: string): CanonicalSuffix | null {
+	const normalized = normalizeWhitespace(value).toLowerCase();
+	return SUFFIX_NORMALIZATION[normalized] ?? null;
+}
+
+function pickSuffixByState(
+	stateCode: string,
+	existingSuffix: CanonicalSuffix | null,
+): CanonicalSuffix {
+	const upper = stateCode.toUpperCase();
+	if (upper === 'AK') {
+		if (existingSuffix === 'City and Borough' || existingSuffix === 'Census Area') {
+			return existingSuffix;
+		}
+		return 'Borough';
+	}
+	if (upper === 'LA') return 'Parish';
+	if (upper === 'PR') return 'Municipio';
+	if (existingSuffix === 'City and County') return existingSuffix;
+	return 'County';
+}
+
+/**
+ * Canonical county-equivalent naming for county-level display surfaces.
+ * Enforces AK/LA/PR conventions and defensively cleans malformed double suffixes.
+ */
+export function canonicalizeCountyEquivalentName(
+	stateCode: string,
+	rawPlaceName: string,
+): CanonicalCountyName {
+	const normalizedName = normalizeWhitespace(rawPlaceName);
+	const tailMatch = normalizedName.match(COUNTY_EQUIV_TAIL_RE);
+	const existingSuffix = tailMatch ? toCanonicalSuffix(tailMatch[1] ?? '') : null;
+	const suffixLabel = pickSuffixByState(stateCode, existingSuffix);
+	const baseName = normalizeWhitespace(normalizedName.replace(COUNTY_EQUIV_TAIL_RE, '')) || normalizedName;
+	const displayName = `${baseName} ${suffixLabel}`.trim();
+	return { displayName, baseName, suffixLabel };
+}
 
 /** Resolve display name for the [county] route param (county, city, or district). */
 export function resolveLocalityName(

--- a/src/lib/electionsHelpers.ts
+++ b/src/lib/electionsHelpers.ts
@@ -2,9 +2,10 @@ import { US_STATES } from '~/constants/usStates';
 import type { CandidacyItem, PlaceItem, PlaceWithFacts, RaceDetail } from '~/types/elections';
 import type { FactsCardProps } from '~/ui/FactsCard';
 
-const COUNTY_EQUIV_SUFFIX_RE = /\s+(County|Parish|City and Borough|City and County|Borough|Census Area|Municipio)$/i;
+const COUNTY_EQUIV_SUFFIX_RE =
+	/\s+(County|Parish|City and Borough|City and County|Borough|Census Area|Municipio|Municipality)$/i;
 const COUNTY_EQUIV_TAIL_RE =
-	/\s+(County|Parish|City and Borough|City and County|Borough|Census Area|Municipio)(?:\s+(County|Parish|City and Borough|City and County|Borough|Census Area|Municipio))*$/i;
+	/\s+(County|Parish|City and Borough|City and County|Borough|Census Area|Municipio|Municipality)(?:\s+(County|Parish|City and Borough|City and County|Borough|Census Area|Municipio|Municipality))*$/i;
 
 type CanonicalSuffix =
 	| 'County'
@@ -13,7 +14,8 @@ type CanonicalSuffix =
 	| 'Census Area'
 	| 'City and Borough'
 	| 'City and County'
-	| 'Municipio';
+	| 'Municipio'
+	| 'Municipality';
 
 type CanonicalCountyName = {
 	displayName: string;
@@ -29,6 +31,7 @@ const SUFFIX_NORMALIZATION: Record<string, CanonicalSuffix> = {
 	'city and borough': 'City and Borough',
 	'city and county': 'City and County',
 	municipio: 'Municipio',
+	municipality: 'Municipality',
 };
 
 function normalizeWhitespace(value: string): string {
@@ -46,7 +49,12 @@ function pickSuffixByState(
 ): CanonicalSuffix {
 	const upper = stateCode.toUpperCase();
 	if (upper === 'AK') {
-		if (existingSuffix === 'City and Borough' || existingSuffix === 'Census Area') {
+		if (
+			existingSuffix === 'City and Borough' ||
+			existingSuffix === 'Census Area' ||
+			existingSuffix === 'Borough' ||
+			existingSuffix === 'Municipality'
+		) {
 			return existingSuffix;
 		}
 		return 'Borough';

--- a/src/lib/sitemap-entries.ts
+++ b/src/lib/sitemap-entries.ts
@@ -5,6 +5,7 @@
 
 import type { MetadataRoute } from 'next';
 import { sanityClient } from '~/sanity/sanityClient';
+import { stripCountySuffix as stripCountySuffixFromHelpers } from '~/lib/electionsHelpers';
 
 /** 51 US state/territory codes (50 states + DC) */
 export const US_STATE_CODES = [
@@ -26,9 +27,6 @@ const ELECTION_API_BASE =
 
 const CACHE_1H: RequestInit = { next: { revalidate: 3600 } };
 
-const COUNTY_SUFFIX_RE =
-	/\s+(County|Parish|City and Borough|City and County|Borough|Census Area|Municipio)$/i;
-
 export type CountyPlace = { slug?: string; name?: string; mtfcc?: string };
 export type CityPlace = { slug?: string; countyName?: string };
 export type RaceEntry = { slug?: string; positionLevel?: string };
@@ -38,7 +36,7 @@ export function normalizeName(name: string): string {
 }
 
 export function stripCountySuffix(name: string): string {
-	return name.replace(COUNTY_SUFFIX_RE, '') || name;
+	return stripCountySuffixFromHelpers(name);
 }
 
 function dedupeByUrl(entries: MetadataRoute.Sitemap): MetadataRoute.Sitemap {


### PR DESCRIPTION
### What changed
This PR standardizes county-equivalent naming across elections surfaces to prevent missing or malformed county labels, especially in AK and LA. It introduces canonical county name handling in shared helpers and applies it to page rendering, metadata generation, and city-to-county filtering logic.

### Key updates
- Added `canonicalizeCountyEquivalentName` in `src/lib/electionsHelpers.ts` to:
  - normalize county-equivalent suffixes,
  - enforce state-specific suffix rules (`Borough`/`Municipality` for AK, `Parish` for LA),
  - clean malformed double-suffix names.
- Updated `getCityPlacesByCounty` in `src/lib/electionsApi.ts` to compare canonicalized county base names, improving city matching when suffixes differ in source data.
- Updated county route page behavior in `src/app/elections/[state]/[county]/page.tsx` to use canonicalized display names in:
  - page headings,
  - breadcrumbs,
  - facts section titles,
  - city section copy,
  - metadata title generation.
- Removed duplicate county-suffix stripping logic in `src/lib/sitemap-entries.ts` and reused shared helper behavior from `electionsHelpers`.
- Expanded tests in `src/lib/electionsHelpers.test.ts` to cover municipality handling and canonicalization behavior for valid and malformed AK/LA/PR county-equivalent names.

### Why
County-equivalent names coming from different sources are not always consistent (missing suffixes, differing suffix types, or accidental double suffixes), which caused naming mismatches and missing county/city associations. Centralizing canonicalization ensures consistent display and reliable matching across the elections experience.

### Scope / Impact
- Affects county-equivalent naming and matching logic for elections pages and related metadata.
- Improves consistency and resilience for edge-case jurisdictions without changing intended route structure.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how county names are normalized for display and for city-to-county matching, which can affect what content appears on elections county pages and which cities are associated with a county. Risk is moderate because it touches shared helpers used across pages, metadata, and sitemap generation.
> 
> **Overview**
> Standardizes county-equivalent naming via new `canonicalizeCountyEquivalentName` to enforce state-specific suffix conventions (notably AK/LA/PR), handle `Municipality`, and clean up malformed double-suffix inputs.
> 
> Updates elections county pages and metadata to use canonicalized county display names and suffix labels in headings, breadcrumbs, facts headers, and city-section copy. City lookup (`getCityPlacesByCounty`) now matches cities to counties by comparing canonicalized *base names* rather than raw county strings, and sitemap code reuses the shared `stripCountySuffix` helper instead of maintaining its own regex; tests are expanded to cover the new canonicalization behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 922a67cfd59776f45c97e3ba61140dfdc7640671. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->