### PR TITLE
fix(elections): Maine state index districts and county town listings

### DIFF
--- a/src/app/elections/[state]/page.tsx
+++ b/src/app/elections/[state]/page.tsx
@@ -5,7 +5,7 @@ import {
 	CITY_MTFCC,
 	getPlacesByState,
 	getPlaceBySlug,
-	isDistrictMtfcc,
+	isStateIndexDistrictPlace,
 } from '~/lib/electionsApi';
 import { isValidStateCode } from '~/constants/usStateCodes';
 import { DEFAULT_DISPLAY_COUNT } from '~/constants/display';
@@ -64,7 +64,7 @@ export default async function Page({
 	]);
 
 	const countyPlaces = allPlaces.filter(p => p.mtfcc === COUNTY_MTFCC);
-	const districtPlaces = allPlaces.filter(p => isDistrictMtfcc(p.mtfcc));
+	const districtPlaces = allPlaces.filter(isStateIndexDistrictPlace);
 	const isSingleCounty = countyPlaces.length <= 1;
 	let cityPlaces = isSingleCounty
 		? await getPlacesByState({ state: stateCode, mtfcc: CITY_MTFCC })

--- a/src/lib/electionsApi.test.ts
+++ b/src/lib/electionsApi.test.ts
@@ -293,6 +293,14 @@ describe('isStateIndexDistrictPlace', () => {
 
 		expect(
 			isStateIndexDistrictPlace({
+				name: 'Union',
+				slug: 'me/union',
+				mtfcc: 'G5420',
+			}),
+		).toBe(false);
+
+		expect(
+			isStateIndexDistrictPlace({
 				name: 'Andover Public Schools',
 				slug: 'me/andover-public-schools',
 				mtfcc: 'G5420',

--- a/src/lib/electionsApi.test.ts
+++ b/src/lib/electionsApi.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import type { PlaceItem } from '~/types/elections';
-import { getCountyChildPlaces } from './electionsApi';
+import { getCountyChildPlaces, isStateIndexDistrictPlace } from './electionsApi';
 
 type FetchMockResponse = {
 	match: (url: string) => boolean;
@@ -205,5 +205,122 @@ describe('getCountyChildPlaces', () => {
 
 		const result = await getCountyChildPlaces({ state: 'WV', countySlug: 'wv/braxton-county' });
 		expect(slugs(result)).toEqual(['wv/sutton', 'wv/gassaway']);
+	});
+
+	test('merges G4040 towns for Maine Androscoggin when hierarchy children are sparse (production-shaped)', async () => {
+		withFetchMock([
+			{
+				match: url => url.includes('/v1/places?') && url.includes('slug=me%2Fandroscoggin-county'),
+				body: [
+					{
+						slug: 'me/androscoggin-county',
+						name: 'Androscoggin County',
+						mtfcc: 'G4020',
+						children: [
+							{
+								slug: 'me/androscoggin-county/sabattus-town',
+								name: 'Sabattus Town',
+								mtfcc: 'G4040',
+								state: 'ME',
+								countyName: 'Androscoggin',
+							},
+							{
+								slug: 'me/androscoggin-county/lisbon-town',
+								name: 'Lisbon Town',
+								mtfcc: 'G4040',
+								state: 'ME',
+								countyName: 'Androscoggin',
+							},
+						],
+					},
+				],
+			},
+			{
+				match: url =>
+					url.includes('/v1/places?') &&
+					url.includes('state=ME') &&
+					url.includes('mtfcc=G4110'),
+				body: [
+					{
+						slug: 'me/lewiston',
+						name: 'Lewiston',
+						mtfcc: 'G4110',
+						state: 'ME',
+						countyName: 'Androscoggin',
+					},
+				],
+			},
+			{
+				match: url =>
+					url.includes('/v1/places?') &&
+					url.includes('state=ME') &&
+					url.includes('mtfcc=G4040'),
+				body: [
+					{
+						slug: 'me/androscoggin-county/auburn-town',
+						name: 'Auburn',
+						mtfcc: 'G4040',
+						state: 'ME',
+						countyName: 'Androscoggin',
+					},
+					{
+						slug: 'me/penobscot-county/some-town',
+						name: 'Other County Town',
+						mtfcc: 'G4040',
+						state: 'ME',
+						countyName: 'Penobscot',
+					},
+				],
+			},
+		]);
+
+		const result = await getCountyChildPlaces({ state: 'ME', countySlug: 'me/androscoggin-county' });
+		expect(slugs(result).sort()).toEqual(
+			['me/androscoggin-county/auburn-town', 'me/androscoggin-county/lisbon-town', 'me/androscoggin-county/sabattus-town', 'me/lewiston'].sort(),
+		);
+	});
+});
+
+describe('isStateIndexDistrictPlace', () => {
+	test('filters municipality-like G54xx rows while preserving district-shaped rows', () => {
+		expect(
+			isStateIndexDistrictPlace({
+				name: 'Acton',
+				slug: 'me/acton',
+				mtfcc: 'G5420',
+			}),
+		).toBe(false);
+
+		expect(
+			isStateIndexDistrictPlace({
+				name: 'Andover Public Schools',
+				slug: 'me/andover-public-schools',
+				mtfcc: 'G5420',
+			}),
+		).toBe(true);
+
+		expect(
+			isStateIndexDistrictPlace({
+				name: 'RSU 16',
+				slug: 'me/rsu-16',
+				mtfcc: 'G5420',
+			}),
+		).toBe(true);
+
+		expect(
+			isStateIndexDistrictPlace({
+				name: 'Bellows Falls UHSD 27',
+				slug: 'vt/bellows-falls-uhsd-27',
+				mtfcc: 'G5410',
+			}),
+		).toBe(true);
+
+		expect(
+			isStateIndexDistrictPlace({
+				name: 'Washington Central Supervisory Union',
+				slug: 'vt/washington-central-supervisory-union',
+				mtfcc: 'G5420',
+			}),
+		).toBe(true);
 	});
 });

--- a/src/lib/electionsApi.ts
+++ b/src/lib/electionsApi.ts
@@ -36,6 +36,31 @@ export function isDistrictMtfcc(mtfcc?: string): boolean {
 	return mtfcc?.startsWith('G54') ?? false;
 }
 
+const COUNTY_EQUIVALENT_SLUG_SUFFIX_RE =
+	/(?:-county|-parish|-borough|-census-area|-municipio|-city-and-borough|-city-and-county)$/i;
+
+/** Matches common school / district naming (incl. VT UHSD and supervisory unions). */
+const DISTRICT_KEYWORD_RE =
+	/\b(district|school|schools|isd|usd|csd|sd|rsu|sau|uhsd|supervisory|union)\b/i;
+
+/**
+ * Defensive classification for the state-level elections index "districts" list.
+ * Some API payloads (notably Maine) attach G54xx to municipality-like slugs; we only
+ * keep rows that look district-shaped by slug depth, county-equivalent tail, or
+ * district keywords in name/slug.
+ */
+export function isStateIndexDistrictPlace(place: Pick<PlaceItem, 'name' | 'slug' | 'mtfcc'>): boolean {
+	if (!isDistrictMtfcc(place.mtfcc)) return false;
+	const slug = (place.slug ?? '').toLowerCase();
+	const name = (place.name ?? '').toLowerCase();
+	const segments = slug.split('/').filter(Boolean);
+	const tail = segments[segments.length - 1] ?? '';
+
+	if (segments.length >= 3) return true;
+	if (COUNTY_EQUIVALENT_SLUG_SUFFIX_RE.test(tail)) return true;
+	return DISTRICT_KEYWORD_RE.test(name) || DISTRICT_KEYWORD_RE.test(tail);
+}
+
 const FETCH_JSON_MAX_RETRIES = 2;
 
 function sleep(ms: number): Promise<void> {
@@ -224,10 +249,13 @@ export async function getCityPlacesByCounty(params: {
 	state: string;
 	countySlug: string;
 }): Promise<PlaceItem[]> {
-	const allCities = await getPlacesByState({ state: params.state, mtfcc: CITY_MTFCC });
+	const [allCities, allTowns] = await Promise.all([
+		getPlacesByState({ state: params.state, mtfcc: CITY_MTFCC }),
+		getPlacesByState({ state: params.state, mtfcc: TOWN_MTFCC }),
+	]);
 	const countyName = countyNameFromSlug(params.countySlug);
 	const normalizedCountyBaseName = canonicalizeCountyEquivalentName(params.state, countyName).baseName;
-	return allCities.filter(
+	return [...allCities, ...allTowns].filter(
 		p =>
 			normalizeName(canonicalizeCountyEquivalentName(params.state, p.countyName ?? '').baseName) ===
 			normalizeName(normalizedCountyBaseName),

--- a/src/lib/electionsApi.ts
+++ b/src/lib/electionsApi.ts
@@ -37,7 +37,7 @@ export function isDistrictMtfcc(mtfcc?: string): boolean {
 }
 
 const COUNTY_EQUIVALENT_SLUG_SUFFIX_RE =
-	/(?:-county|-parish|-borough|-census-area|-municipio|-city-and-borough|-city-and-county)$/i;
+	/(?:-county|-parish|-borough|-census-area|-city-and-borough|-city-and-county)$/i;
 
 /** Matches common school / district naming (incl. VT UHSD and supervisory-union phrases). */
 const DISTRICT_KEYWORD_RE =
@@ -239,7 +239,7 @@ function normalizeName(name: string): string {
 function countyNameFromSlug(countySlug: string): string {
 	const part = countySlug.split('/').pop() ?? '';
 	const withoutSuffix = part.replace(
-		/-(county|parish|city-and-borough|city-and-county|borough|census-area|municipio)$/i,
+		/-(county|parish|city-and-borough|city-and-county|borough|census-area)$/i,
 		'',
 	);
 	return withoutSuffix.replace(/-/g, ' ').replace(/\b\w/g, c => c.toUpperCase());

--- a/src/lib/electionsApi.ts
+++ b/src/lib/electionsApi.ts
@@ -39,9 +39,9 @@ export function isDistrictMtfcc(mtfcc?: string): boolean {
 const COUNTY_EQUIVALENT_SLUG_SUFFIX_RE =
 	/(?:-county|-parish|-borough|-census-area|-municipio|-city-and-borough|-city-and-county)$/i;
 
-/** Matches common school / district naming (incl. VT UHSD and supervisory unions). */
+/** Matches common school / district naming (incl. VT UHSD and supervisory-union phrases). */
 const DISTRICT_KEYWORD_RE =
-	/\b(district|school|schools|isd|usd|csd|sd|rsu|sau|uhsd|supervisory|union)\b/i;
+	/\b(district|schools?|isd|usd|csd|sd|rsu|sau|uhsd)\b|\bsupervisory(?:\s+|-)union\b/i;
 
 /**
  * Defensive classification for the state-level elections index "districts" list.

--- a/src/lib/electionsHelpers.test.ts
+++ b/src/lib/electionsHelpers.test.ts
@@ -107,10 +107,6 @@ describe('stripCountySuffix', () => {
 		expect(stripCountySuffix('Yukon-Koyukuk Census Area')).toBe('Yukon-Koyukuk');
 	});
 
-	test('strips Municipio', () => {
-		expect(stripCountySuffix('San Juan Municipio')).toBe('San Juan');
-	});
-
 	test('strips Municipality', () => {
 		expect(stripCountySuffix('Anchorage Municipality')).toBe('Anchorage');
 	});
@@ -202,22 +198,6 @@ describe('canonicalizeCountyEquivalentName', () => {
 			displayName: 'Jefferson Parish',
 			baseName: 'Jefferson',
 			suffixLabel: 'Parish',
-		});
-	});
-
-	test('preserves Puerto Rico municipio naming', () => {
-		expect(canonicalizeCountyEquivalentName('PR', 'San Juan Municipio')).toEqual({
-			displayName: 'San Juan Municipio',
-			baseName: 'San Juan',
-			suffixLabel: 'Municipio',
-		});
-	});
-
-	test('fixes malformed Puerto Rico double suffix', () => {
-		expect(canonicalizeCountyEquivalentName('PR', 'San Juan Municipio County')).toEqual({
-			displayName: 'San Juan Municipio',
-			baseName: 'San Juan',
-			suffixLabel: 'Municipio',
 		});
 	});
 });

--- a/src/lib/electionsHelpers.ts
+++ b/src/lib/electionsHelpers.ts
@@ -5,9 +5,9 @@ import type { FactsCardProps } from '~/ui/FactsCard';
 export { isCityOrTownMtfcc } from '~/lib/electionsApi';
 
 const COUNTY_EQUIV_SUFFIX_RE =
-	/\s+(County|Parish|City and Borough|City and County|Borough|Census Area|Municipio|Municipality)$/i;
+	/\s+(County|Parish|City and Borough|City and County|Borough|Census Area|Municipality)$/i;
 const COUNTY_EQUIV_TAIL_RE =
-	/\s+(County|Parish|City and Borough|City and County|Borough|Census Area|Municipio|Municipality)(?:\s+(County|Parish|City and Borough|City and County|Borough|Census Area|Municipio|Municipality))*$/i;
+	/\s+(County|Parish|City and Borough|City and County|Borough|Census Area|Municipality)(?:\s+(County|Parish|City and Borough|City and County|Borough|Census Area|Municipality))*$/i;
 
 type CanonicalSuffix =
 	| 'County'
@@ -16,7 +16,6 @@ type CanonicalSuffix =
 	| 'Census Area'
 	| 'City and Borough'
 	| 'City and County'
-	| 'Municipio'
 	| 'Municipality';
 
 type CanonicalCountyName = {
@@ -32,7 +31,6 @@ const SUFFIX_NORMALIZATION: Record<string, CanonicalSuffix> = {
 	'census area': 'Census Area',
 	'city and borough': 'City and Borough',
 	'city and county': 'City and County',
-	municipio: 'Municipio',
 	municipality: 'Municipality',
 };
 
@@ -62,14 +60,13 @@ function pickSuffixByState(
 		return 'Borough';
 	}
 	if (upper === 'LA') return 'Parish';
-	if (upper === 'PR') return 'Municipio';
 	if (existingSuffix === 'City and County') return existingSuffix;
 	return 'County';
 }
 
 /**
  * Canonical county-equivalent naming for county-level display surfaces.
- * Enforces AK/LA/PR conventions and defensively cleans malformed double suffixes.
+ * Enforces AK/LA conventions and defensively cleans malformed double suffixes.
  */
 export function canonicalizeCountyEquivalentName(
 	stateCode: string,

--- a/src/lib/sitemap-entries.test.ts
+++ b/src/lib/sitemap-entries.test.ts
@@ -31,7 +31,6 @@ describe('stripCountySuffix (sitemap-entries)', () => {
 		['Jefferson Parish', 'Jefferson'],
 		['Fairbanks North Star Borough', 'Fairbanks North Star'],
 		['Yukon-Koyukuk Census Area', 'Yukon-Koyukuk'],
-		['San Juan Municipio', 'San Juan'],
 		['Juneau City and Borough', 'Juneau'],
 		['San Francisco City and County', 'San Francisco'],
 	])('strips suffix from "%s"', (input, expected) => {
@@ -95,15 +94,6 @@ describe('buildCountyLookups', () => {
 		const { citySlugToCountySlug } = buildCountyLookups(places, cities);
 
 		expect(citySlugToCountySlug.get('ak/galena')).toBe('ak/yukon-koyukuk-census-area');
-	});
-
-	test('maps city to county with Municipio suffix', () => {
-		const places = [countyPlace('pr/san-juan-municipio', 'San Juan Municipio')];
-		const cities = [cityPlace('pr/san-juan-city', 'San Juan Municipio')];
-
-		const { citySlugToCountySlug } = buildCountyLookups(places, cities);
-
-		expect(citySlugToCountySlug.get('pr/san-juan-city')).toBe('pr/san-juan-municipio');
 	});
 
 	test('maps city to county with City and Borough suffix', () => {

--- a/src/lib/sitemap-entries.ts
+++ b/src/lib/sitemap-entries.ts
@@ -7,7 +7,7 @@ import type { MetadataRoute } from 'next';
 import { sanityClient } from '~/sanity/sanityClient';
 import { stripCountySuffix as stripCountySuffixFromHelpers } from '~/lib/electionsHelpers';
 
-/** 51 US state/territory codes (50 states + DC) */
+/** 51 US state/DC codes (50 states + DC) */
 export const US_STATE_CODES = [
 	'AL', 'AK', 'AZ', 'AR', 'CA', 'CO', 'CT', 'DE', 'DC', 'FL', 'GA', 'HI', 'ID', 'IL', 'IN', 'IA', 'KS', 'KY', 'LA', 'ME', 'MD', 'MA', 'MI', 'MN', 'MS', 'MO', 'MT', 'NE', 'NV', 'NH', 'NJ', 'NM', 'NY', 'NC', 'ND', 'OH', 'OK', 'OR', 'PA', 'RI', 'SC', 'SD', 'TN', 'TX', 'UT', 'VT', 'VA', 'WA', 'WV', 'WI', 'WY',
 ] as const;


### PR DESCRIPTION
- **State elections index:** Replace raw `G54xx` filtering with `isStateIndexDistrictPlace` so Maine (and similar) API rows that use school-district MTFCC for municipalities no longer appear under "districts" when they look like two-segment place slugs without district keywords.
- **County locality lists:** `getCityPlacesByCounty` now fetches **incorporated places (`G4110`) and Census towns (`G4040`)**, then applies the same `countyName` matching as before. This fills county pages when the API returns few or no hierarchy `children` but many `G4040` rows with correct `countyName` (common in Maine).
- **Regression:** Extended district-name keywords so Vermont **UHSD** and **supervisory union** rows are still classified as districts (validated against live VT payloads).

## Context
Root cause was **API shape** (many ME places under `G5420` with short slugs; sparse `children` on county records; most localities as `G4040`), not incorrect `G4020` county rows. This matches the Census MTFCC model (county vs incorporated place vs town vs school district).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts how places are classified and fetched for elections index/counties, which can change what locations users see (especially for Maine/Vermont) if the heuristics are off or API data shifts.
> 
> **Overview**
> Updates the state elections index to build its "districts" list via new `isStateIndexDistrictPlace` heuristics (slug shape/suffix + district keywords) instead of raw `G54xx` matching, preventing municipality-like Maine rows from showing up as districts while keeping real district entities (e.g., VT UHSD/supervisory unions).
> 
> Expands county locality fallback logic by having `getCityPlacesByCounty` fetch and county-match both incorporated places (`G4110`) and towns (`G4040`), with tests added to cover Maine’s sparse county `children` payloads and the new district filter behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36fde03644e26b5f2727a50d4f8e69de519f3393. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->