### PR TITLE
Release: develop -> master

### DIFF
--- a/src/app/[slug]/page.tsx
+++ b/src/app/[slug]/page.tsx
@@ -11,22 +11,16 @@ import { PageSections } from '~/PageSections';
 import { ExperimentResolver } from '~/experiments/ExperimentResolver';
 import { HeaderBlock } from '~/ui/HeaderBlock';
 import { Container } from '~/ui/Container';
-import { client } from '~/lib/client';
-
-export async function generateStaticParams() {
-	const entries = await client.fetch<Array<string>>(
-		'*[_type in ["goodpartyOrg_landingPages","policy"]]{"slug": select(_type == "goodpartyOrg_landingPages" => detailPageOverviewNoHero.field_slug,_type == "policy" => policyOverview.field_slug)}.slug',
-	);
-	return entries.filter(Boolean).map(entry => ({
-		slug: entry,
-	}));
-}
 
 // SSR per request so ExperimentResolver reads the visitor's AMP_* cookie and
 // resolves the variant on the server before HTML is sent (no client flicker).
-// Without this, generateStaticParams above would prerender these routes at
-// build time without any cookie, so no exposure event would ever fire.
+// `generateStaticParams` is intentionally omitted: it is a build-time API for
+// static generation and the Next.js docs only sanction combining it with
+// `force-static`. Pairing it with `force-dynamic` is contradictory and causes
+// dev/prod render differences. Unknown slugs are handled by `notFound()` below
+// and the sitemap enumerates landing pages via `src/lib/sitemap-entries.ts`.
 export const dynamic = 'force-dynamic';
+
 export default async function Page(props: any) {
 	const slug = (await props.params)['slug'];
 

--- a/src/app/[slug]/page.tsx
+++ b/src/app/[slug]/page.tsx
@@ -21,6 +21,12 @@ export async function generateStaticParams() {
 		slug: entry,
 	}));
 }
+
+// SSR per request so ExperimentResolver reads the visitor's AMP_* cookie and
+// resolves the variant on the server before HTML is sent (no client flicker).
+// Without this, generateStaticParams above would prerender these routes at
+// build time without any cookie, so no exposure event would ever fire.
+export const dynamic = 'force-dynamic';
 export default async function Page(props: any) {
 	const slug = (await props.params)['slug'];
 

--- a/src/app/[slug]/page.tsx
+++ b/src/app/[slug]/page.tsx
@@ -49,7 +49,11 @@ export default async function Page(props: any) {
 			<Container className='bg-goodparty-cream py-(--container-padding) flex flex-col gap-12' size='xl'>
 				<HeaderBlock
 					title={page.policyOverview?.field_policyName}
-					copy={`${page.policyOverview?.field_policySummary}${page.policyOverview?.field_lastUpdated && ` | ${new Date(page.policyOverview.field_lastUpdated).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}`}`}
+					copy={`${page.policyOverview?.field_policySummary ?? ''}${
+						page.policyOverview?.field_lastUpdated
+							? ` | ${new Date(page.policyOverview.field_lastUpdated).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}`
+							: ''
+					}`}
 				/>
 				<RichTextContentSections contentSections={page.policySections?.block_policyText as any} />
 			</Container>

--- a/src/app/api/revalidate/route.ts
+++ b/src/app/api/revalidate/route.ts
@@ -3,6 +3,7 @@ import { revalidatePath, revalidateTag } from 'next/cache';
 import { type NextRequest, NextResponse } from 'next/server';
 import { parseBody } from 'next-sanity/webhook';
 import { revalidateSecret } from '~/lib/env';
+import { sanityClient } from '~/sanity/sanityClient';
 
 const CUSTOM_SECRET_HEADER = 'x-sanity-webhook-secret';
 const HMAC_KEY = 'safeCompare';
@@ -73,6 +74,68 @@ function getPathsToRevalidate(_type: string, payload: Record<string, unknown>): 
 	return ['/'];
 }
 
+/**
+ * Map a referenced "target page" document to the public route that renders it.
+ * Mirrors the routes in `src/app/**` that mount each singleton/landing-page type.
+ */
+function targetPageToRoute(target: {
+	_type?: string;
+	slug?: string | null;
+}): string | null {
+	switch (target._type) {
+		case 'goodpartyOrg_home':
+			return '/';
+		case 'goodpartyOrg_landingPages':
+			return target.slug ? `/${target.slug}` : null;
+		case 'goodpartyOrg_contact':
+			return '/contact';
+		case 'goodpartyOrg_glossary':
+			return '/political-terms';
+		case 'goodpartyOrg_allArticles':
+			return '/blog';
+		default:
+			return null;
+	}
+}
+
+/**
+ * Resolve the public routes affected by an experiment_variant change.
+ *
+ * The webhook payload only carries unresolved `_ref`s, so we round-trip to
+ * Sanity to dereference `field_targetPages[]` into a `{_type, slug}` shape we
+ * can map onto our App Router routes. Without this, publishing a variant only
+ * busts `/` regardless of which landing page it actually targets, leaving
+ * targeted pages stuck on stale cached HTML.
+ */
+async function resolveExperimentVariantPaths(
+	payload: Record<string, unknown>,
+): Promise<string[]> {
+	const id = typeof payload['_id'] === 'string' ? (payload['_id'] as string) : null;
+	if (!id) return ['/'];
+
+	type TargetRow = { _type?: string; slug?: string | null };
+	const publishedId = id.startsWith('drafts.') ? id.slice('drafts.'.length) : id;
+
+	try {
+		const targets = await sanityClient.fetch<TargetRow[]>(
+			`*[_id == $id || _id == $publishedId][0].field_targetPages[]->{
+				_type,
+				"slug": detailPageOverviewNoHero.field_slug
+			}`,
+			{ id, publishedId },
+		);
+
+		const routes = (targets ?? [])
+			.map(targetPageToRoute)
+			.filter((route): route is string => Boolean(route));
+
+		return routes.length > 0 ? Array.from(new Set(routes)) : ['/'];
+	} catch (err) {
+		console.error('Failed to resolve experiment_variant target paths:', err);
+		return ['/'];
+	}
+}
+
 export async function POST(req: NextRequest) {
 	if (!revalidateSecret) {
 		return NextResponse.json(
@@ -116,7 +179,10 @@ export async function POST(req: NextRequest) {
 	try {
 		revalidateTag(_type);
 
-		const paths = getPathsToRevalidate(_type, payload);
+		const paths =
+			_type === 'experiment_variant'
+				? await resolveExperimentVariantPaths(payload)
+				: getPathsToRevalidate(_type, payload);
 		for (const path of paths) {
 			revalidatePath(path);
 		}

--- a/src/app/api/revalidate/route.ts
+++ b/src/app/api/revalidate/route.ts
@@ -63,7 +63,6 @@ function getPathsToRevalidate(_type: string, payload: Record<string, unknown>): 
 		goodpartyOrg_404Page: ['/'],
 		goodpartyOrg_allComponents: ['/all'],
 		quoteCollections: ['/elections'],
-		experiment_variant: ['/'],
 	};
 
 	const paths = pathMap[_type];
@@ -110,20 +109,31 @@ function targetPageToRoute(target: {
 async function resolveExperimentVariantPaths(
 	payload: Record<string, unknown>,
 ): Promise<string[]> {
-	const id = typeof payload['_id'] === 'string' ? (payload['_id'] as string) : null;
-	if (!id) return ['/'];
+	const rawId = typeof payload['_id'] === 'string' ? (payload['_id'] as string) : null;
+	if (!rawId) return ['/'];
+
+	// Cached HTML is rendered from published content only (sanityClient pins
+	// `perspective: 'published'`), so the published doc is the only meaningful
+	// source for revalidation. Strip the `drafts.` prefix if present; if the
+	// document has only ever existed as a draft, no public HTML was built from
+	// it and the fallback below correctly degrades to `/`.
+	const publishedId = rawId.startsWith('drafts.') ? rawId.slice('drafts.'.length) : rawId;
 
 	type TargetRow = { _type?: string; slug?: string | null };
-	const publishedId = id.startsWith('drafts.') ? id.slice('drafts.'.length) : id;
 
 	try {
-		const targets = await sanityClient.fetch<TargetRow[]>(
-			`*[_id == $id || _id == $publishedId][0].field_targetPages[]->{
+		// Bypass the CDN: it can lag up to ~60s after publish, and the webhook
+		// fires immediately on publish, so a CDN read here would reliably return
+		// pre-publish data and revalidate the wrong (or no) targets.
+		const targets = await sanityClient
+			.withConfig({ useCdn: false })
+			.fetch<TargetRow[]>(
+				`*[_id == $publishedId][0].field_targetPages[]->{
 				_type,
 				"slug": detailPageOverviewNoHero.field_slug
 			}`,
-			{ id, publishedId },
-		);
+				{ publishedId },
+			);
 
 		const routes = (targets ?? [])
 			.map(targetPageToRoute)

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -29,13 +29,13 @@ function encodeAmplitudeBrowserSdk20Cookie(deviceId: string): string {
  * First-time visitors have no `AMP_*` cookie yet, so SSR cannot bucket them.
  * Bootstrap the same cookie shape the Browser SDK uses, forward it on this
  * request, and set it on the response so the client keeps the same device id.
+ *
+ * Runs on every page route the matcher allows so experiments can be resolved
+ * server-side on first visit, not just on the homepage.
  */
 function maybeBootstrapAmplitudeDeviceCookie(
 	request: NextRequest,
-	pathname: string,
 ): NextResponse | null {
-	if (pathname !== '/') return null;
-
 	const apiKey = process.env['NEXT_PUBLIC_AMPLITUDE_API_KEY'];
 	const cookieName = apiKey ? amplitudeBrowserSdk20CookieName(apiKey) : null;
 	if (!cookieName) return null;
@@ -89,7 +89,7 @@ export async function middleware(request: NextRequest): Promise<NextResponse | u
 		return NextResponse.redirect(destination, match.permanent ? 308 : 307);
 	}
 
-	const bootstrapped = maybeBootstrapAmplitudeDeviceCookie(request, pathname);
+	const bootstrapped = maybeBootstrapAmplitudeDeviceCookie(request);
 	if (bootstrapped) return bootstrapped;
 
 	return undefined;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes page rendering from static to per-request SSR for all `[slug]` routes and alters cache revalidation behavior for experiment variants, which could impact performance and cache correctness if misconfigured.
> 
> **Overview**
> For the dynamic `[slug]` route, switches to **per-request SSR** (`dynamic = 'force-dynamic'`) and removes `generateStaticParams` so `ExperimentResolver` can pick the correct variant from the visitor’s `AMP_*` cookie before HTML is sent (avoiding client-side flicker).
> 
> Improves the Sanity webhook revalidation endpoint so `experiment_variant` publishes revalidate the *actual targeted routes* by dereferencing `field_targetPages` via a non-CDN Sanity fetch, instead of always revalidating `/`.
> 
> Updates middleware to bootstrap the Amplitude `AMP_*` device cookie on all matched page routes (not just `/`) to enable server-side experiment resolution on first visit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d050c6fa43c81a7dcf43a088daf2928e8e1698d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->