### PR TITLE
Fix middleware redirects and improve Sanity/static-build reliability

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -38,6 +38,8 @@ const nextConfig = {
 		];
 	},
 	devIndicators: false,
+	/** Default 60s is too tight on slow or proxied networks (many Sanity/API fetches per page). */
+	staticPageGenerationTimeout: 240,
 	swcMinify: true,
 	reactStrictMode: true,
 	poweredByHeader: false,
@@ -76,6 +78,9 @@ const nextConfig = {
 		taint: false,
 		// optimizeServerReact: true,
 		appDocumentPreloading: false,
+		/** Fewer concurrent prerenders reduces flaky TLS resets through strict corporate proxies. */
+		staticGenerationMaxConcurrency: 6,
+		staticGenerationRetryCount: 5,
 	},
 	webpack(config) {
 		config.module.rules.push({

--- a/src/app/api/redirects/route.ts
+++ b/src/app/api/redirects/route.ts
@@ -1,35 +1,15 @@
 import { NextResponse } from 'next/server';
+import {
+	REDIRECTS_GROQ,
+	entriesToRedirectMap,
+	type RedirectEntry,
+} from '~/lib/redirect-map';
 import { sanityClient } from '~/sanity/sanityClient';
 
-interface RedirectEntry {
-	field_fromUrl?: string;
-	field_toUrl?: string;
-	field_permanentRedirect?: boolean;
-}
-
-const QUERY = `*[_type=="goodpartyOrg_redirects"][0].list_redirects[]{field_fromUrl,field_toUrl,field_permanentRedirect}`;
-
-function normalizePath(path: string): string {
-	return path.endsWith('/') && path.length > 1 ? path.slice(0, -1) : path;
-}
-
 export async function GET() {
-	const entries = await sanityClient.fetch<RedirectEntry[] | null>(QUERY, undefined, {
+	const entries = await sanityClient.fetch<RedirectEntry[] | null>(REDIRECTS_GROQ, {}, {
 		next: { tags: ['goodpartyOrg_redirects'] },
 	});
 
-	const map: Record<string, { to: string; permanent: boolean }> = {};
-
-	if (entries) {
-		for (const entry of entries) {
-			if (entry.field_fromUrl && entry.field_toUrl) {
-				map[normalizePath(entry.field_fromUrl)] = {
-					to: entry.field_toUrl,
-					permanent: entry.field_permanentRedirect ?? false,
-				};
-			}
-		}
-	}
-
-	return NextResponse.json(map);
+	return NextResponse.json(entriesToRedirectMap(entries));
 }

--- a/src/lib/redirect-map.ts
+++ b/src/lib/redirect-map.ts
@@ -1,0 +1,46 @@
+import { dataset, projectId } from '~/lib/env';
+
+export type RedirectMap = Record<string, { to: string; permanent: boolean }>;
+
+export interface RedirectEntry {
+	field_fromUrl?: string;
+	field_toUrl?: string;
+	field_permanentRedirect?: boolean;
+}
+
+/** GROQ for CMS-driven paths; keep in sync with `src/app/api/redirects/route.ts`. */
+export const REDIRECTS_GROQ =
+	'*[_type=="goodpartyOrg_redirects"][0].list_redirects[]{field_fromUrl,field_toUrl,field_permanentRedirect}';
+
+const SANITY_QUERY_API_VERSION = '2025-10-08';
+
+export function normalizePath(path: string): string {
+	return path.endsWith('/') && path.length > 1 ? path.slice(0, -1) : path;
+}
+
+export function entriesToRedirectMap(entries: RedirectEntry[] | null | undefined): RedirectMap {
+	const map: RedirectMap = {};
+	if (!entries) return map;
+	for (const entry of entries) {
+		if (entry.field_fromUrl && entry.field_toUrl) {
+			map[normalizePath(entry.field_fromUrl)] = {
+				to: entry.field_toUrl,
+				permanent: entry.field_permanentRedirect ?? false,
+			};
+		}
+	}
+	return map;
+}
+
+/**
+ * Load redirect rules from Sanity without calling this app’s `/api/redirects`.
+ * Same-origin fetches from middleware deadlock Next.js dev (e.g. Bun + Turbopack).
+ */
+export async function fetchRedirectMapFromSanityCdn(): Promise<RedirectMap> {
+	const query = encodeURIComponent(REDIRECTS_GROQ);
+	const url = `https://${projectId}.apicdn.sanity.io/v${SANITY_QUERY_API_VERSION}/data/query/${dataset}?query=${query}`;
+	const res = await fetch(url, { headers: { Accept: 'application/json' } });
+	if (!res.ok) throw new Error(`Sanity CDN responded ${res.status}`);
+	const data = (await res.json()) as { result: RedirectEntry[] | null };
+	return entriesToRedirectMap(data.result);
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,6 +1,9 @@
 import { type NextRequest, NextResponse } from 'next/server';
-
-type RedirectMap = Record<string, { to: string; permanent: boolean }>;
+import {
+	type RedirectMap,
+	fetchRedirectMapFromSanityCdn,
+	normalizePath,
+} from '~/lib/redirect-map';
 
 /** Runtime gate — avoids baking preview-only headers into the build (next.config headers). */
 function withPreviewNoIndex(response: NextResponse): NextResponse {
@@ -8,10 +11,6 @@ function withPreviewNoIndex(response: NextResponse): NextResponse {
 		response.headers.set('X-Robots-Tag', 'noindex, nofollow');
 	}
 	return response;
-}
-
-function normalizePath(path: string): string {
-	return path.endsWith('/') && path.length > 1 ? path.slice(0, -1) : path;
 }
 
 /**
@@ -35,15 +34,12 @@ function encodeAmplitudeBrowserSdk20Cookie(deviceId: string): string {
 
 /**
  * First-time visitors have no `AMP_*` cookie yet, so SSR cannot bucket them.
- * Bootstrap the same cookie shape the Browser SDK uses, forward it on this
- * request, and set it on the response so the client keeps the same device id.
- *
  * Runs on every page route the matcher allows so experiments can be resolved
- * server-side on first visit, not just on the homepage.
+ * server-side on first visit, not just on the homepage. Bootstrap the same
+ * cookie shape the Browser SDK uses, forward it on this request, and set it
+ * on the response so the client keeps the same device id.
  */
-function maybeBootstrapAmplitudeDeviceCookie(
-	request: NextRequest,
-): NextResponse | null {
+function maybeBootstrapAmplitudeDeviceCookie(request: NextRequest): NextResponse | null {
 	const apiKey = process.env['NEXT_PUBLIC_AMPLITUDE_API_KEY'];
 	const cookieName = apiKey ? amplitudeBrowserSdk20CookieName(apiKey) : null;
 	if (!cookieName) return null;
@@ -75,15 +71,11 @@ function maybeBootstrapAmplitudeDeviceCookie(
 }
 
 export async function middleware(request: NextRequest): Promise<NextResponse> {
-	const origin = request.nextUrl.origin;
-
-	let map: RedirectMap;
+	let map: RedirectMap = {};
 	try {
-		const res = await fetch(`${origin}/api/redirects`);
-		if (!res.ok) return withPreviewNoIndex(NextResponse.next());
-		map = (await res.json()) as RedirectMap;
+		map = await fetchRedirectMapFromSanityCdn();
 	} catch {
-		return withPreviewNoIndex(NextResponse.next());
+		// CMS fetch failed — continue without CMS redirects (still run Amplitude cookie bootstrap).
 	}
 
 	const pathname = normalizePath(request.nextUrl.pathname);

--- a/src/sanity/sanityClient.ts
+++ b/src/sanity/sanityClient.ts
@@ -3,14 +3,75 @@ import { projectId, dataset } from 'env';
 import { draftMode } from 'next/headers';
 import { token } from '~/lib/env';
 
+async function sleep(ms: number): Promise<void> {
+	await new Promise<void>(resolve => setTimeout(resolve, ms));
+}
+
+function isAbortError(err: unknown): boolean {
+	return err instanceof Error && err.name === 'AbortError';
+}
+
+/**
+ * Transient TLS / proxy / middlebox resets are common on corporate networks during
+ * parallel static generation; retry a few times with backoff before failing the build.
+ */
+function isRetryableSanityError(err: unknown): boolean {
+	if (!err || typeof err !== 'object') return false;
+	if (isAbortError(err)) return false;
+
+	const e = err as { code?: string; isNetworkError?: boolean; statusCode?: number; message?: string };
+	if (e.isNetworkError) return true;
+	if (
+		e.code === 'ECONNRESET' ||
+		e.code === 'ETIMEDOUT' ||
+		e.code === 'ECONNREFUSED' ||
+		e.code === 'ESOCKETTIMEDOUT'
+	)
+		return true;
+	if (typeof e.statusCode === 'number' && e.statusCode >= 500 && e.statusCode <= 504) return true;
+
+	const msg = String(e.message ?? '');
+	if (/socket connection was closed|socket timed out|ECONNRESET|ETIMEDOUT|fetch failed|network error|UND_ERR_CONNECT_TIMEOUT/i.test(msg))
+		return true;
+	return false;
+}
+
+async function withSanityNetworkRetries<T>(fn: () => Promise<T>): Promise<T> {
+	const maxAttempts = 3;
+	const baseMs = 400;
+	let lastErr: unknown;
+	for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+		try {
+			return await fn();
+		} catch (err) {
+			lastErr = err;
+			if (!isRetryableSanityError(err) || attempt === maxAttempts) throw err;
+			const delay = baseMs * 2 ** (attempt - 1) + Math.random() * 250;
+			if (process.env['NODE_ENV'] !== 'production' || process.env['SANITY_FETCH_VERBOSE'] === '1') {
+				console.warn(`[sanity] fetch retry ${attempt}/${maxAttempts} (${err instanceof Error ? err.message : err})`);
+			}
+			await sleep(delay);
+		}
+	}
+	throw lastErr;
+}
+
 // Canonical: tag-based revalidation via sanityFetch. electionsApi.ts and ashby.ts use time-based caching; migrate to tags in a follow-up.
-export const sanityClient = createClient({
+const _sanityClient = createClient({
 	projectId,
 	dataset,
 	apiVersion: '2025-10-08',
 	useCdn: true,
 	perspective: 'published',
+	/** Extra attempts on top of get-it defaults; static builds fan out many parallel CDN requests. */
+	maxRetries: 10,
 });
+
+const _sanityFetch = _sanityClient.fetch.bind(_sanityClient);
+_sanityClient.fetch = (async (...args: Parameters<typeof _sanityFetch>) =>
+	withSanityNetworkRetries(async () => _sanityFetch(...args))) as typeof _sanityClient.fetch;
+
+export const sanityClient = _sanityClient;
 
 // Pull the augmented SanityQueries interface:
 declare module '@sanity/client' {


### PR DESCRIPTION
## Summary
- **Middleware redirects:** Load CMS redirect rules from the Sanity CDN via a shared `redirect-map` module instead of fetching this app’s `/api/redirects`. Same-origin fetches from middleware can deadlock in dev (e.g. Bun + Turbopack); on fetch failure we now continue without CMS redirects instead of short-circuiting the rest of the chain.
- **API:** `/api/redirects` reuses the same GROQ and `entriesToRedirectMap` helper for a single source of truth.
- **Static generation:** Raise `staticPageGenerationTimeout`, cap `staticGenerationMaxConcurrency`, and set `staticGenerationRetryCount` to reduce flakes on slow or strict corporate proxies.
- **Sanity client:** Retry transient network/TLS/proxy errors with backoff and higher `maxRetries` on the client.
- **Amplitude:** No intentional behavior change here after review — device cookie bootstrap remains on all routes covered by the middleware matcher when applicable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches request-time middleware redirect behavior and adds retry/backoff logic to Sanity fetches, which could impact routing and build stability if misconfigured. Changes are bounded but affect edge/runtime paths and build-time networking.
> 
> **Overview**
> **Fixes CMS-driven redirects in middleware** by introducing a shared `redirect-map` helper and having middleware fetch redirect rules directly from the Sanity CDN (avoiding same-origin `/api/redirects` calls that can deadlock in dev); on fetch failure it now continues without CMS redirects rather than bailing out of the chain.
> 
> **Unifies redirect logic** by updating `/api/redirects` to reuse the shared `REDIRECTS_GROQ` + `entriesToRedirectMap` helpers.
> 
> **Improves build reliability on slow/proxied networks** by increasing `staticPageGenerationTimeout`, reducing `staticGenerationMaxConcurrency`, adding `staticGenerationRetryCount`, and wrapping `sanityClient.fetch` with retry/backoff for transient network/TLS errors (plus higher Sanity client `maxRetries`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48f5144da27c998404331b387355c695b6952de7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->