### PR TITLE
Add component_usMapBlock schema

### DIFF
--- a/src/sanity/schema/components/componentSchema.ts
+++ b/src/sanity/schema/components/componentSchema.ts
@@ -40,6 +40,7 @@ import {component_profileContentBlock} from './component_profileContentBlock.ts'
 import {component_listOfOfficesBlock} from './component_listOfOfficesBlock.ts'
 import {component_embeddedBlock} from './component_embeddedBlock.ts'
 import {component_teamValuesBlock} from './component_teamValuesBlock.ts'
+import {component_usMapBlock} from './component_usMapBlock.ts'
 
 export const componentSchema = [
 	component_jobOpeningsBlock,
@@ -83,5 +84,6 @@ export const componentSchema = [
 	component_profileContentBlock,
 	component_listOfOfficesBlock,
 	component_embeddedBlock,
-	component_teamValuesBlock
+	component_teamValuesBlock,
+	component_usMapBlock,
 ];

--- a/src/sanity/schema/components/component_usMapBlock.ts
+++ b/src/sanity/schema/components/component_usMapBlock.ts
@@ -1,0 +1,75 @@
+import {resolveValue} from "../../utils/resolveValue.ts";
+import {handleReplacements} from "../../utils/handleReplacements.ts";
+import {getIcon} from "../../utils/getIcon.tsx";
+
+export const component_usMapBlock = {
+  title: 'US Map Block',
+  name: 'component_usMapBlock',
+  type: 'object',
+  icon: getIcon('Map'),
+  fields: [
+    {
+      title: 'Text',
+      name: 'summaryInfo',
+      type: 'summaryInfo',
+      group: 'summaryInfo',
+    },
+    {
+      title: 'Map States',
+      name: 'usMapBlockContent',
+      type: 'usMapBlockContent',
+      group: 'usMapBlockContent',
+    },
+    {
+      title: 'Design Settings',
+      name: 'usMapBlockDesignSettings',
+      type: 'usMapBlockDesignSettings',
+      group: 'usMapBlockDesignSettings',
+    },
+    {
+      title: 'Settings',
+      name: 'componentSettings',
+      type: 'componentSettings',
+      group: 'componentSettings',
+    },
+  ],
+  preview: {
+    select: {
+      title: 'summaryInfo.field_title',
+      _type: '_type',
+    },
+    prepare: x => {
+const infer = {
+      singletonTitle: null,
+      icon: getIcon('Map'),
+      fallback: {
+        previewTitle: 'summaryInfo.field_title',
+        previewSubTitle: '*US Map Block',
+        title: 'US Map Block',
+      },
+    }
+         const title = resolveValue("title", component_usMapBlock.preview.select, x);         const subtitle = resolveValue("subtitle", component_usMapBlock.preview.select, x);         const media = resolveValue("media", component_usMapBlock.preview.select, x);         return handleReplacements({           title: infer.singletonTitle || title || undefined,           subtitle: subtitle ? subtitle : infer.fallback["title"],           media: media || infer.icon         }, x, infer.fallback);       },
+  },
+  groups: [
+    {
+      title: 'Text',
+      name: 'summaryInfo',
+      icon: getIcon('TextFont'),
+    },
+    {
+      title: 'Map States',
+      name: 'usMapBlockContent',
+      icon: getIcon('Map'),
+    },
+    {
+      title: 'Design Settings',
+      name: 'usMapBlockDesignSettings',
+      icon: getIcon('ColorPalette'),
+    },
+    {
+      title: 'Settings',
+      name: 'componentSettings',
+      icon: getIcon('Settings'),
+    },
+  ],
+}

--- a/src/sanity/schema/fields/fieldSchema.ts
+++ b/src/sanity/schema/fields/fieldSchema.ts
@@ -109,6 +109,12 @@ import { field_heroImageSize } from './field_heroImageSize.ts';
 import { field_slug } from './field_slug.ts';
 import { field_aspectRatio } from './field_aspectRatio.ts';
 import { field_textSize } from './field_textSize.ts';
+import { field_stateCode } from './field_stateCode.ts';
+import { field_mapStateColor } from './field_mapStateColor.ts';
+import { field_hoverTitle } from './field_hoverTitle.ts';
+import { field_hoverDescription } from './field_hoverDescription.ts';
+import { field_hoverStat } from './field_hoverStat.ts';
+import { field_defaultStateColor } from './field_defaultStateColor.ts';
 
 export const fieldSchema = [
 	field_aspectRatio,
@@ -222,4 +228,10 @@ export const fieldSchema = [
 	field_heroImageSize,
 	field_slug,
 	field_textSize,
+	field_stateCode,
+	field_mapStateColor,
+	field_hoverTitle,
+	field_hoverDescription,
+	field_hoverStat,
+	field_defaultStateColor,
 ];

--- a/src/sanity/schema/fields/field_defaultStateColor.ts
+++ b/src/sanity/schema/fields/field_defaultStateColor.ts
@@ -1,0 +1,10 @@
+
+export const field_defaultStateColor = {
+  name: 'field_defaultStateColor',
+  title: 'Default State Color',
+  description: 'Hex color applied to all states without a custom color (e.g. #E5E7EB)',
+  options: {
+    collapsible: false,
+  },
+  type: 'string',
+}

--- a/src/sanity/schema/fields/field_hoverDescription.ts
+++ b/src/sanity/schema/fields/field_hoverDescription.ts
@@ -1,0 +1,11 @@
+
+export const field_hoverDescription = {
+  name: 'field_hoverDescription',
+  title: 'Hover Description',
+  description: 'Description displayed when hovering over this state',
+  options: {
+    collapsible: false,
+  },
+  rows: 3,
+  type: 'text',
+}

--- a/src/sanity/schema/fields/field_hoverStat.ts
+++ b/src/sanity/schema/fields/field_hoverStat.ts
@@ -1,0 +1,10 @@
+
+export const field_hoverStat = {
+  name: 'field_hoverStat',
+  title: 'Hover Stat',
+  description: 'Optional stat or number to highlight on hover (e.g. 1,234 candidates)',
+  options: {
+    collapsible: false,
+  },
+  type: 'string',
+}

--- a/src/sanity/schema/fields/field_hoverTitle.ts
+++ b/src/sanity/schema/fields/field_hoverTitle.ts
@@ -1,0 +1,10 @@
+
+export const field_hoverTitle = {
+  name: 'field_hoverTitle',
+  title: 'Hover Title',
+  description: 'Title displayed when hovering over this state',
+  options: {
+    collapsible: false,
+  },
+  type: 'string',
+}

--- a/src/sanity/schema/fields/field_mapStateColor.ts
+++ b/src/sanity/schema/fields/field_mapStateColor.ts
@@ -1,0 +1,10 @@
+
+export const field_mapStateColor = {
+  name: 'field_mapStateColor',
+  title: 'State Color',
+  description: 'Hex color code for this state (e.g. #4F46E5)',
+  options: {
+    collapsible: false,
+  },
+  type: 'string',
+}

--- a/src/sanity/schema/fields/field_stateCode.ts
+++ b/src/sanity/schema/fields/field_stateCode.ts
@@ -1,0 +1,10 @@
+
+export const field_stateCode = {
+  name: 'field_stateCode',
+  title: 'State Code',
+  description: 'Two-letter state abbreviation (e.g. CA, TX, NY)',
+  options: {
+    collapsible: false,
+  },
+  type: 'string',
+}

--- a/src/sanity/schema/groups/groupSchema.ts
+++ b/src/sanity/schema/groups/groupSchema.ts
@@ -146,6 +146,9 @@ import { officeItem } from './officeItem.ts';
 import { teamValuesCard } from './teamValuesCard.ts';
 import { teamValuesBlockContent } from './teamValuesBlockContent.ts';
 import { teamValuesBlockDesignSettings } from './teamValuesBlockDesignSettings.ts';
+import { usMapStateItem } from './usMapStateItem.ts';
+import { usMapBlockContent } from './usMapBlockContent.ts';
+import { usMapBlockDesignSettings } from './usMapBlockDesignSettings.ts';
 
 export const groupSchema = [
 	calculatorTextBlockDesignSettings,
@@ -296,4 +299,7 @@ export const groupSchema = [
 	teamValuesCard,
 	teamValuesBlockContent,
 	teamValuesBlockDesignSettings,
+	usMapStateItem,
+	usMapBlockContent,
+	usMapBlockDesignSettings,
 ];

--- a/src/sanity/schema/groups/usMapBlockContent.ts
+++ b/src/sanity/schema/groups/usMapBlockContent.ts
@@ -1,0 +1,34 @@
+import {resolveValue} from "../../utils/resolveValue.ts";
+import {handleReplacements} from "../../utils/handleReplacements.ts";
+import {getIcon} from "../../utils/getIcon.tsx";
+
+export const usMapBlockContent = {
+  title: 'Map States',
+  name: 'usMapBlockContent',
+  type: 'object',
+  options: {
+    collapsed: false,
+    columns: 1,
+  },
+  icon: getIcon('Map'),
+  fields: [
+    {
+      title: 'State Configurations',
+      name: 'list_usMapStateItems',
+      type: 'list_usMapStateItems',
+    },
+  ],
+  preview: {
+    select: {
+      list: 'list_usMapStateItems',
+    },
+    prepare: x => {
+const infer = {
+      name: 'Map States',
+      singletonTitle: null,
+      icon: getIcon('Map'),
+      fallback: {},
+    }
+           const title = resolveValue("title", usMapBlockContent.preview.select, x);           const subtitle = resolveValue("subtitle", usMapBlockContent.preview.select, x);           const media = resolveValue("media", usMapBlockContent.preview.select, x);           return handleReplacements({             title: infer.singletonTitle || title || infer.name,             subtitle: subtitle || x.list?.length && x.list.length === 1 ? "1 state" : x.list?.length > 0 ? `${x.list.length} states configured` : "No states configured",             media: media || infer.icon           }, x, infer.fallback);         },
+  },
+}

--- a/src/sanity/schema/groups/usMapBlockDesignSettings.ts
+++ b/src/sanity/schema/groups/usMapBlockDesignSettings.ts
@@ -1,0 +1,34 @@
+import {resolveValue} from "../../utils/resolveValue.ts";
+import {handleReplacements} from "../../utils/handleReplacements.ts";
+import {getIcon} from "../../utils/getIcon.tsx";
+
+export const usMapBlockDesignSettings = {
+  title: 'Design Settings',
+  name: 'usMapBlockDesignSettings',
+  type: 'object',
+  options: {
+    collapsed: false,
+    columns: 1,
+  },
+  icon: getIcon('ColorPalette'),
+  fields: [
+    {
+      title: 'Default State Color',
+      name: 'field_defaultStateColor',
+      type: 'field_defaultStateColor',
+    },
+  ],
+  preview: {
+    select: {
+      title: 'field_defaultStateColor',
+      _type: '_type',
+    },
+    prepare: x => {
+const infer = {
+      singletonTitle: null,
+      icon: getIcon('ColorPalette'),
+      fallback: {},
+    }
+         const title = resolveValue("title", usMapBlockDesignSettings.preview.select, x);         const subtitle = resolveValue("subtitle", usMapBlockDesignSettings.preview.select, x);         const media = resolveValue("media", usMapBlockDesignSettings.preview.select, x);         return handleReplacements({           title: infer.singletonTitle || title || undefined,           subtitle: subtitle ? subtitle : infer.fallback["title"],           media: media || infer.icon         }, x, infer.fallback);       },
+  },
+}

--- a/src/sanity/schema/groups/usMapStateItem.ts
+++ b/src/sanity/schema/groups/usMapStateItem.ts
@@ -1,0 +1,65 @@
+import {resolveValue} from "../../utils/resolveValue.ts";
+import {handleReplacements} from "../../utils/handleReplacements.ts";
+import {getIcon} from "../../utils/getIcon.tsx";
+
+export const usMapStateItem = {
+  title: 'State Map Item',
+  name: 'usMapStateItem',
+  type: 'object',
+  options: {
+    collapsed: false,
+    columns: 1,
+  },
+  description: 'Configuration for a single US state on the map',
+  icon: getIcon('LocationFilled'),
+  fields: [
+    {
+      title: 'State Code',
+      name: 'field_stateCode',
+      type: 'field_stateCode',
+    },
+    {
+      title: 'State Name',
+      name: 'field_stateName',
+      type: 'field_stateName',
+    },
+    {
+      title: 'State Color',
+      name: 'field_mapStateColor',
+      type: 'field_mapStateColor',
+    },
+    {
+      title: 'Hover Title',
+      name: 'field_hoverTitle',
+      type: 'field_hoverTitle',
+    },
+    {
+      title: 'Hover Description',
+      name: 'field_hoverDescription',
+      type: 'field_hoverDescription',
+    },
+    {
+      title: 'Hover Stat',
+      name: 'field_hoverStat',
+      type: 'field_hoverStat',
+    },
+  ],
+  preview: {
+    select: {
+      title: 'field_stateName',
+      _type: '_type',
+      subtitle: 'field_stateCode',
+    },
+    prepare: x => {
+const infer = {
+      singletonTitle: null,
+      icon: getIcon('LocationFilled'),
+      fallback: {
+        previewTitle: 'field_stateName',
+        previewSubTitle: 'field_stateCode',
+        title: 'State Map Item',
+      },
+    }
+         const title = resolveValue("title", usMapStateItem.preview.select, x);         const subtitle = resolveValue("subtitle", usMapStateItem.preview.select, x);         const media = resolveValue("media", usMapStateItem.preview.select, x);         return handleReplacements({           title: infer.singletonTitle || title || undefined,           subtitle: subtitle ? subtitle : infer.fallback["title"],           media: media || infer.icon         }, x, infer.fallback);       },
+  },
+}

--- a/src/sanity/schema/lists/listSchema.ts
+++ b/src/sanity/schema/lists/listSchema.ts
@@ -31,6 +31,7 @@ import {list_pricingPlans} from './list_pricingPlans.ts'
 import {list_collectionFaQs} from './list_collectionFaQs.ts'
 import {list_officeItems} from './list_officeItems.ts'
 import {list_teamValuesCards} from './list_teamValuesCards.ts'
+import {list_usMapStateItems} from './list_usMapStateItems.ts'
 
 export const listSchema = [
 list_footerLegalNavigation,
@@ -65,5 +66,6 @@ list_socialChannels,
 list_pricingPlans,
 	list_collectionFaQs,
 	list_officeItems,
-	list_teamValuesCards
+	list_teamValuesCards,
+	list_usMapStateItems,
 ];

--- a/src/sanity/schema/lists/list_pageSections.ts
+++ b/src/sanity/schema/lists/list_pageSections.ts
@@ -134,6 +134,13 @@ export const list_pageSections = {
           ],
         },
         {
+          name: 'map',
+          title: 'Map',
+          of: [
+            'component_usMapBlock',
+          ],
+        },
+        {
           name: 'cta',
           title: 'CTA',
           of: [
@@ -326,6 +333,10 @@ export const list_pageSections = {
     {
       title: 'Team Values Block',
       type: 'component_teamValuesBlock',
+    },
+    {
+      title: 'US Map Block',
+      type: 'component_usMapBlock',
     },
   ],
 }

--- a/src/sanity/schema/lists/list_usMapStateItems.ts
+++ b/src/sanity/schema/lists/list_usMapStateItems.ts
@@ -1,0 +1,16 @@
+
+export const list_usMapStateItems = {
+  name: 'list_usMapStateItems',
+  title: 'State Configurations',
+  description: 'Configure color and hover info for individual states. States not listed will use the default color.',
+  options: {
+    collapsible: false,
+  },
+  type: 'array',
+  of: [
+    {
+      title: 'State',
+      type: 'usMapStateItem',
+    },
+  ],
+}


### PR DESCRIPTION
## Summary
- Adds a new `component_usMapBlock` page section for an interactive US map
- Each state can be configured with a custom fill color and hover tooltip (title, description, stat)
- Includes a default color setting for unconfigured states
- Registers the component in `list_pageSections` so it's available in the Studio insert menu under a new **Map** group

## New files
- `component_usMapBlock.ts` — main component
- `usMapStateItem.ts`, `usMapBlockContent.ts`, `usMapBlockDesignSettings.ts` — group types
- `list_usMapStateItems.ts` — array type for state configs
- `field_stateCode`, `field_mapStateColor`, `field_hoverTitle`, `field_hoverDescription`, `field_hoverStat`, `field_defaultStateColor` — field types

## Test plan
- [ ] Confirm Studio insert menu shows "US Map Block" under the Map group
- [ ] Add a US Map Block to a page and verify state items can be created with code, color, and hover fields
- [ ] Confirm no validation errors in Studio

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to Sanity Studio schema registration, mainly adding new types/fields and insert-menu grouping with no runtime logic or data migrations.
> 
> **Overview**
> Adds a new Sanity page section `component_usMapBlock` for a US map, including grouped configuration for per-state overrides (code/name, fill color, and hover title/description/stat) plus a default state color.
> 
> Registers the new component, groups, list type (`list_usMapStateItems`), and supporting field types in the central `componentSchema`, `groupSchema`, `listSchema`, and `fieldSchema`, and exposes the block in `list_pageSections` under a new **Map** insert-menu group.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d34ce2218edb3d3ac1a02e47f5e5573828aa5f0f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->