### PR TITLE
Refactor: enhance Amplitude initialization and state management.

### DIFF
--- a/src/types/amplitude.d.ts
+++ b/src/types/amplitude.d.ts
@@ -1,5 +1,10 @@
 declare global {
 	interface Window {
+		/** Survives HMR and Strict Mode remounts; prevents duplicate `init` / experiment wiring. */
+		__goodpartyAmplitude?: {
+			clientInitialized: boolean;
+			scriptInjected: boolean;
+		};
 		amplitude?: {
 			init(apiKey: string, options?: {
 				fetchRemoteConfig?: boolean;

--- a/src/ui/Amplitude.tsx
+++ b/src/ui/Amplitude.tsx
@@ -49,8 +49,11 @@ function whenAmplitudeScriptProvidesGlobal(
 	script: HTMLScriptElement,
 	onReady: () => void,
 ): (() => void) | undefined {
+	let called = false;
 	const tryBoot = () => {
+		if (called) return true;
 		if (!window.amplitude) return false;
+		called = true;
 		onReady();
 		return true;
 	};

--- a/src/ui/Amplitude.tsx
+++ b/src/ui/Amplitude.tsx
@@ -4,6 +4,7 @@ import { useEffect } from 'react';
 
 const AMPLITUDE_API_KEY = process.env['NEXT_PUBLIC_AMPLITUDE_API_KEY'];
 const EXTERNAL_AMPLITUDE_WAIT_MS = 1_500;
+const AMPLITUDE_CDN_WAIT_MS = 10_000;
 
 function getAmplitudeState() {
 	if (typeof window === 'undefined') return undefined;
@@ -13,6 +14,13 @@ function getAmplitudeState() {
 
 function markAmplitudeReady() {
 	window.dispatchEvent(new Event('experiment:ready'));
+}
+
+function markAmplitudeUnavailable(message: string) {
+	const state = getAmplitudeState();
+	if (state) state.scriptInjected = false;
+	console.warn(message);
+	markAmplitudeReady();
 }
 
 function adoptExternalAmplitude() {
@@ -48,36 +56,60 @@ function findInjectedAmplitudeScript(apiKey: string) {
 function whenAmplitudeScriptProvidesGlobal(
 	script: HTMLScriptElement,
 	onReady: () => void,
+	onUnavailable: (message: string) => void,
 ): (() => void) | undefined {
-	let called = false;
+	if (window.amplitude) {
+		onReady();
+		return undefined;
+	}
+
+	let completed = false;
+
+	const cleanup = () => {
+		script.removeEventListener('load', handleLoad);
+		script.removeEventListener('error', handleError);
+		window.clearInterval(pollId);
+	};
+
 	const tryBoot = () => {
-		if (called) return true;
+		if (completed) return true;
 		if (!window.amplitude) return false;
-		called = true;
+		completed = true;
+		cleanup();
 		onReady();
 		return true;
 	};
 
-	if (tryBoot()) return undefined;
-
-	const run = () => {
+	function handleLoad() {
 		void tryBoot();
-	};
+	}
 
-	script.addEventListener('load', run, { once: true });
-	script.addEventListener('error', run, { once: true });
-	void queueMicrotask(run);
-	requestAnimationFrame(run);
+	function handleError() {
+		if (completed) return;
+		completed = true;
+		cleanup();
+		script.remove();
+		onUnavailable('[Amplitude] CDN script failed to load');
+	}
+
+	script.addEventListener('load', handleLoad);
+	script.addEventListener('error', handleError);
+	void queueMicrotask(handleLoad);
+	requestAnimationFrame(handleLoad);
 
 	const started = performance.now();
 	const pollId = window.setInterval(() => {
-		if (tryBoot() || performance.now() - started > 10_000) {
-			window.clearInterval(pollId);
+		if (tryBoot()) return;
+		if (performance.now() - started > AMPLITUDE_CDN_WAIT_MS) {
+			completed = true;
+			cleanup();
+			script.remove();
+			onUnavailable('[Amplitude] CDN script did not provide window.amplitude');
 		}
 	}, 100);
 
 	return () => {
-		window.clearInterval(pollId);
+		cleanup();
 	};
 }
 
@@ -112,6 +144,7 @@ export function Amplitude() {
 				stopWaitingForScript = whenAmplitudeScriptProvidesGlobal(
 					existing,
 					state.scriptInjected ? bootAppAmplitude : adoptExternalAmplitude,
+					markAmplitudeUnavailable,
 				);
 				return;
 			}
@@ -121,7 +154,11 @@ export function Amplitude() {
 			script.src = `https://cdn.amplitude.com/script/${AMPLITUDE_API_KEY}.js`;
 			script.async = true;
 			document.head.appendChild(script);
-			stopWaitingForScript = whenAmplitudeScriptProvidesGlobal(script, bootAppAmplitude);
+			stopWaitingForScript = whenAmplitudeScriptProvidesGlobal(
+				script,
+				bootAppAmplitude,
+				markAmplitudeUnavailable,
+			);
 		}, EXTERNAL_AMPLITUDE_WAIT_MS);
 
 		return () => {

--- a/src/ui/Amplitude.tsx
+++ b/src/ui/Amplitude.tsx
@@ -3,41 +3,37 @@
 import { useEffect } from 'react';
 
 const AMPLITUDE_API_KEY = process.env['NEXT_PUBLIC_AMPLITUDE_API_KEY'];
-const EXPERIMENT_DEPLOYMENT_KEY = process.env['NEXT_PUBLIC_AMPLITUDE_EXPERIMENT_DEPLOYMENT_KEY'];
+const EXTERNAL_AMPLITUDE_WAIT_MS = 1_500;
 
-/** Prevents double `init` on Strict Mode remount or duplicate script `load` handlers. */
-let amplitudeClientBooted = false;
+function getAmplitudeState() {
+	if (typeof window === 'undefined') return undefined;
+	window.__goodpartyAmplitude ??= { clientInitialized: false, scriptInjected: false };
+	return window.__goodpartyAmplitude;
+}
 
-function boot() {
+function markAmplitudeReady() {
+	window.dispatchEvent(new Event('experiment:ready'));
+}
+
+function adoptExternalAmplitude() {
+	const state = getAmplitudeState();
+	if (!state || state.clientInitialized) return;
+	state.clientInitialized = true;
+	markAmplitudeReady();
+}
+
+function bootAppAmplitude() {
 	if (typeof window === 'undefined' || !window.amplitude || !AMPLITUDE_API_KEY) return;
-	if (amplitudeClientBooted) return;
-	amplitudeClientBooted = true;
+	const state = getAmplitudeState();
+	if (!state || state.clientInitialized) return;
+	state.clientInitialized = true;
 
-	if (window.sessionReplay?.plugin) {
-		window.amplitude.add?.(window.sessionReplay.plugin({ sampleRate: 1 }));
-	}
 	window.amplitude.init(AMPLITUDE_API_KEY, {
 		fetchRemoteConfig: true,
 		autocapture: true,
 		transport: 'beacon',
 	});
-
-	if (EXPERIMENT_DEPLOYMENT_KEY) {
-		import('@amplitude/experiment-js-client')
-			.then(({ Experiment }) => {
-				const experiment = Experiment.initializeWithAmplitudeAnalytics(
-					EXPERIMENT_DEPLOYMENT_KEY,
-				);
-				window.experiment = experiment;
-				void experiment.fetch().finally(() => {
-					window.dispatchEvent(new Event('experiment:ready'));
-				});
-			})
-			.catch((err: unknown) => {
-				console.warn('[Amplitude] Experiment SDK failed to load', err);
-				window.dispatchEvent(new Event('experiment:ready'));
-			});
-	}
+	markAmplitudeReady();
 }
 
 function findInjectedAmplitudeScript(apiKey: string) {
@@ -45,28 +41,91 @@ function findInjectedAmplitudeScript(apiKey: string) {
 	return [...document.scripts].find((s) => s.src.endsWith(suffix));
 }
 
+/**
+ * When the script is already in the DOM (Strict Mode remount or cache), `load` may have
+ * fired before we attach a listener. Poll briefly after `load` + microtask/rAF.
+ */
+function whenAmplitudeScriptProvidesGlobal(
+	script: HTMLScriptElement,
+	onReady: () => void,
+): (() => void) | undefined {
+	const tryBoot = () => {
+		if (!window.amplitude) return false;
+		onReady();
+		return true;
+	};
+
+	if (tryBoot()) return undefined;
+
+	const run = () => {
+		void tryBoot();
+	};
+
+	script.addEventListener('load', run, { once: true });
+	script.addEventListener('error', run, { once: true });
+	void queueMicrotask(run);
+	requestAnimationFrame(run);
+
+	const started = performance.now();
+	const pollId = window.setInterval(() => {
+		if (tryBoot() || performance.now() - started > 10_000) {
+			window.clearInterval(pollId);
+		}
+	}, 100);
+
+	return () => {
+		window.clearInterval(pollId);
+	};
+}
+
 export function Amplitude() {
 	useEffect(() => {
 		if (!AMPLITUDE_API_KEY) return;
 
-		// GTM (or another tag) already loaded the Amplitude snippet — skip injecting a second script.
+		const state = getAmplitudeState();
+		if (!state) return;
+		let cancelled = false;
+		let stopWaitingForScript: (() => void) | undefined;
+
+		// Already initialized in this tab (HMR, duplicate layout, etc.)
+		if (state.clientInitialized) return;
+
+		// GTM/Segment may already own Amplitude. Do not re-init an externally-owned SDK.
 		if (window.amplitude) {
-			boot();
+			adoptExternalAmplitude();
 			return;
 		}
 
-		// Strict Mode runs effects twice before `window.amplitude` exists; reuse the first script tag.
-		const existing = findInjectedAmplitudeScript(AMPLITUDE_API_KEY);
-		if (existing) {
-			existing.addEventListener('load', boot, { once: true });
-			return;
-		}
+		const waitForExternalTags = window.setTimeout(() => {
+			if (cancelled || state.clientInitialized) return;
 
-		const script = document.createElement('script');
-		script.src = `https://cdn.amplitude.com/script/${AMPLITUDE_API_KEY}.js`;
-		script.async = true;
-		script.onload = boot;
-		document.head.appendChild(script);
+			if (window.amplitude) {
+				adoptExternalAmplitude();
+				return;
+			}
+
+			const existing = findInjectedAmplitudeScript(AMPLITUDE_API_KEY);
+			if (existing) {
+				stopWaitingForScript = whenAmplitudeScriptProvidesGlobal(
+					existing,
+					state.scriptInjected ? bootAppAmplitude : adoptExternalAmplitude,
+				);
+				return;
+			}
+
+			state.scriptInjected = true;
+			const script = document.createElement('script');
+			script.src = `https://cdn.amplitude.com/script/${AMPLITUDE_API_KEY}.js`;
+			script.async = true;
+			document.head.appendChild(script);
+			stopWaitingForScript = whenAmplitudeScriptProvidesGlobal(script, bootAppAmplitude);
+		}, EXTERNAL_AMPLITUDE_WAIT_MS);
+
+		return () => {
+			cancelled = true;
+			window.clearTimeout(waitForExternalTags);
+			stopWaitingForScript?.();
+		};
 	}, []);
 
 	return null;


### PR DESCRIPTION
- Introduced a global state object on the window to manage Amplitude client initialization and script injection status.
- Refactored the Amplitude component to prevent duplicate initializations and handle external script loading more effectively.
- Improved handling of script loading events and added polling for script readiness to ensure proper integration with existing setups.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes client-side analytics bootstrapping timing/ownership detection; regressions could lead to missing or double-tracked events if the new state/polling logic misbehaves in edge cases.
> 
> **Overview**
> Refactors `Amplitude` initialization to persist a global `window.__goodpartyAmplitude` state across HMR/Strict Mode and prevent duplicate `init` calls and duplicate script injection.
> 
> Adds a short wait period to allow external tag managers (e.g., GTM/Segment) to provide `window.amplitude`, and introduces more robust readiness detection for already-in-DOM scripts via microtask/rAF hooks plus polling before running `bootAppAmplitude` or adopting an external SDK.
> 
> Removes the in-component Amplitude Experiment SDK initialization path and instead consistently signals readiness via the `experiment:ready` event after Amplitude is initialized or adopted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 695c2c2daa8b6a650bf848a173669fcbcf72fb4d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->