### PR TITLE
Prevent Publish of empty quotes

### DIFF
--- a/src/sanity/schema/fields/field_quote.ts
+++ b/src/sanity/schema/fields/field_quote.ts
@@ -1,3 +1,4 @@
+import type { Rule } from 'sanity';
 
 export const field_quote = {
   name: 'field_quote',
@@ -6,5 +7,9 @@ export const field_quote = {
   options: {
     collapsible: false,
   },
+  validation: (Rule: Rule) =>
+    Rule.required().custom((value) =>
+      typeof value === 'string' && value.trim().length > 0 ? true : 'Quote text is required',
+    ),
   type: 'text',
 }

--- a/src/ui/_lib/resolveAuthor.ts
+++ b/src/ui/_lib/resolveAuthor.ts
@@ -2,6 +2,9 @@ import type { Sections } from '~/PageSections';
 import type { AuthorProps } from '~/ui/Author';
 import type { SanityImage } from '~/ui/types';
 
+const PERSON_TYPE = 'person';
+const ORGANISATION_TYPE = 'organisation';
+
 export function resolveAuthor(
 	quote?: NonNullable<
 		NonNullable<
@@ -13,7 +16,7 @@ export function resolveAuthor(
 
 	const { _type } = quote;
 
-	if (_type === 'person') {
+	if (_type === PERSON_TYPE) {
 		const { personOverview } = quote;
 		const { field_personName, field_jobTitleOrRole, img_profilePicture } = personOverview ?? {};
 		if (!field_personName) return undefined;
@@ -25,7 +28,7 @@ export function resolveAuthor(
 		};
 	}
 
-	if (_type === 'organisation') {
+	if (_type === ORGANISATION_TYPE) {
 		const { organisationOverview } = quote;
 		const { field_organisationName, img_logo } = organisationOverview ?? {};
 		if (!field_organisationName) return undefined;

--- a/src/ui/_lib/resolveAuthor.ts
+++ b/src/ui/_lib/resolveAuthor.ts
@@ -10,18 +10,31 @@ export function resolveAuthor(
 	>['ref_quoteBy'],
 ): AuthorProps | undefined {
 	if (!quote) return undefined;
-	if (quote._type === 'person' && quote.personOverview?.field_personName) {
+
+	const { _type } = quote;
+
+	if (_type === 'person') {
+		const { personOverview } = quote;
+		const { field_personName, field_jobTitleOrRole, img_profilePicture } = personOverview ?? {};
+		if (!field_personName) return undefined;
+
 		return {
-			name: quote.personOverview?.field_personName,
-			meta: quote.personOverview?.field_jobTitleOrRole ? [quote.personOverview?.field_jobTitleOrRole] : undefined,
-			image: quote.personOverview?.img_profilePicture as unknown as SanityImage,
+			name: field_personName,
+			meta: field_jobTitleOrRole ? [field_jobTitleOrRole] : undefined,
+			image: img_profilePicture as unknown as SanityImage,
 		};
 	}
-	if (quote._type === 'organisation' && quote.organisationOverview?.field_organisationName) {
+
+	if (_type === 'organisation') {
+		const { organisationOverview } = quote;
+		const { field_organisationName, img_logo } = organisationOverview ?? {};
+		if (!field_organisationName) return undefined;
+
 		return {
-			name: quote.organisationOverview?.field_organisationName,
-			image: quote.organisationOverview?.img_logo as unknown as SanityImage,
+			name: field_organisationName,
+			image: img_logo as unknown as SanityImage,
 		};
 	}
+
 	return undefined;
 }

--- a/src/ui/_lib/resolveTestimonials.ts
+++ b/src/ui/_lib/resolveTestimonials.ts
@@ -1,20 +1,32 @@
 import type { TestimonialCardProps } from '../TestimonialCard';
 
 export function resolveTestimonials(item: any): TestimonialCardProps[] {
-	let testimonials: TestimonialCardProps[] = [];
+	const quotes = item?.quotes;
+	if (!Array.isArray(quotes) || quotes.length === 0) {
+		return [];
+	}
 
-	item.quotes.map(quote => {
+	const testimonials: TestimonialCardProps[] = [];
+
+	for (const row of quotes as Array<{ quote?: any }>) {
+		const nested = row?.quote;
+		const copy = nested?.field_quote;
+		if (typeof copy !== 'string' || copy.trim().length === 0) {
+			continue;
+		}
+
+		const { ref_quoteBy } = nested ?? {};
+		const { personOverview: person, organisationOverview: org } = ref_quoteBy ?? {};
+
 		testimonials.push({
 			author: {
-				name:
-					quote?.quote?.ref_quoteBy?.personOverview?.field_personName ||
-					quote?.quote?.ref_quoteBy?.organisationOverview?.field_organisationName,
-				meta: [quote?.quote?.ref_quoteBy?.personOverview?.field_jobTitleOrRole],
-				image: quote?.quote?.ref_quoteBy?.personOverview?.img_profilePicture || quote?.quote?.ref_quoteBy?.organisationOverview?.img_logo,
+				name: person?.field_personName || org?.field_organisationName,
+				meta: [person?.field_jobTitleOrRole],
+				image: person?.img_profilePicture || org?.img_logo,
 			},
-			copy: quote.quote.field_quote,
+			copy,
 		});
-	});
+	}
 
 	return testimonials;
 }

--- a/src/ui/_lib/resolveTestimonials.ts
+++ b/src/ui/_lib/resolveTestimonials.ts
@@ -1,4 +1,5 @@
 import type { TestimonialCardProps } from '../TestimonialCard';
+import { resolveAuthor } from './resolveAuthor';
 
 export function resolveTestimonials(item: any): TestimonialCardProps[] {
 	const quotes = item?.quotes;
@@ -16,14 +17,9 @@ export function resolveTestimonials(item: any): TestimonialCardProps[] {
 		}
 
 		const { ref_quoteBy } = nested ?? {};
-		const { personOverview: person, organisationOverview: org } = ref_quoteBy ?? {};
 
 		testimonials.push({
-			author: {
-				name: person?.field_personName || org?.field_organisationName,
-				meta: [person?.field_jobTitleOrRole],
-				image: person?.img_profilePicture || org?.img_logo,
-			},
+			author: resolveAuthor(ref_quoteBy),
 			copy,
 		});
 	}


### PR DESCRIPTION
- Added validation to the field_quote schema to ensure that quote text is required and not empty.
- Updated resolveTestimonials function to handle quotes more robustly, ensuring only valid quotes are processed and improving the extraction of author details.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds simple Sanity validation and defensive filtering to skip empty/invalid quote entries without changing data models or external interfaces.
> 
> **Overview**
> Prevents publishing empty `field_quote` values by adding required + non-whitespace validation with a clear error message.
> 
> Hardens `resolveTestimonials` to return early when `quotes` is missing/empty and to ignore rows with blank `field_quote`, while simplifying author extraction from `ref_quoteBy` to safely handle person vs organisation sources.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60a52290b685553733366d4f76119daef7b847bd. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->