### PR TITLE
Updated testimonial branch

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -16,7 +16,10 @@
       "PowerShell(.\\\\scripts\\\\install-bun.ps1)",
       "Bash(\"/c/Users/jack/.bun/bin/bun\" run *)",
       "Bash(echo \"Started with PID: $!\")",
-      "Bash(\"/c/Users/jack/.bun/bin/bun\" install *)"
+      "Bash(\"/c/Users/jack/.bun/bin/bun\" install *)",
+      "mcp__Amplitude__get_context",
+      "mcp__Amplitude__create_experiment",
+      "mcp__Amplitude__create_flags"
     ]
   }
 }

--- a/src/PageSections/TestimonialAutoScrollSection.tsx
+++ b/src/PageSections/TestimonialAutoScrollSection.tsx
@@ -1,0 +1,37 @@
+import { stegaClean } from 'next-sanity';
+
+import type { Sections } from '~/PageSections';
+import { transformButtons, type ButtonType } from '~/lib/buttonTransformer';
+import { resolveBg } from '~/ui/_lib/resolveBg';
+import { resolveTestimonials } from '~/ui/_lib/resolveTestimonials';
+import { resolveTextSize } from '~/ui/_lib/resolveTextSize';
+import { RichData } from '~/ui/RichData';
+import { TestimonialsAutoScroll } from '~/ui/TestimonialsAutoScroll';
+
+// Shares the same fields as component_testimonialBlock — run `bun run sanity:generate` to get a generated type.
+type TestimonialAutoScrollSection = Omit<Extract<Sections, { _type: 'component_testimonialBlock' }>, '_type'> & {
+	_type: 'component_testimonialAutoScroll';
+};
+
+export function TestimonialAutoScrollSection(section: TestimonialAutoScrollSection) {
+	const backgroundColor = section.testimonialBlockDesignSettings?.field_blockColorCreamMidnight
+		? resolveBg(section.testimonialBlockDesignSettings.field_blockColorCreamMidnight)
+		: 'cream';
+
+	return (
+		<section id={stegaClean(section.componentSettings?.field_anchorId)} data-section='Testimonials Auto Scroll'>
+			<TestimonialsAutoScroll
+				backgroundColor={backgroundColor}
+				header={{
+					title: section.summaryInfo?.field_title,
+					label: section.summaryInfo?.field_label,
+					caption: section.summaryInfo?.field_caption,
+					copy: <RichData value={section.summaryInfo?.block_summaryText} />,
+					buttons: transformButtons(section.summaryInfo?.list_buttons as unknown as ButtonType[]),
+					textSize: resolveTextSize(section.summaryInfo?.field_textSize),
+				}}
+				cards={resolveTestimonials(section.quotesContentCollection)}
+			/>
+		</section>
+	);
+}

--- a/src/PageSections/index.tsx
+++ b/src/PageSections/index.tsx
@@ -42,6 +42,7 @@ import { ProfileContentBlockSection } from '~/PageSections/ProfileContentBlockSe
 import { ListOfOfficesBlockSection } from '~/PageSections/ListOfOfficesBlockSection';
 import { EmbeddedBlockSection } from '~/PageSections/EmbeddedBlockSection';
 import { TeamValuesBlockSection } from '~/PageSections/TeamValuesBlockSection';
+import { TestimonialAutoScrollSection } from '~/PageSections/TestimonialAutoScrollSection';
 import { ComponentErrorBoundary } from '~/ui/ComponentErrorBoundary';
 
 export type Sections = NonNullable<NonNullable<NonNullable<GoodpartyOrg_homeQueryResult>['pageSections']>['list_pageSections']>[number];
@@ -361,6 +362,13 @@ export function PageSections(props: Props) {
 					return (
 						<ComponentErrorBoundary key={section._key} componentName='Team Values Block'>
 							<TeamValuesBlockSection {...section} />
+						</ComponentErrorBoundary>
+					);
+				// @ts-expect-error — run `bun run sanity:generate` to add component_testimonialAutoScroll to the Sections union
+				case 'component_testimonialAutoScroll':
+					return (
+						<ComponentErrorBoundary key={section._key} componentName='Testimonials Auto Scroll'>
+							<TestimonialAutoScrollSection {...(section as any)} />
 						</ComponentErrorBoundary>
 					);
 				default:

--- a/src/sanity/schema/components/componentSchema.ts
+++ b/src/sanity/schema/components/componentSchema.ts
@@ -40,6 +40,7 @@ import {component_profileContentBlock} from './component_profileContentBlock.ts'
 import {component_listOfOfficesBlock} from './component_listOfOfficesBlock.ts'
 import {component_embeddedBlock} from './component_embeddedBlock.ts'
 import {component_teamValuesBlock} from './component_teamValuesBlock.ts'
+import {component_testimonialAutoScroll} from './component_testimonialAutoScroll.ts'
 
 export const componentSchema = [
 	component_jobOpeningsBlock,
@@ -83,5 +84,6 @@ export const componentSchema = [
 	component_profileContentBlock,
 	component_listOfOfficesBlock,
 	component_embeddedBlock,
-	component_teamValuesBlock
+	component_teamValuesBlock,
+	component_testimonialAutoScroll,
 ];

--- a/src/sanity/schema/components/component_testimonialAutoScroll.ts
+++ b/src/sanity/schema/components/component_testimonialAutoScroll.ts
@@ -1,0 +1,84 @@
+import {resolveValue} from "../../utils/resolveValue.ts";
+import {handleReplacements} from "../../utils/handleReplacements.ts";
+import {getIcon} from "../../utils/getIcon.tsx";
+
+export const component_testimonialAutoScroll = {
+  title: 'Testimonials Auto Scroll',
+  name: 'component_testimonialAutoScroll',
+  description: 'An infinite auto-scrolling marquee of testimonial quotes.',
+  type: 'object',
+  icon: getIcon('Quotes'),
+  fields: [
+    {
+      title: 'Text',
+      name: 'summaryInfo',
+      type: 'summaryInfo',
+      group: 'summaryInfo',
+    },
+    {
+      title: 'Content',
+      name: 'quotesContentCollection',
+      type: 'quotesContentCollection',
+      group: 'quotesContentCollection',
+    },
+    {
+      title: 'Design Settings',
+      name: 'testimonialBlockDesignSettings',
+      type: 'testimonialBlockDesignSettings',
+      group: 'testimonialBlockDesignSettings',
+    },
+    {
+      title: 'Settings',
+      name: 'componentSettings',
+      type: 'componentSettings',
+      group: 'componentSettings',
+    },
+  ],
+  preview: {
+    select: {
+      title: 'summaryInfo.field_title',
+      _type: '_type',
+    },
+    prepare: x => {
+      const infer = {
+        singletonTitle: null,
+        icon: getIcon('TextFont'),
+        fallback: {
+          previewTitle: 'summaryInfo.field_title',
+          previewSubTitle: '*Testimonials Auto Scroll',
+          title: 'Testimonials Auto Scroll',
+        },
+      }
+      const title = resolveValue("title", component_testimonialAutoScroll.preview.select, x);
+      const subtitle = resolveValue("subtitle", component_testimonialAutoScroll.preview.select, x);
+      const media = resolveValue("media", component_testimonialAutoScroll.preview.select, x);
+      return handleReplacements({
+        title: infer.singletonTitle || title || undefined,
+        subtitle: subtitle ? subtitle : infer.fallback["title"],
+        media: media || infer.icon
+      }, x, infer.fallback);
+    },
+  },
+  groups: [
+    {
+      title: 'Text',
+      name: 'summaryInfo',
+      icon: getIcon('TextFont'),
+    },
+    {
+      title: 'Content',
+      name: 'quotesContentCollection',
+      icon: getIcon('Grid'),
+    },
+    {
+      title: 'Design Settings',
+      name: 'testimonialBlockDesignSettings',
+      icon: getIcon('ColorPalette'),
+    },
+    {
+      title: 'Settings',
+      name: 'componentSettings',
+      icon: getIcon('Settings'),
+    },
+  ],
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces a new CMS-driven page section type and wires it into the runtime section renderer, including `any` casting/`@ts-expect-error` until Sanity types are regenerated, which could hide schema/type mismatches.
> 
> **Overview**
> Adds a new Sanity component and page section for **auto-scrolling testimonials** (`component_testimonialAutoScroll`), reusing the existing testimonial block fields (text, quote collection, design settings, anchor settings).
> 
> Wires the new section type into `PageSections` via `TestimonialAutoScrollSection`, which renders `TestimonialsAutoScroll` with resolved background color, header content/buttons, and testimonial cards.
> 
> Also updates local Claude settings to allow additional Amplitude MCP commands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05ee0815e34297a0c9b4bfde660ed898e0744e07. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->