### PR TITLE
Refactor experiment handling and add ExperimentResolver component

### DIFF
--- a/src/app/[slug]/page.tsx
+++ b/src/app/[slug]/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata, ResolvingMetadata } from 'next';
+import { Suspense } from 'react';
 import { notFound } from 'next/navigation';
 import { goodpartyOrg_landingPagesAndPolicyQuery } from '~/sanity/groq';
 import { sanityFetch } from '~/sanity/sanityClient';
@@ -7,10 +8,10 @@ import { StructureMetaData } from '~/components/StructureMetadata';
 import type { Params } from '~/lib/types';
 import { RichTextContentSections } from '~/RichTextContentSections';
 import { PageSections } from '~/PageSections';
+import { ExperimentResolver } from '~/experiments/ExperimentResolver';
 import { HeaderBlock } from '~/ui/HeaderBlock';
 import { Container } from '~/ui/Container';
 import { client } from '~/lib/client';
-import { resolveTextSize } from '~/ui/_lib/resolveTextSize';
 
 export async function generateStaticParams() {
 	const entries = await client.fetch<Array<string>>(
@@ -36,7 +37,12 @@ export default async function Page(props: any) {
 	}
 
 	if (page._type === 'goodpartyOrg_landingPages') {
-		return <PageSections pageSections={page.pageSections?.list_pageSections} />;
+		const controlSections = page.pageSections?.list_pageSections;
+		return (
+			<Suspense fallback={<PageSections pageSections={controlSections} />}>
+				<ExperimentResolver pageId={page._id} controlSections={controlSections} />
+			</Suspense>
+		);
 	}
 	if (page._type === 'policy') {
 		return (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,13 +1,12 @@
 import type { ResolvingMetadata } from 'next';
 import type { Params } from '~/lib/types';
 import { Suspense } from 'react';
-import { PageSections, type Sections } from '~/PageSections';
+import { PageSections } from '~/PageSections';
 import { sanityFetch } from '~/sanity/sanityClient';
 import { goodpartyOrg_homeQuery } from '~/sanity/groq';
 import { notFound } from 'next/navigation';
 import { StructureMetaData } from '~/components/StructureMetadata';
-import { ExperimentExposureTracker } from '~/experiments/ExperimentExposureTracker';
-import { resolvePageExperiments } from '~/experiments/resolvePageExperiments';
+import { ExperimentResolver } from '~/experiments/ExperimentResolver';
 
 export default async function Page() {
 	const page = await sanityFetch({ query: goodpartyOrg_homeQuery, tags: ['goodpartyOrg_home'] });
@@ -22,25 +21,6 @@ export default async function Page() {
 		<Suspense fallback={<PageSections pageSections={controlSections} />}>
 			<ExperimentResolver pageId={page._id} controlSections={controlSections} />
 		</Suspense>
-	);
-}
-
-async function ExperimentResolver(props: {
-	pageId: string;
-	controlSections?: Sections[] | null;
-}) {
-	const result = await resolvePageExperiments({
-		pageId: props.pageId,
-		controlSections: props.controlSections,
-	});
-
-	return (
-		<>
-			{result.exposures.map((exp) => (
-				<ExperimentExposureTracker key={exp.flagKey} flagKey={exp.flagKey} variant={exp.variant} />
-			))}
-			<PageSections pageSections={result.pageSections} />
-		</>
 	);
 }
 

--- a/src/experiments/ExperimentExposureTracker.tsx
+++ b/src/experiments/ExperimentExposureTracker.tsx
@@ -12,6 +12,9 @@ export function ExperimentExposureTracker(props: {
 	useEffect(() => {
 		if (tracked.current) return;
 		tracked.current = true;
+
+		window.experiment?.exposure(props.flagKey);
+
 		trackEvent('Experiment Viewed', {
 			flag_key: props.flagKey,
 			variant: props.variant,

--- a/src/experiments/ExperimentResolver.tsx
+++ b/src/experiments/ExperimentResolver.tsx
@@ -1,0 +1,24 @@
+import type { Sections } from '~/PageSections';
+import { PageSections, type SectionOverrides } from '~/PageSections';
+import { ExperimentExposureTracker } from '~/experiments/ExperimentExposureTracker';
+import { resolvePageExperiments } from '~/experiments/resolvePageExperiments';
+
+export async function ExperimentResolver(props: {
+	pageId: string;
+	controlSections?: Sections[] | null;
+	sectionOverrides?: SectionOverrides;
+}) {
+	const result = await resolvePageExperiments({
+		pageId: props.pageId,
+		controlSections: props.controlSections,
+	});
+
+	return (
+		<>
+			{result.exposures.map((exp) => (
+				<ExperimentExposureTracker key={exp.flagKey} flagKey={exp.flagKey} variant={exp.variant} />
+			))}
+			<PageSections pageSections={result.pageSections} sectionOverrides={props.sectionOverrides} />
+		</>
+	);
+}

--- a/src/experiments/pickResolvedPageExperiments.test.ts
+++ b/src/experiments/pickResolvedPageExperiments.test.ts
@@ -25,7 +25,7 @@ describe('pickResolvedPageExperiments', () => {
 		});
 	});
 
-	test('skips control assignment and uses next experiment', () => {
+	test('control assignment returns control sections with exposure tracked', () => {
 		const control = [{ _key: 'c', _type: 'component_hero' }] as unknown as Sections[];
 		const variants = [
 			row('exp_a', 'treat', treatmentSections),
@@ -33,8 +33,8 @@ describe('pickResolvedPageExperiments', () => {
 		];
 		const assignments = { exp_a: 'control', exp_b: 'v2' };
 		const r = pickResolvedPageExperiments(variants, assignments, control);
-		expect(r.exposures).toEqual([{ flagKey: 'exp_b', variant: 'v2' }]);
-		expect(r.pageSections).toEqual(variants[1].pageSections?.list_pageSections);
+		expect(r.exposures).toEqual([{ flagKey: 'exp_a', variant: 'control' }]);
+		expect(r.pageSections).toEqual(control);
 	});
 
 	test('lower-priority experiment listed first still wins when first has no match', () => {
@@ -59,10 +59,18 @@ describe('pickResolvedPageExperiments', () => {
 		expect(r.pageSections).toEqual(a);
 	});
 
-	test('skips off and null', () => {
+	test('skips off and null (no exposure tracked)', () => {
 		const control = [{ _key: 'c', _type: 'component_hero' }] as unknown as Sections[];
 		const variants = [row('e1', 't', treatmentSections)];
 		expect(pickResolvedPageExperiments(variants, { e1: 'off' }, control).exposures).toEqual([]);
 		expect(pickResolvedPageExperiments(variants, { e1: null }, control).exposures).toEqual([]);
+	});
+
+	test('control tracks exposure but off does not', () => {
+		const control = [{ _key: 'c', _type: 'component_hero' }] as unknown as Sections[];
+		const variants = [row('e1', 't', treatmentSections)];
+		const r = pickResolvedPageExperiments(variants, { e1: 'control' }, control);
+		expect(r.exposures).toEqual([{ flagKey: 'e1', variant: 'control' }]);
+		expect(r.pageSections).toEqual(control);
 	});
 });

--- a/src/experiments/pickResolvedPageExperiments.ts
+++ b/src/experiments/pickResolvedPageExperiments.ts
@@ -43,8 +43,15 @@ export function pickResolvedPageExperiments(
 	for (const experimentId of orderedExperimentIds) {
 		const assignedVariant = assignments[experimentId];
 
-		if (!assignedVariant || assignedVariant === 'control' || assignedVariant === 'off') {
+		if (!assignedVariant || assignedVariant === 'off') {
 			continue;
+		}
+
+		if (assignedVariant === 'control') {
+			return {
+				pageSections: controlSections,
+				exposures: [{ flagKey: experimentId, variant: 'control' }],
+			};
 		}
 
 		const match = variants.find(

--- a/src/sanity/schema/lists/list_pageSections.ts
+++ b/src/sanity/schema/lists/list_pageSections.ts
@@ -77,6 +77,7 @@ export const list_pageSections = {
             'component_twoUpCardBlock',
             'component_carouselBlock',
             'component_testimonialBlock',
+            'component_testimonialAutoScroll',
           ],
         },
         {
@@ -326,6 +327,10 @@ export const list_pageSections = {
     {
       title: 'Team Values Block',
       type: 'component_teamValuesBlock',
+    },
+    {
+      title: 'Testimonials Auto Scroll',
+      type: 'component_testimonialAutoScroll',
     },
   ],
 }

--- a/src/ui/Amplitude.tsx
+++ b/src/ui/Amplitude.tsx
@@ -37,7 +37,7 @@ function bootAppAmplitude() {
 	state.clientInitialized = true;
 
 	window.amplitude.init(AMPLITUDE_API_KEY, {
-		fetchRemoteConfig: true,
+		fetchRemoteConfig: false,
 		autocapture: true,
 		transport: 'beacon',
 	});


### PR DESCRIPTION
- Replaced the inline ExperimentResolver function in `page.tsx` with a dedicated `ExperimentResolver` component for better code organization.
- Updated the `ExperimentExposureTracker` to track exposure when the experiment is viewed.
- Modified the logic in `pickResolvedPageExperiments` to ensure control sections are returned with exposure tracking.
- Added a new component type `component_testimonialAutoScroll` to the Sanity schema for testimonials.
- Adjusted Amplitude initialization to disable remote config fetching.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes experiment resolution and exposure tracking for key marketing pages, which can affect what content renders and how analytics/experiment attribution is recorded. Also tweaks Amplitude initialization behavior and extends the Sanity page-sections schema, both of which can impact production telemetry and CMS-driven rendering.
> 
> **Overview**
> Refactors page-level experimentation by introducing a shared server `ExperimentResolver` component and using it (via `Suspense` fallback to control sections) on both the home page and slug-based landing pages.
> 
> Updates experiment attribution: `pickResolvedPageExperiments` now treats an assigned `control` variant as a first-class result (returns control sections *and* records an exposure), and `ExperimentExposureTracker` now calls `window.experiment?.exposure()` in addition to the existing analytics event.
> 
> Extends CMS capabilities by adding `component_testimonialAutoScroll` to the Sanity `list_pageSections` schema, and disables Amplitude `fetchRemoteConfig` during SDK init.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e83c7c9282a1e726b130dd854a0bab084a67d7bd. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->