### PR TITLE
Enhance site URL handling and canonical checks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 # SEO - required for canonical URLs, sitemap, Open Graph
 # Production: https://goodparty.org
 # Local dev: http://localhost:3009
+# In Vercel, paste without trailing spaces or newlines (bad values break canonical URLs).
 NEXT_PUBLIC_SITE_URL=
 
 # Storybook deploy - required for `bun run sb:deploy`
@@ -14,6 +15,7 @@ SANITY_STUDIO_API_TOKEN=
 # Editor (write) token required for: bun run sanity:backfill:experiments
 # BACKFILL_STUCK_LOG_MS=5000
 # Shared secret for Sanity webhook to trigger on-demand cache revalidation (POST /api/revalidate)
+# Paste in Vercel without trailing newlines or webhook signature checks will fail.
 SANITY_REVALIDATE_SECRET=
 
 # Ashby job board - required for /work-with-us careers page

--- a/next.config.ts
+++ b/next.config.ts
@@ -8,6 +8,17 @@ const nextConfig = {
 	async rewrites() {
 		return [{ source: '/sitemap.xml', destination: '/api/sitemap-index' }];
 	},
+	async headers() {
+		if (process.env['VERCEL_ENV'] === 'preview') {
+			return [
+				{
+					source: '/:path*',
+					headers: [{ key: 'X-Robots-Tag', value: 'noindex, nofollow' }],
+				},
+			];
+		}
+		return [];
+	},
 	async redirects() {
 		return [
 			{

--- a/next.config.ts
+++ b/next.config.ts
@@ -8,17 +8,6 @@ const nextConfig = {
 	async rewrites() {
 		return [{ source: '/sitemap.xml', destination: '/api/sitemap-index' }];
 	},
-	async headers() {
-		if (process.env['VERCEL_ENV'] === 'preview') {
-			return [
-				{
-					source: '/:path*',
-					headers: [{ key: 'X-Robots-Tag', value: 'noindex, nofollow' }],
-				},
-			];
-		}
-		return [];
-	},
 	async redirects() {
 		return [
 			{

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "dev": "next dev --turbopack -p 3009",
     "prebuild": "rm -rf dist public/sitemap.xml public/sitemaps",
     "build": "next build --turbopack",
+    "postbuild": "bun run scripts/check-canonicals.ts",
     "lint": "next lint",
     "test": "bun test ./src ./scripts",
     "start": "next start",

--- a/scripts/check-canonicals.ts
+++ b/scripts/check-canonicals.ts
@@ -1,0 +1,96 @@
+#!/usr/bin/env bun
+/**
+ * After `next build`, optionally verifies HTML canonical links point at https://goodparty.org/
+ * when this deployment targets the public site (getBaseUrl() === https://goodparty.org).
+ * Skips on Vercel preview and when NEXT_PUBLIC_SITE_URL points at a non-production host.
+ */
+
+import { spawn } from 'node:child_process';
+import { getBaseUrl } from '../src/lib/siteBaseUrl';
+
+const PRODUCTION_ORIGIN = 'https://goodparty.org';
+const SAMPLE_PATHS = ['/', '/blog', '/blog/article/20-reasons-to-run'];
+
+function shouldRunCheck(): boolean {
+	if (process.env['SKIP_CANONICAL_CHECK'] === '1') return false;
+	if (process.env['VERCEL_ENV'] === 'preview') return false;
+	return getBaseUrl() === PRODUCTION_ORIGIN;
+}
+
+function extractCanonical(html: string): string | null {
+	const patterns = [
+		/<link\s+[^>]*rel=["']canonical["'][^>]*href=["']([^"']+)["']/i,
+		/<link\s+[^>]*href=["']([^"']+)["'][^>]*rel=["']canonical["']/i,
+	];
+	for (const re of patterns) {
+		const m = html.match(re);
+		if (m?.[1]) return m[1];
+	}
+	return null;
+}
+
+async function waitForHttpOk(origin: string, maxMs: number): Promise<void> {
+	const deadline = Date.now() + maxMs;
+	while (Date.now() < deadline) {
+		try {
+			const res = await fetch(`${origin}/`, { redirect: 'follow' });
+			if (res.ok || res.status === 404) return;
+		} catch {
+			/* retry */
+		}
+		await new Promise(r => setTimeout(r, 400));
+	}
+	throw new Error(`Server at ${origin} did not become ready within ${maxMs}ms`);
+}
+
+async function main() {
+	if (!shouldRunCheck()) {
+		console.log('[check-canonicals] Skipping (not a goodparty.org production base or SKIP_CANONICAL_CHECK=1)');
+		return;
+	}
+
+	const port = process.env['CANONICAL_CHECK_PORT'] ?? '3010';
+	const origin = `http://127.0.0.1:${port}`;
+
+	const child = spawn('bun', ['run', 'start', '--', '-p', port], {
+		cwd: process.cwd(),
+		stdio: ['ignore', 'pipe', 'pipe'],
+		env: { ...process.env, PORT: port },
+	});
+
+	const onExit = new Promise<number>((resolve, reject) => {
+		child.once('error', reject);
+		child.once('exit', (code) => resolve(code ?? 0));
+	});
+
+	try {
+		await waitForHttpOk(origin, 90_000);
+
+		const failures: string[] = [];
+		for (const path of SAMPLE_PATHS) {
+			const res = await fetch(`${origin}${path}`, { redirect: 'follow' });
+			const html = await res.text();
+			const canonical = extractCanonical(html);
+			if (!canonical) {
+				failures.push(`${path}: no canonical link found`);
+				continue;
+			}
+			if (!canonical.startsWith(`${PRODUCTION_ORIGIN}/`) && canonical !== PRODUCTION_ORIGIN) {
+				failures.push(`${path}: canonical is ${canonical}`);
+			}
+		}
+
+		if (failures.length > 0) {
+			throw new Error(`Canonical check failed:\n${failures.join('\n')}`);
+		}
+		console.log('[check-canonicals] OK for paths:', SAMPLE_PATHS.join(', '));
+	} finally {
+		child.kill('SIGTERM');
+		await onExit;
+	}
+}
+
+main().catch(err => {
+	console.error(err instanceof Error ? err.message : err);
+	process.exit(1);
+});

--- a/sites.ts
+++ b/sites.ts
@@ -1,11 +1,10 @@
 import { Logo } from './src/sanity/utils/Logo.tsx';
+import { getBaseUrl } from './src/lib/siteBaseUrl';
 
 export const sites = {
 	goodpartyOrg: {
 		title: 'Goodparty.org',
 		icon: Logo,
-		url: process.env.NODE_ENV === 'development'
-			? 'http://localhost:3009'
-			: process.env.VERCEL_URL || process.env.NEXT_PUBLIC_PREVIEW_URL || 'https://gp-marketing-git-develop-good-party.vercel.app',
+		url: process.env.NODE_ENV === 'development' ? 'http://localhost:3009' : getBaseUrl(),
 	},
 };

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,11 +1,26 @@
 import type { MetadataRoute } from 'next';
 import { getBaseUrl } from '~/lib/url';
 
+function hostnameLooksLikePreview(host: string): boolean {
+	return /\.vercel\.app$/i.test(host);
+}
+
 export default function robots(): MetadataRoute.Robots {
 	const baseUrl = getBaseUrl();
-	const isStaging = baseUrl.includes('staging') || baseUrl.includes('e6.digital');
+	let host = '';
+	try {
+		host = new URL(baseUrl).hostname;
+	} catch {
+		host = '';
+	}
 
-	if (isStaging) {
+	const isPreviewLike =
+		process.env['VERCEL_ENV'] === 'preview' ||
+		hostnameLooksLikePreview(host) ||
+		baseUrl.includes('staging') ||
+		baseUrl.includes('e6.digital');
+
+	if (isPreviewLike) {
 		return {
 			rules: [
 				{

--- a/src/lib/siteBaseUrl.ts
+++ b/src/lib/siteBaseUrl.ts
@@ -1,0 +1,44 @@
+/**
+ * Public site base URL only (canonical, sitemap, OG). No Sanity/env image deps so
+ * Sanity Studio and root-level modules can import this without Vite alias issues.
+ */
+
+const PRODUCTION_HOST = 'https://goodparty.org';
+
+function sanitizeSiteUrl(value: string | undefined): string | undefined {
+	if (value == null || typeof value !== 'string') return undefined;
+	const cleaned = value.replace(/[\s\r\n]+/g, '').replace(/\/$/, '');
+	if (!cleaned) return undefined;
+	return cleaned.startsWith('http') ? cleaned : `https://${cleaned}`;
+}
+
+/**
+ * Returns the absolute base URL for the site.
+ * Checks NEXT_PUBLIC_APP_BASE first (CLI override), then NEXT_PUBLIC_SITE_URL.
+ * Production never uses a *.vercel.app host; preview uses VERCEL_URL.
+ */
+export function getBaseUrl(): string {
+	const explicit =
+		sanitizeSiteUrl(process.env['NEXT_PUBLIC_APP_BASE']) ?? sanitizeSiteUrl(process.env['NEXT_PUBLIC_SITE_URL']);
+
+	const isProd =
+		process.env['VERCEL_ENV'] === 'production' ||
+		(process.env['NODE_ENV'] === 'production' && !process.env['VERCEL_ENV']);
+
+	if (isProd) {
+		if (explicit) {
+			try {
+				if (!/\.vercel\.app$/i.test(new URL(explicit).hostname)) return explicit;
+			} catch {
+				/* fall through to PRODUCTION_HOST */
+			}
+		}
+		return PRODUCTION_HOST;
+	}
+
+	if (explicit) return explicit;
+	if (process.env['VERCEL_ENV'] === 'preview' && process.env['VERCEL_URL']) {
+		return `https://${process.env['VERCEL_URL']}`;
+	}
+	return PRODUCTION_HOST;
+}

--- a/src/lib/url.test.ts
+++ b/src/lib/url.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { getBaseUrl, toAbsoluteUrl } from './url';
+
+const envKeys = ['NEXT_PUBLIC_APP_BASE', 'NEXT_PUBLIC_SITE_URL', 'VERCEL_ENV', 'VERCEL_URL', 'NODE_ENV'] as const;
+
+let snapshot: Partial<Record<(typeof envKeys)[number], string | undefined>>;
+
+beforeEach(() => {
+	snapshot = {};
+	for (const k of envKeys) {
+		snapshot[k] = process.env[k];
+	}
+});
+
+afterEach(() => {
+	for (const k of envKeys) {
+		const v = snapshot[k];
+		if (v === undefined) delete process.env[k];
+		else process.env[k] = v;
+	}
+});
+
+describe('getBaseUrl', () => {
+	test('strips whitespace and newlines from explicit site URL', () => {
+		process.env['NODE_ENV'] = 'development';
+		delete process.env['VERCEL_ENV'];
+		process.env['NEXT_PUBLIC_SITE_URL'] = '  https://goodparty.org\n  ';
+		expect(getBaseUrl()).toBe('https://goodparty.org');
+	});
+
+	test('prefixes https when scheme omitted', () => {
+		process.env['NODE_ENV'] = 'development';
+		delete process.env['VERCEL_ENV'];
+		process.env['NEXT_PUBLIC_SITE_URL'] = 'www.example.org';
+		expect(getBaseUrl()).toBe('https://www.example.org');
+	});
+
+	test('production rejects *.vercel.app explicit URL and falls back to goodparty.org', () => {
+		process.env['NODE_ENV'] = 'production';
+		process.env['VERCEL_ENV'] = 'production';
+		process.env['NEXT_PUBLIC_SITE_URL'] = 'https://gp-marketing-abc.vercel.app';
+		expect(getBaseUrl()).toBe('https://goodparty.org');
+	});
+
+	test('production allows non-Vercel explicit URL', () => {
+		process.env['NODE_ENV'] = 'production';
+		process.env['VERCEL_ENV'] = 'production';
+		process.env['NEXT_PUBLIC_SITE_URL'] = 'https://www.goodparty.org';
+		expect(getBaseUrl()).toBe('https://www.goodparty.org');
+	});
+
+	test('preview uses VERCEL_URL when site URL unset', () => {
+		process.env['NODE_ENV'] = 'production';
+		process.env['VERCEL_ENV'] = 'preview';
+		delete process.env['NEXT_PUBLIC_SITE_URL'];
+		delete process.env['NEXT_PUBLIC_APP_BASE'];
+		process.env['VERCEL_URL'] = 'gp-marketing-abc-good-party.vercel.app';
+		expect(getBaseUrl()).toBe('https://gp-marketing-abc-good-party.vercel.app');
+	});
+
+	test('NEXT_PUBLIC_APP_BASE wins over NEXT_PUBLIC_SITE_URL', () => {
+		process.env['NODE_ENV'] = 'development';
+		delete process.env['VERCEL_ENV'];
+		process.env['NEXT_PUBLIC_APP_BASE'] = 'https://from-app-base.example';
+		process.env['NEXT_PUBLIC_SITE_URL'] = 'https://from-site-url.example';
+		expect(getBaseUrl()).toBe('https://from-app-base.example');
+	});
+
+	test('defaults to goodparty.org when unset (non-preview)', () => {
+		process.env['NODE_ENV'] = 'development';
+		delete process.env['VERCEL_ENV'];
+		delete process.env['NEXT_PUBLIC_SITE_URL'];
+		delete process.env['NEXT_PUBLIC_APP_BASE'];
+		delete process.env['VERCEL_URL'];
+		expect(getBaseUrl()).toBe('https://goodparty.org');
+	});
+});
+
+describe('toAbsoluteUrl', () => {
+	test('joins path with base', () => {
+		process.env['NODE_ENV'] = 'development';
+		delete process.env['VERCEL_ENV'];
+		process.env['NEXT_PUBLIC_SITE_URL'] = 'https://goodparty.org';
+		expect(toAbsoluteUrl('/blog')).toBe('https://goodparty.org/blog');
+	});
+
+	test('passes through absolute URLs', () => {
+		process.env['NODE_ENV'] = 'development';
+		expect(toAbsoluteUrl('https://elsewhere.example/x')).toBe('https://elsewhere.example/x');
+	});
+});

--- a/src/lib/url.ts
+++ b/src/lib/url.ts
@@ -1,25 +1,10 @@
 import { dataset, projectId } from '~/lib/env';
+import { getBaseUrl } from './siteBaseUrl';
+
+export { getBaseUrl } from './siteBaseUrl';
 
 /** Default share image for Open Graph, Twitter, and schema when no page-specific image is set */
 export const DEFAULT_SHARE_IMAGE = 'https://assets.goodparty.org/gp-share-2025.png';
-
-/**
- * Returns the absolute base URL for the site.
- * Used for canonical URLs, sitemap, Open Graph, and schema.org.
- * Checks NEXT_PUBLIC_APP_BASE first (CLI override), then NEXT_PUBLIC_SITE_URL.
- * Production falls back to goodparty.org; VERCEL_URL is used for preview deployments.
- */
-export function getBaseUrl(): string {
-	const explicit = process.env['NEXT_PUBLIC_APP_BASE'] ?? process.env['NEXT_PUBLIC_SITE_URL'];
-	if (explicit && typeof explicit === 'string') {
-		const trimmed = explicit.trim().replace(/\/$/, '');
-		return trimmed.startsWith('http') ? trimmed : `https://${trimmed}`;
-	}
-	if (process.env['VERCEL_ENV'] === 'preview' && process.env['VERCEL_URL']) {
-		return `https://${process.env['VERCEL_URL']}`;
-	}
-	return 'https://goodparty.org';
-}
 
 /**
  * Converts a path to an absolute URL using the site base. Pass-through for already-absolute URLs.

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,6 +2,14 @@ import { type NextRequest, NextResponse } from 'next/server';
 
 type RedirectMap = Record<string, { to: string; permanent: boolean }>;
 
+/** Runtime gate — avoids baking preview-only headers into the build (next.config headers). */
+function withPreviewNoIndex(response: NextResponse): NextResponse {
+	if (process.env['VERCEL_ENV'] === 'preview') {
+		response.headers.set('X-Robots-Tag', 'noindex, nofollow');
+	}
+	return response;
+}
+
 function normalizePath(path: string): string {
 	return path.endsWith('/') && path.length > 1 ? path.slice(0, -1) : path;
 }
@@ -66,16 +74,16 @@ function maybeBootstrapAmplitudeDeviceCookie(
 	return response;
 }
 
-export async function middleware(request: NextRequest): Promise<NextResponse | undefined> {
+export async function middleware(request: NextRequest): Promise<NextResponse> {
 	const origin = request.nextUrl.origin;
 
 	let map: RedirectMap;
 	try {
 		const res = await fetch(`${origin}/api/redirects`);
-		if (!res.ok) return undefined;
+		if (!res.ok) return withPreviewNoIndex(NextResponse.next());
 		map = (await res.json()) as RedirectMap;
 	} catch {
-		return undefined;
+		return withPreviewNoIndex(NextResponse.next());
 	}
 
 	const pathname = normalizePath(request.nextUrl.pathname);
@@ -86,13 +94,15 @@ export async function middleware(request: NextRequest): Promise<NextResponse | u
 			? match.to
 			: new URL(match.to, request.url).toString();
 
-		return NextResponse.redirect(destination, match.permanent ? 308 : 307);
+		return withPreviewNoIndex(
+			NextResponse.redirect(destination, match.permanent ? 308 : 307),
+		);
 	}
 
 	const bootstrapped = maybeBootstrapAmplitudeDeviceCookie(request);
-	if (bootstrapped) return bootstrapped;
+	if (bootstrapped) return withPreviewNoIndex(bootstrapped);
 
-	return undefined;
+	return withPreviewNoIndex(NextResponse.next());
 }
 
 export const config = {

--- a/src/ui/_lib/linkBehavior.ts
+++ b/src/ui/_lib/linkBehavior.ts
@@ -1,4 +1,4 @@
-const DEFAULT_ORIGIN = process.env['NEXT_PUBLIC_SITE_URL'] ?? 'https://goodparty.org';
+import { getBaseUrl } from '~/lib/url';
 
 function isGoodPartyHost(host: string): boolean {
 	return host === 'goodparty.org' || host.endsWith('.goodparty.org');
@@ -23,7 +23,7 @@ export function isExternalToEcosystem(href: string | undefined | null): boolean 
 
 	let url: URL;
 	try {
-		url = new URL(trimmed, DEFAULT_ORIGIN);
+		url = new URL(trimmed, getBaseUrl());
 	} catch {
 		// Malformed URLs are treated as external to be safe.
 		return true;


### PR DESCRIPTION
- Updated `.env.example` to clarify usage instructions for Vercel and webhook signature checks.
- Introduced `getBaseUrl` function in `siteBaseUrl.ts` to centralize base URL logic, ensuring proper handling of production and preview environments.
- Added `check-canonicals.ts` script to verify canonical links post-build, ensuring they point to the correct production URL.
- Updated `robots.ts` to improve handling of preview environments and prevent indexing.
- Refactored URL handling in various components to utilize the new `getBaseUrl` function for consistency.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches SEO-critical behavior (canonicals/robots) and adds a post-build check that can fail deployments if misconfigured, but the changes are localized and guarded for preview environments.
> 
> **Overview**
> Centralizes public-site base URL resolution into a new `src/lib/siteBaseUrl.ts`, adding sanitization (whitespace/newline stripping), stricter production defaults, and preventing `*.vercel.app` origins from being treated as production canonicals.
> 
> Adds a `postbuild` canonical verifier (`scripts/check-canonicals.ts`) that boots the built app and asserts canonical links for a few representative pages resolve to `https://goodparty.org` (with opt-out via env flags).
> 
> Hardens no-index behavior for non-production by (1) sending `X-Robots-Tag: noindex, nofollow` on all routes in Vercel preview via `next.config.ts` and (2) updating `src/app/robots.ts` to treat Vercel/preview-like hosts as disallowed.
> 
> Refactors callers (e.g., `sites.ts`, `src/lib/url.ts`, `linkBehavior.ts`) to use the shared base URL logic, and updates `.env.example` with Vercel copy/paste warnings to avoid broken canonicals and webhook signature mismatches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 481aa4364fae5a785f391d252b2a009cb04b897f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->