### PR TITLE
Multiple Pages (Sanity CMS) + Multiple Experiments (Amplitude)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,7 @@ VERCEL_PROJECT_ID=
 NEXT_PUBLIC_SANITY_PROJECT_ID=
 NEXT_PUBLIC_SANITY_DATASET=
 SANITY_STUDIO_API_TOKEN=
+# Editor (write) token required for: bun run sanity:backfill:experiments
 # Shared secret for Sanity webhook to trigger on-demand cache revalidation (POST /api/revalidate)
 SANITY_REVALIDATE_SECRET=
 

--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,7 @@ NEXT_PUBLIC_SANITY_PROJECT_ID=
 NEXT_PUBLIC_SANITY_DATASET=
 SANITY_STUDIO_API_TOKEN=
 # Editor (write) token required for: bun run sanity:backfill:experiments
+# BACKFILL_STUCK_LOG_MS=5000
 # Shared secret for Sanity webhook to trigger on-demand cache revalidation (POST /api/revalidate)
 SANITY_REVALIDATE_SECRET=
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "sanity:dev": "sanity dev",
     "sanity:extract": "sanity schema extract",
     "sanity:generate": "sanity typegen generate",
+    "sanity:backfill:experiments": "bun run scripts/backfill-experiment-variant-fields.ts",
     "sanity:start": "sanity start",
     "sanity:build": "sanity build",
     "sanity:deploy": "sanity deploy",

--- a/schema.json
+++ b/schema.json
@@ -7828,6 +7828,13 @@
           },
           "optional": true
         },
+        "field_backCopy": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string"
+          },
+          "optional": true
+        },
         "ctaActionWithShared": {
           "type": "objectAttribute",
           "value": {
@@ -13681,6 +13688,176 @@
         "type": "objectAttribute",
         "value": {
           "type": "string"
+        },
+        "optional": true
+      },
+      "field_targetPages": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "array",
+          "of": {
+            "type": "union",
+            "of": [
+              {
+                "type": "object",
+                "attributes": {
+                  "_ref": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "_type": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "string",
+                      "value": "reference"
+                    }
+                  },
+                  "_weak": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "boolean"
+                    },
+                    "optional": true
+                  }
+                },
+                "dereferencesTo": "goodpartyOrg_home"
+              },
+              {
+                "type": "object",
+                "attributes": {
+                  "_ref": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "_type": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "string",
+                      "value": "reference"
+                    }
+                  },
+                  "_weak": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "boolean"
+                    },
+                    "optional": true
+                  }
+                },
+                "dereferencesTo": "goodpartyOrg_landingPages"
+              },
+              {
+                "type": "object",
+                "attributes": {
+                  "_ref": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "_type": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "string",
+                      "value": "reference"
+                    }
+                  },
+                  "_weak": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "boolean"
+                    },
+                    "optional": true
+                  }
+                },
+                "dereferencesTo": "goodpartyOrg_contact"
+              },
+              {
+                "type": "object",
+                "attributes": {
+                  "_ref": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "_type": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "string",
+                      "value": "reference"
+                    }
+                  },
+                  "_weak": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "boolean"
+                    },
+                    "optional": true
+                  }
+                },
+                "dereferencesTo": "goodpartyOrg_glossary"
+              },
+              {
+                "type": "object",
+                "attributes": {
+                  "_ref": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "_type": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "string",
+                      "value": "reference"
+                    }
+                  },
+                  "_weak": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "boolean"
+                    },
+                    "optional": true
+                  }
+                },
+                "dereferencesTo": "goodpartyOrg_allArticles"
+              }
+            ]
+          }
+        },
+        "optional": true
+      },
+      "field_status": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "union",
+          "of": [
+            {
+              "type": "string",
+              "value": "draft"
+            },
+            {
+              "type": "string",
+              "value": "running"
+            },
+            {
+              "type": "string",
+              "value": "ended"
+            }
+          ]
+        },
+        "optional": true
+      },
+      "field_priority": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "number"
         },
         "optional": true
       },

--- a/scripts/backfill-experiment-variant-fields.ts
+++ b/scripts/backfill-experiment-variant-fields.ts
@@ -1,0 +1,61 @@
+/**
+ * One-time backfill: set field_targetPages, field_status, field_priority on existing
+ * experiment_variant documents after schema deploy.
+ *
+ * Requires write token:
+ *   export SANITY_STUDIO_API_TOKEN="your-token-with-editor-permissions"
+ *
+ * Run:
+ *   bun run scripts/backfill-experiment-variant-fields.ts
+ */
+import { createClient } from '@sanity/client';
+
+const projectId = '3rbseux7';
+const dataset = 'production';
+const token = process.env['SANITY_STUDIO_API_TOKEN'];
+
+if (!token) {
+	console.error('Missing SANITY_STUDIO_API_TOKEN');
+	process.exit(1);
+}
+
+const client = createClient({
+	projectId,
+	dataset,
+	token,
+	apiVersion: '2025-09-25',
+	useCdn: false,
+});
+
+const homeRef = { _type: 'reference' as const, _ref: 'goodpartyOrg_home', _key: 'targetHome' };
+
+async function main() {
+	const patches: Array<{ id: string; set: Record<string, unknown> }> = [
+		{
+			id: '038be548-3011-43bc-acb9-e3e9df9bdd78',
+			set: {
+				field_targetPages: [homeRef],
+				field_status: 'running',
+				field_priority: 100,
+			},
+		},
+		{
+			id: '4c434b7b-5417-431f-a2c2-520046c29eb2',
+			set: {
+				field_targetPages: [homeRef],
+				field_status: 'draft',
+				field_priority: 200,
+			},
+		},
+	];
+
+	for (const { id, set } of patches) {
+		await client.patch(id).set(set).commit();
+		console.log('Patched', id);
+	}
+}
+
+main().catch((e) => {
+	console.error(e);
+	process.exit(1);
+});

--- a/scripts/backfill-experiment-variant-fields.ts
+++ b/scripts/backfill-experiment-variant-fields.ts
@@ -7,6 +7,9 @@
  *
  * Run:
  *   bun run scripts/backfill-experiment-variant-fields.ts
+ *
+ * Optional env:
+ *   BACKFILL_STUCK_LOG_MS — heartbeat interval while waiting on Sanity (default 5000)
  */
 import { createClient } from '@sanity/client';
 
@@ -19,17 +22,53 @@ if (!token) {
 	process.exit(1);
 }
 
+const REQUEST_TIMEOUT_MS = 60_000;
+const STUCK_LOG_MS = Math.max(
+	1000,
+	Number.parseInt(process.env['BACKFILL_STUCK_LOG_MS'] ?? '5000', 10) || 5000,
+);
+
+function log(...parts: unknown[]) {
+	console.error(new Date().toISOString(), '[backfill]', ...parts);
+}
+
+/** Logs every `intervalMs` until `promise` settles (so long hangs are visible). */
+function withStuckHeartbeat<T>(promise: Promise<T>, label: string, intervalMs: number): Promise<T> {
+	const started = Date.now();
+	const tick = setInterval(() => {
+		const s = Math.round((Date.now() - started) / 1000);
+		log(`still waiting on ${label} (${s}s elapsed) — if this repeats, check network, token, or Sanity status`);
+	}, intervalMs);
+
+	return promise.finally(() => {
+		clearInterval(tick);
+	});
+}
+
 const client = createClient({
 	projectId,
 	dataset,
 	token,
 	apiVersion: '2025-09-25',
 	useCdn: false,
+	fetch: (url, init) => {
+		const timeout = AbortSignal.timeout(REQUEST_TIMEOUT_MS);
+		const userSignal = init && 'signal' in init ? init.signal : undefined;
+		const signal =
+			userSignal && userSignal instanceof AbortSignal
+				? AbortSignal.any([userSignal, timeout])
+				: timeout;
+		return fetch(url, { ...init, signal });
+	},
 });
 
 const homeRef = { _type: 'reference' as const, _ref: 'goodpartyOrg_home', _key: 'targetHome' };
 
 async function main() {
+	log(
+		`start project=${projectId} dataset=${dataset} patches=2 httpTimeoutMs=${REQUEST_TIMEOUT_MS} stuckLogMs=${STUCK_LOG_MS}`,
+	);
+
 	const patches: Array<{ id: string; set: Record<string, unknown> }> = [
 		{
 			id: '038be548-3011-43bc-acb9-e3e9df9bdd78',
@@ -50,9 +89,16 @@ async function main() {
 	];
 
 	for (const { id, set } of patches) {
-		await client.patch(id).set(set).commit();
-		console.log('Patched', id);
+		log(`patch begin id=${id}`);
+		await withStuckHeartbeat(
+			client.patch(id).set(set).commit(),
+			`Sanity mutate id=${id}`,
+			STUCK_LOG_MS,
+		);
+		log(`patch ok id=${id}`);
 	}
+
+	log('done');
 }
 
 main().catch((e) => {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,13 +3,11 @@ import type { Params } from '~/lib/types';
 import { Suspense } from 'react';
 import { PageSections, type Sections } from '~/PageSections';
 import { sanityFetch } from '~/sanity/sanityClient';
-import { goodpartyOrg_homeQuery, experiment_variantsByExperimentIdQuery } from '~/sanity/groq';
+import { goodpartyOrg_homeQuery } from '~/sanity/groq';
 import { notFound } from 'next/navigation';
 import { StructureMetaData } from '~/components/StructureMetadata';
-import { resolveVariant } from '~/lib/experimentServer';
 import { ExperimentExposureTracker } from '~/experiments/ExperimentExposureTracker';
-
-const EXPERIMENT_FLAG_KEY = 'home_claude_layout_test';
+import { resolvePageExperiments } from '~/experiments/resolvePageExperiments';
 
 export default async function Page() {
 	const page = await sanityFetch({ query: goodpartyOrg_homeQuery, tags: ['goodpartyOrg_home'] });
@@ -22,37 +20,26 @@ export default async function Page() {
 
 	return (
 		<Suspense fallback={<PageSections pageSections={controlSections} />}>
-			<ExperimentResolver flagKey={EXPERIMENT_FLAG_KEY} controlSections={controlSections} />
+			<ExperimentResolver pageId={page._id} controlSections={controlSections} />
 		</Suspense>
 	);
 }
 
 async function ExperimentResolver(props: {
-	flagKey: string;
+	pageId: string;
 	controlSections?: Sections[] | null;
 }) {
-	const variant = await resolveVariant(props.flagKey);
-
-	if (!variant || variant === 'control' || variant === 'off') {
-		return <PageSections pageSections={props.controlSections} />;
-	}
-
-	const variantDocs = await sanityFetch({
-		query: experiment_variantsByExperimentIdQuery,
-		params: { experimentId: props.flagKey },
-		tags: ['experiment_variant'],
+	const result = await resolvePageExperiments({
+		pageId: props.pageId,
+		controlSections: props.controlSections,
 	});
-
-	const match = variantDocs?.find((d) => d.field_variantName === variant);
-
-	if (!match) {
-		return <PageSections pageSections={props.controlSections} />;
-	}
 
 	return (
 		<>
-			<ExperimentExposureTracker flagKey={props.flagKey} variant={variant} />
-			<PageSections pageSections={match.pageSections?.list_pageSections} />
+			{result.exposures.map((exp) => (
+				<ExperimentExposureTracker key={exp.flagKey} flagKey={exp.flagKey} variant={exp.variant} />
+			))}
+			<PageSections pageSections={result.pageSections} />
 		</>
 	);
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,7 +9,7 @@ import { StructureMetaData } from '~/components/StructureMetadata';
 import { resolveVariant } from '~/lib/experimentServer';
 import { ExperimentExposureTracker } from '~/experiments/ExperimentExposureTracker';
 
-const EXPERIMENT_FLAG_KEY = 'home_hero_layout_test';
+const EXPERIMENT_FLAG_KEY = 'home_claude_layout_test';
 
 export default async function Page() {
 	const page = await sanityFetch({ query: goodpartyOrg_homeQuery, tags: ['goodpartyOrg_home'] });
@@ -33,7 +33,7 @@ async function ExperimentResolver(props: {
 }) {
 	const variant = await resolveVariant(props.flagKey);
 
-	if (!variant || variant === 'control') {
+	if (!variant || variant === 'control' || variant === 'off') {
 		return <PageSections pageSections={props.controlSections} />;
 	}
 
@@ -57,7 +57,7 @@ async function ExperimentResolver(props: {
 	);
 }
 
-export async function generateMetadata(props: Params, parent: ResolvingMetadata) {
+export async function generateMetadata(_props: Params, parent: ResolvingMetadata) {
 	const parentMetadata = await parent;
 	const page = await sanityFetch({ query: goodpartyOrg_homeQuery, tags: ['goodpartyOrg_home'] });
 

--- a/src/experiments/pickResolvedPageExperiments.test.ts
+++ b/src/experiments/pickResolvedPageExperiments.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from 'bun:test';
+import type { Sections } from '~/PageSections';
+import { pickResolvedPageExperiments, type ActiveExperimentVariantRow } from './pickResolvedPageExperiments';
+
+const treatmentSections = [{ _key: 't1', _type: 'component_bannerBlock' }] as unknown as Sections[];
+
+function row(
+	experimentId: string,
+	variantName: string,
+	sections?: Sections[] | null,
+): ActiveExperimentVariantRow {
+	return {
+		field_experimentId: experimentId,
+		field_variantName: variantName,
+		pageSections: sections ? { list_pageSections: sections } : undefined,
+	};
+}
+
+describe('pickResolvedPageExperiments', () => {
+	test('returns control when variants empty', () => {
+		const control = [{ _key: 'c', _type: 'component_hero' }] as unknown as Sections[];
+		expect(pickResolvedPageExperiments([], {}, control)).toEqual({
+			pageSections: control,
+			exposures: [],
+		});
+	});
+
+	test('skips control assignment and uses next experiment', () => {
+		const control = [{ _key: 'c', _type: 'component_hero' }] as unknown as Sections[];
+		const variants = [
+			row('exp_a', 'treat', treatmentSections),
+			row('exp_b', 'v2', [{ _key: 'x', _type: 'component_statsBlock' }] as unknown as Sections[]),
+		];
+		const assignments = { exp_a: 'control', exp_b: 'v2' };
+		const r = pickResolvedPageExperiments(variants, assignments, control);
+		expect(r.exposures).toEqual([{ flagKey: 'exp_b', variant: 'v2' }]);
+		expect(r.pageSections).toEqual(variants[1].pageSections?.list_pageSections);
+	});
+
+	test('lower-priority experiment listed first still wins when first has no match', () => {
+		const control = [] as unknown as Sections[];
+		const variants = [
+			row('exp_high', 'missing', treatmentSections),
+			row('exp_low', 'on', treatmentSections),
+		];
+		const assignments = { exp_high: 'other', exp_low: 'on' };
+		const r = pickResolvedPageExperiments(variants, assignments, control);
+		expect(r.exposures).toEqual([{ flagKey: 'exp_low', variant: 'on' }]);
+	});
+
+	test('respects experiment order for same page (first matching flag in list order)', () => {
+		const control = [] as unknown as Sections[];
+		const a = treatmentSections;
+		const b = [{ _key: 'b', _type: 'component_statsBlock' }] as unknown as Sections[];
+		const variants = [row('first', 't1', a), row('second', 't2', b)];
+		const assignments = { first: 't1', second: 't2' };
+		const r = pickResolvedPageExperiments(variants, assignments, control);
+		expect(r.exposures).toEqual([{ flagKey: 'first', variant: 't1' }]);
+		expect(r.pageSections).toEqual(a);
+	});
+
+	test('skips off and null', () => {
+		const control = [{ _key: 'c', _type: 'component_hero' }] as unknown as Sections[];
+		const variants = [row('e1', 't', treatmentSections)];
+		expect(pickResolvedPageExperiments(variants, { e1: 'off' }, control).exposures).toEqual([]);
+		expect(pickResolvedPageExperiments(variants, { e1: null }, control).exposures).toEqual([]);
+	});
+});

--- a/src/experiments/pickResolvedPageExperiments.ts
+++ b/src/experiments/pickResolvedPageExperiments.ts
@@ -1,0 +1,65 @@
+import type { Sections } from '~/PageSections';
+
+export type PageExperimentExposure = {
+	flagKey: string;
+	variant: string;
+};
+
+export type ResolvedPageExperiments = {
+	pageSections: Sections[] | null | undefined;
+	exposures: PageExperimentExposure[];
+};
+
+/** Minimal row shape from activeVariantsByPageIdQuery (for tests and runtime). */
+export type ActiveExperimentVariantRow = {
+	field_experimentId: string | null;
+	field_variantName: string | null;
+	pageSections?: { list_pageSections?: Sections[] | null } | null;
+};
+
+/**
+ * Given running variant rows (already ordered by priority) and Amplitude assignments,
+ * returns the first applicable variant (full-page replacement, first match wins).
+ */
+export function pickResolvedPageExperiments(
+	variants: readonly ActiveExperimentVariantRow[],
+	assignments: Record<string, string | null>,
+	controlSections?: Sections[] | null,
+): ResolvedPageExperiments {
+	if (!variants.length) {
+		return { pageSections: controlSections, exposures: [] };
+	}
+
+	const seenIds = new Set<string>();
+	const orderedExperimentIds: string[] = [];
+	for (const v of variants) {
+		const id = v.field_experimentId;
+		if (id && !seenIds.has(id)) {
+			seenIds.add(id);
+			orderedExperimentIds.push(id);
+		}
+	}
+
+	for (const experimentId of orderedExperimentIds) {
+		const assignedVariant = assignments[experimentId];
+
+		if (!assignedVariant || assignedVariant === 'control' || assignedVariant === 'off') {
+			continue;
+		}
+
+		const match = variants.find(
+			(v) => v.field_experimentId === experimentId && v.field_variantName === assignedVariant,
+		);
+
+		if (!match?.pageSections?.list_pageSections) {
+			continue;
+		}
+
+		return {
+			pageSections: match.pageSections.list_pageSections,
+			exposures: [{ flagKey: experimentId, variant: assignedVariant }],
+		};
+	}
+
+	return { pageSections: controlSections, exposures: [] };
+}

--- a/src/experiments/resolvePageExperiments.ts
+++ b/src/experiments/resolvePageExperiments.ts
@@ -1,0 +1,48 @@
+import 'server-only';
+
+import type { Sections } from '~/PageSections';
+import { resolveVariants } from '~/lib/experimentServer';
+import {
+	type PageExperimentExposure,
+	type ResolvedPageExperiments,
+	pickResolvedPageExperiments,
+} from '~/experiments/pickResolvedPageExperiments';
+import { activeVariantsByPageIdQuery } from '~/sanity/groq';
+import { sanityFetch } from '~/sanity/sanityClient';
+
+export type { PageExperimentExposure, ResolvedPageExperiments };
+
+export async function resolvePageExperiments(args: {
+	pageId: string;
+	controlSections?: Sections[] | null;
+}): Promise<ResolvedPageExperiments> {
+	const { pageId, controlSections } = args;
+
+	try {
+		const variants = await sanityFetch({
+			query: activeVariantsByPageIdQuery,
+			params: { pageId },
+			tags: ['experiment_variant'],
+		});
+
+		if (!variants?.length) {
+			return { pageSections: controlSections, exposures: [] };
+		}
+
+		const seenIds = new Set<string>();
+		const orderedExperimentIds: string[] = [];
+		for (const v of variants) {
+			const id = v.field_experimentId;
+			if (id && !seenIds.has(id)) {
+				seenIds.add(id);
+				orderedExperimentIds.push(id);
+			}
+		}
+
+		const assignments = await resolveVariants(orderedExperimentIds);
+
+		return pickResolvedPageExperiments(variants, assignments, controlSections);
+	} catch {
+		return { pageSections: controlSections, exposures: [] };
+	}
+}

--- a/src/lib/experimentServer.ts
+++ b/src/lib/experimentServer.ts
@@ -1,5 +1,5 @@
 import 'server-only';
-import { Experiment } from '@amplitude/experiment-node-server';
+import { AmplitudeCookie, Experiment } from '@amplitude/experiment-node-server';
 import { cookies } from 'next/headers';
 
 const DEPLOYMENT_KEY = process.env['AMPLITUDE_EXPERIMENT_DEPLOYMENT_KEY'];
@@ -8,9 +8,7 @@ let clientPromise: ReturnType<typeof initClient> | null = null;
 
 async function initClient() {
 	if (!DEPLOYMENT_KEY) return null;
-	const client = Experiment.initializeLocal(DEPLOYMENT_KEY);
-	await client.start();
-	return client;
+	return Experiment.initializeRemote(DEPLOYMENT_KEY);
 }
 
 function getClient() {
@@ -29,13 +27,16 @@ export async function getAmplitudeDeviceId(): Promise<string | null> {
 	const raw = jar.get(cookieName)?.value;
 	if (!raw) return null;
 
+	// Next may URL-encode cookie values in Set-Cookie (e.g. '=' as '%3D'). Browsers usually
+	// send decoded values, but normalize so AmplitudeCookie.parse always receives raw base64.
+	let normalized = raw;
 	try {
-		const decoded = decodeURIComponent(raw);
-		const parsed = JSON.parse(decoded);
-		return typeof parsed.deviceId === 'string' ? parsed.deviceId : null;
+		normalized = decodeURIComponent(raw);
 	} catch {
-		return null;
+		normalized = raw;
 	}
+	const parsed = AmplitudeCookie.parse(normalized, true);
+	return parsed.device_id ?? null;
 }
 
 export async function resolveVariant(flagKey: string): Promise<string | null> {
@@ -46,8 +47,9 @@ export async function resolveVariant(flagKey: string): Promise<string | null> {
 		const deviceId = await getAmplitudeDeviceId();
 		if (!deviceId) return null;
 
-		const variants = client.evaluateV2({ device_id: deviceId }, [flagKey]);
-		return variants[flagKey]?.value ?? null;
+		const variants = await client.fetchV2({ device_id: deviceId }, { flagKeys: [flagKey] });
+		const variant = variants[flagKey];
+		return variant?.value ?? variant?.key ?? null;
 	} catch {
 		return null;
 	}

--- a/src/lib/experimentServer.ts
+++ b/src/lib/experimentServer.ts
@@ -39,18 +39,31 @@ export async function getAmplitudeDeviceId(): Promise<string | null> {
 	return parsed.device_id ?? null;
 }
 
-export async function resolveVariant(flagKey: string): Promise<string | null> {
+export async function resolveVariants(flagKeys: string[]): Promise<Record<string, string | null>> {
 	try {
 		const client = await getClient();
-		if (!client) return null;
+		if (!client) return {};
 
 		const deviceId = await getAmplitudeDeviceId();
-		if (!deviceId) return null;
+		if (!deviceId) return {};
 
-		const variants = await client.fetchV2({ device_id: deviceId }, { flagKeys: [flagKey] });
-		const variant = variants[flagKey];
-		return variant?.value ?? variant?.key ?? null;
+		const uniqueKeys = [...new Set(flagKeys)].filter(Boolean);
+		if (uniqueKeys.length === 0) return {};
+
+		const variants = await client.fetchV2({ device_id: deviceId }, { flagKeys: uniqueKeys });
+
+		return Object.fromEntries(
+			uniqueKeys.map((key) => {
+				const v = variants[key];
+				return [key, v?.value ?? v?.key ?? null];
+			}),
+		) as Record<string, string | null>;
 	} catch {
-		return null;
+		return {};
 	}
+}
+
+export async function resolveVariant(flagKey: string): Promise<string | null> {
+	const result = await resolveVariants([flagKey]);
+	return result[flagKey] ?? null;
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -6,6 +6,66 @@ function normalizePath(path: string): string {
 	return path.endsWith('/') && path.length > 1 ? path.slice(0, -1) : path;
 }
 
+/**
+ * Browser SDK 2.0 cookie name. Must match {@link AmplitudeCookie.cookieName} in
+ * `@amplitude/experiment-node-server` (newFormat: true).
+ */
+function amplitudeBrowserSdk20CookieName(apiKey: string): string | null {
+	if (apiKey.length < 10) return null;
+	return `AMP_${apiKey.substring(0, 10)}`;
+}
+
+/**
+ * Browser SDK 2.0 cookie value. Must match {@link AmplitudeCookie.generate} in
+ * `@amplitude/experiment-node-server` (newFormat: true), without Node `Buffer`.
+ */
+function encodeAmplitudeBrowserSdk20Cookie(deviceId: string): string {
+	const json = JSON.stringify({ deviceId });
+	const encoded = encodeURIComponent(json);
+	return btoa(encoded);
+}
+
+/**
+ * First-time visitors have no `AMP_*` cookie yet, so SSR cannot bucket them.
+ * Bootstrap the same cookie shape the Browser SDK uses, forward it on this
+ * request, and set it on the response so the client keeps the same device id.
+ */
+function maybeBootstrapAmplitudeDeviceCookie(
+	request: NextRequest,
+	pathname: string,
+): NextResponse | null {
+	if (pathname !== '/') return null;
+
+	const apiKey = process.env['NEXT_PUBLIC_AMPLITUDE_API_KEY'];
+	const cookieName = apiKey ? amplitudeBrowserSdk20CookieName(apiKey) : null;
+	if (!cookieName) return null;
+
+	if (request.cookies.get(cookieName)?.value) return null;
+
+	const deviceId = crypto.randomUUID();
+	const cookieValue = encodeAmplitudeBrowserSdk20Cookie(deviceId);
+
+	const requestHeaders = new Headers(request.headers);
+	const preceding = requestHeaders.get('cookie');
+	requestHeaders.set(
+		'cookie',
+		preceding ? `${preceding}; ${cookieName}=${cookieValue}` : `${cookieName}=${cookieValue}`,
+	);
+
+	const response = NextResponse.next({
+		request: { headers: requestHeaders },
+	});
+
+	response.cookies.set(cookieName, cookieValue, {
+		path: '/',
+		maxAge: 365 * 24 * 60 * 60,
+		sameSite: 'lax',
+		secure: request.nextUrl.protocol === 'https:',
+	});
+
+	return response;
+}
+
 export async function middleware(request: NextRequest): Promise<NextResponse | undefined> {
 	const origin = request.nextUrl.origin;
 
@@ -28,6 +88,9 @@ export async function middleware(request: NextRequest): Promise<NextResponse | u
 
 		return NextResponse.redirect(destination, match.permanent ? 308 : 307);
 	}
+
+	const bootstrapped = maybeBootstrapAmplitudeDeviceCookie(request, pathname);
+	if (bootstrapped) return bootstrapped;
 
 	return undefined;
 }

--- a/src/sanity/groq.ts
+++ b/src/sanity/groq.ts
@@ -177,6 +177,23 @@ export const goodpartyOrg_homeQuery = defineQuery(
 export const experiment_variantsByExperimentIdQuery = defineQuery(
 	`*[_type == "experiment_variant" && field_experimentId == $experimentId]{field_variantName,pageSections{...,list_pageSections[]{${sectionsGroq}}}}`,
 );
+/*language=textmate*/
+export const activeVariantsByPageIdQuery = defineQuery(`
+  *[
+    _type == "experiment_variant" &&
+    $pageId in field_targetPages[]._ref &&
+    field_status == "running"
+  ] | order(field_priority asc, _id asc) {
+    _id,
+    field_experimentId,
+    field_variantName,
+    field_priority,
+    pageSections{
+      ...,
+      list_pageSections[]{${sectionsGroq}}
+    }
+  }
+`);
 
 /*language=textmate*/
 export const goodpartyOrg_allArticlesQuery = defineQuery(

--- a/src/sanity/schema/documents/experiment_variant.ts
+++ b/src/sanity/schema/documents/experiment_variant.ts
@@ -25,6 +25,54 @@ export const experiment_variant = {
       group: 'experimentSettings',
     },
     {
+      title: 'Target Pages',
+      name: 'field_targetPages',
+      type: 'array',
+      of: [
+        {
+          type: 'reference',
+          to: [
+            { type: 'goodpartyOrg_home' },
+            { type: 'goodpartyOrg_landingPages' },
+            { type: 'goodpartyOrg_contact' },
+            { type: 'goodpartyOrg_glossary' },
+            { type: 'goodpartyOrg_allArticles' },
+          ],
+        },
+      ],
+      description:
+        'Pages where this experiment variant is active. Uses references to prevent typos.',
+      validation: (Rule: any) => Rule.required().min(1),
+      group: 'experimentSettings',
+    },
+    {
+      title: 'Status',
+      name: 'field_status',
+      type: 'string',
+      initialValue: 'draft',
+      options: {
+        list: [
+          { title: 'Draft', value: 'draft' },
+          { title: 'Running', value: 'running' },
+          { title: 'Ended', value: 'ended' },
+        ],
+        layout: 'radio',
+      },
+      description: 'Only Running experiments are resolved at runtime.',
+      validation: (Rule: any) => Rule.required(),
+      group: 'experimentSettings',
+    },
+    {
+      title: 'Priority',
+      name: 'field_priority',
+      type: 'number',
+      initialValue: 100,
+      description:
+        'Lower numbers take precedence. When multiple experiments target the same page, the lowest priority number wins.',
+      validation: (Rule: any) => Rule.required().integer().min(1).max(999),
+      group: 'experimentSettings',
+    },
+    {
       title: 'Page Sections',
       name: 'pageSections',
       type: 'pageSections',


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only adds a new `bun` script alias and documents optional env vars in `.env.example`, with no runtime code-path changes.
> 
> **Overview**
> Adds a new `sanity:backfill:experiments` package script to run `scripts/backfill-experiment-variant-fields.ts` for one-time Sanity experiment-variant backfills.
> 
> Updates `.env.example` with notes about needing an editor/write token and an optional `BACKFILL_STUCK_LOG_MS` setting when running the backfill.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f85a4986d8a70fd6604d55f6d4d55165d21a027. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->