### PR TITLE
fix: strip HubSpot tracking params in middleware (308)

### DIFF
--- a/src/lib/stripHubSpotTrackingParams.test.ts
+++ b/src/lib/stripHubSpotTrackingParams.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from 'bun:test';
+import { urlWithoutHubSpotTrackingParams } from './stripHubSpotTrackingParams';
+
+describe('urlWithoutHubSpotTrackingParams', () => {
+	test('returns null when no HubSpot params', () => {
+		const u = new URL('https://goodparty.org/blog/article/foo?utm_source=x');
+		expect(urlWithoutHubSpotTrackingParams(u)).toBeNull();
+		expect(u.search).toBe('?utm_source=x');
+	});
+
+	test('returns null when search is empty', () => {
+		const u = new URL('https://goodparty.org/blog');
+		expect(urlWithoutHubSpotTrackingParams(u)).toBeNull();
+	});
+
+	test('strips only HubSpot params and removes query when nothing left', () => {
+		const u = new URL('https://goodparty.org/p?__hstc=1&__hssc=2&__hsfp=3');
+		const next = urlWithoutHubSpotTrackingParams(u);
+		expect(next?.href).toBe('https://goodparty.org/p');
+		expect(u.search).toBe('?__hstc=1&__hssc=2&__hsfp=3');
+	});
+
+	test('strips HubSpot params and preserves others', () => {
+		const u = new URL(
+			'https://goodparty.org/blog/article/slug?__hstc=a&utm_medium=email&__hsfp=b&foo=bar',
+		);
+		const next = urlWithoutHubSpotTrackingParams(u);
+		expect(next?.pathname).toBe('/blog/article/slug');
+		const sp = next?.searchParams;
+		expect(sp?.get('utm_medium')).toBe('email');
+		expect(sp?.get('foo')).toBe('bar');
+		expect(sp?.has('__hstc')).toBe(false);
+		expect(sp?.has('__hsfp')).toBe(false);
+		expect(sp?.has('__hssc')).toBe(false);
+	});
+
+	test('strips one HubSpot param and leaves the rest of query', () => {
+		const u = new URL('https://goodparty.org/x?__hstc=1&keep=1');
+		const next = urlWithoutHubSpotTrackingParams(u);
+		expect(next?.href).toBe('https://goodparty.org/x?keep=1');
+	});
+
+	test('does not mutate input URL', () => {
+		const href =
+			'https://goodparty.org/a?__hstc=1&utm_campaign=z';
+		const u = new URL(href);
+		urlWithoutHubSpotTrackingParams(u);
+		expect(u.href).toBe(href);
+	});
+});

--- a/src/lib/stripHubSpotTrackingParams.ts
+++ b/src/lib/stripHubSpotTrackingParams.ts
@@ -1,0 +1,22 @@
+const HUBSPOT_TRACKING_KEYS = ['__hstc', '__hssc', '__hsfp'] as const;
+
+/**
+ * If the URL's query string contains HubSpot tracking parameters, returns a new
+ * URL with those keys removed. Other query keys are preserved. Returns null if
+ * nothing was removed.
+ */
+export function urlWithoutHubSpotTrackingParams(url: URL): URL | null {
+	const next = new URL(url.href);
+	let removed = false;
+	for (const key of HUBSPOT_TRACKING_KEYS) {
+		if (next.searchParams.has(key)) {
+			next.searchParams.delete(key);
+			removed = true;
+		}
+	}
+	if (!removed) return null;
+
+	const qs = next.searchParams.toString();
+	next.search = qs;
+	return next;
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,4 +1,5 @@
 import { type NextRequest, NextResponse } from 'next/server';
+import { urlWithoutHubSpotTrackingParams } from '~/lib/stripHubSpotTrackingParams';
 
 type RedirectMap = Record<string, { to: string; permanent: boolean }>;
 
@@ -75,6 +76,11 @@ function maybeBootstrapAmplitudeDeviceCookie(
 }
 
 export async function middleware(request: NextRequest): Promise<NextResponse> {
+	const withoutHubSpot = urlWithoutHubSpotTrackingParams(request.nextUrl);
+	if (withoutHubSpot) {
+		return withPreviewNoIndex(NextResponse.redirect(withoutHubSpot, 308));
+	}
+
 	const origin = request.nextUrl.origin;
 
 	let map: RedirectMap;


### PR DESCRIPTION
## Summary

Adds an early middleware check that issues a **308 Permanent Redirect** when a request includes HubSpot cookie-bridging query parameters (`__hstc`, `__hssc`, `__hsfp`). The redirect target is the same path with only those keys removed; all other query parameters are left unchanged.

## Why

Parameterized URLs were showing up in Google Search Console as separate URLs from the clean article/page URLs. Sending bots (and users) to a single URL shape complements existing canonical metadata and reduces duplicate discovery.

## Implementation

- New helper `urlWithoutHubSpotTrackingParams` in `src/lib/stripHubSpotTrackingParams.ts` (unit-tested).
- Wired at the **start** of `src/middleware.ts` so Sanity redirect map fetch is skipped when the only work needed is stripping these params.

## How to test

- `bun test src/lib/stripHubSpotTrackingParams.test.ts`
- With dev server running, e.g. `curl -I 'http://localhost:3009/blog?__hstc=1'` and expect **308** with `Location` pointing to `/blog` (no HubSpot keys).

## Notes

- Does not strip `utm_*` or other marketing params unless they share the HubSpot keys above.
- Preview deployments still get `X-Robots-Tag: noindex, nofollow` via existing `withPreviewNoIndex` on the redirect response.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds an early middleware redirect that changes request handling for any URL containing `__hstc`/`__hssc`/`__hsfp`, which could impact routing/caching/SEO if misapplied, though it’s narrowly scoped to specific query keys.
> 
> **Overview**
> Requests that include HubSpot cookie-bridging query params (`__hstc`, `__hssc`, `__hsfp`) are now **normalized via an early `308` redirect** to the same URL with only those keys removed (other query params preserved), short-circuiting the rest of middleware work.
> 
> This introduces a new helper `urlWithoutHubSpotTrackingParams` (with Bun unit tests) to strip those keys without mutating the input URL, and applies existing preview `X-Robots-Tag` behavior to the redirect response.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c941be3b51392748f1c925596034c3af0cc9965e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->