### PR TITLE
Enhance schema generation across various pages

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -55,6 +55,7 @@
         "babel-plugin-react-compiler": "^1.0.0",
         "chromatic": "^14.0.0--canary.1188.15686730781.0",
         "clsx": "^2.1.1",
+        "date-fns": "^4.3.0",
         "dompurify": "^3.3.1",
         "embla-carousel": "^8.6.0",
         "embla-carousel-react": "^8.6.0",
@@ -2027,7 +2028,7 @@
 
     "dataloader": ["dataloader@2.2.3", "", {}, "sha512-y2krtASINtPFS1rSDjacrFgn1dcUuoREVabwlOGOe4SdxenREqwjwjElAdwvbGM7kgZz9a3KVicWR7vcz8rnzA=="],
 
-    "date-fns": ["date-fns@3.6.0", "", {}, "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww=="],
+    "date-fns": ["date-fns@4.3.0", "", {}, "sha512-OYcL+3N/jyWbYdFGqoMAhytDgxP9pbYPUUiRCOgn4Fewaadk9l/Wam4Avciiyp2BgkpfQyBV9B+ehnVJych+eQ=="],
 
     "debounce": ["debounce@1.2.1", "", {}, "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug=="],
 
@@ -3890,6 +3891,8 @@
     "@portabletext/to-html/@portabletext/toolkit": ["@portabletext/toolkit@5.0.0", "", { "dependencies": { "@portabletext/types": "^4.0.0" } }, "sha512-jcDOv1RKO/j08pdnc/6i5tULcAzEYCR41XDVYOqmmX8bvEJbWJabhpVjHT1ls6p27v9gtA4NG2SO5xdMpgWSQQ=="],
 
     "@portabletext/to-html/@portabletext/types": ["@portabletext/types@4.0.0", "", {}, "sha512-mEoN82OQckrshqRx8idp+x8B/OpMfUMSjQp1w1wZFM3hf8cplGhK59Sa/UuGU6XdgAnFq90vJtnj5ejOmZmhvw=="],
+
+    "@sanity/assist/date-fns": ["date-fns@3.6.0", "", {}, "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww=="],
 
     "@sanity/codegen/groq": ["groq@4.22.0", "", {}, "sha512-98P1gLlIHbdB0wP2dPsKsn6c31iaUoPi+ES+iwNpe7L8sQp7zYWm/yZDdX/KEdCloCPthTlWIYEXVKHqiTc0eA=="],
 

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "babel-plugin-react-compiler": "^1.0.0",
     "chromatic": "^14.0.0--canary.1188.15686730781.0",
     "clsx": "^2.1.1",
+    "date-fns": "^4.3.0",
     "dompurify": "^3.3.1",
     "embla-carousel": "^8.6.0",
     "embla-carousel-react": "^8.6.0",

--- a/src/PageSections/FAQBlockSection.tsx
+++ b/src/PageSections/FAQBlockSection.tsx
@@ -2,12 +2,18 @@ import { stegaClean } from 'next-sanity';
 import { transformButtons } from '~/lib/buttonTransformer';
 import type { Sections } from '~/PageSections';
 import { resolveFAQItems } from '~/ui/_lib/resolveFAQItems';
+import { resolveFAQItemsAsText } from '~/lib/resolveFAQItemsAsText';
 import { FAQBlock } from '~/ui/FAQBlock';
 import { RichData } from '~/ui/RichData';
+import { PageSchema } from '~/ui/PageSchema';
+import { buildFAQSchema } from '~/lib/schema';
 
 export function FAQBlockSection(section: Extract<Sections, { _type: 'component_faqBlock' }>) {
+	const sourceFaqs = (section.faQsContentCollection?.['faQs'] ?? null) as Parameters<typeof resolveFAQItemsAsText>[0];
+	const faqSchema = buildFAQSchema(resolveFAQItemsAsText(sourceFaqs));
 	return (
 		<section id={stegaClean(section.componentSettings?.field_anchorId)} data-section='FAQ Block'>
+			<PageSchema schema={faqSchema ?? undefined} />
 			<FAQBlock
 				header={{
 					label: section.summaryInfo?.field_label,

--- a/src/RichTextContentSections/index.tsx
+++ b/src/RichTextContentSections/index.tsx
@@ -1,6 +1,6 @@
 import { PortableText } from '@portabletext/react';
 import { ComponentErrorBoundary } from '~/ui/ComponentErrorBoundary';
-import type { ArticleQueryResult } from 'sanity.types';
+import type { ArticleQueryResult, Block_policyText } from 'sanity.types';
 import { ImageCTAGroup } from '~/RichTextContentSections/ImageCTAGroup';
 import { CTASectionGroup } from '~/RichTextContentSections/CTASectionGroup';
 import { TableSectionGroup } from '~/RichTextContentSections/TableSectionGroup';
@@ -18,7 +18,7 @@ export type ArticleSections = NonNullable<
 >;
 
 interface Props {
-	contentSections?: ArticleSections[] | null;
+	contentSections?: ArticleSections[] | Block_policyText | null;
 	stackSpacing?: TypographyStackSpacing;
 }
 

--- a/src/app/[slug]/page.tsx
+++ b/src/app/[slug]/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata, ResolvingMetadata } from 'next';
 import { Suspense } from 'react';
 import { notFound } from 'next/navigation';
+import { stegaClean } from 'next-sanity';
 import { goodpartyOrg_landingPagesAndPolicyQuery } from '~/sanity/groq';
 import { sanityFetch } from '~/sanity/sanityClient';
 
@@ -11,6 +12,9 @@ import { PageSections } from '~/PageSections';
 import { ExperimentResolver } from '~/experiments/ExperimentResolver';
 import { HeaderBlock } from '~/ui/HeaderBlock';
 import { Container } from '~/ui/Container';
+import { PageSchema } from '~/ui/PageSchema';
+import { buildWebPageSchema } from '~/lib/schema';
+import { toAbsoluteUrl } from '~/lib/url';
 
 // SSR per request so ExperimentResolver reads the visitor's AMP_* cookie and
 // resolves the variant on the server before HTML is sent (no client flicker).
@@ -36,27 +40,61 @@ export default async function Page(props: any) {
 		notFound();
 	}
 
+	const pageUrl = page.href ? toAbsoluteUrl(page.href) : toAbsoluteUrl(`/${slug}`);
+	const seoDescription = page.seo?.field_metaDescription
+		? stegaClean(page.seo.field_metaDescription)
+		: undefined;
+
 	if (page._type === 'goodpartyOrg_landingPages') {
 		const controlSections = page.pageSections?.list_pageSections;
+		const landingName = page.detailPageOverviewNoHero?.field_pageName
+			? stegaClean(page.detailPageOverviewNoHero.field_pageName)
+			: slug;
+		const landingSchema = buildWebPageSchema({
+			url: pageUrl,
+			name: landingName,
+			description: seoDescription,
+		});
 		return (
-			<Suspense fallback={<PageSections pageSections={controlSections} />}>
-				<ExperimentResolver pageId={page._id} controlSections={controlSections} />
-			</Suspense>
+			<>
+				<PageSchema schema={landingSchema} />
+				<Suspense fallback={<PageSections pageSections={controlSections} />}>
+					<ExperimentResolver pageId={page._id} controlSections={controlSections} />
+				</Suspense>
+			</>
 		);
 	}
 	if (page._type === 'policy') {
+		const policyName = page.policyOverview?.field_policyName
+			? stegaClean(page.policyOverview.field_policyName)
+			: slug;
+		const policySummary = page.policyOverview?.field_policySummary
+			? stegaClean(page.policyOverview.field_policySummary)
+			: undefined;
+		const lastUpdated = page.policyOverview?.field_lastUpdated
+			? new Date(stegaClean(page.policyOverview.field_lastUpdated)).toISOString()
+			: undefined;
+		const policySchema = buildWebPageSchema({
+			url: pageUrl,
+			name: policyName,
+			description: policySummary ?? seoDescription,
+			dateModified: lastUpdated,
+		});
 		return (
-			<Container className='bg-goodparty-cream py-(--container-padding) flex flex-col gap-12' size='xl'>
-				<HeaderBlock
-					title={page.policyOverview?.field_policyName}
-					copy={`${page.policyOverview?.field_policySummary ?? ''}${
-						page.policyOverview?.field_lastUpdated
-							? ` | ${new Date(page.policyOverview.field_lastUpdated).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}`
-							: ''
-					}`}
-				/>
-				<RichTextContentSections contentSections={page.policySections?.block_policyText as any} />
-			</Container>
+			<>
+				<PageSchema schema={policySchema} />
+				<Container className='bg-goodparty-cream py-(--container-padding) flex flex-col gap-12' size='xl'>
+					<HeaderBlock
+						title={page.policyOverview?.field_policyName}
+						copy={`${page.policyOverview?.field_policySummary ?? ''}${
+							page.policyOverview?.field_lastUpdated
+								? ` | ${new Date(page.policyOverview.field_lastUpdated).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}`
+								: ''
+						}`}
+					/>
+					<RichTextContentSections contentSections={page.policySections?.block_policyText as any} />
+				</Container>
+			</>
 		);
 	}
 	return null;

--- a/src/app/[slug]/page.tsx
+++ b/src/app/[slug]/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata, ResolvingMetadata } from 'next';
 import { Suspense } from 'react';
 import { notFound } from 'next/navigation';
 import { stegaClean } from 'next-sanity';
+import { format, parseISO } from 'date-fns';
 import { goodpartyOrg_landingPagesAndPolicyQuery } from '~/sanity/groq';
 import { sanityFetch } from '~/sanity/sanityClient';
 
@@ -15,6 +16,7 @@ import { Container } from '~/ui/Container';
 import { PageSchema } from '~/ui/PageSchema';
 import { buildWebPageSchema } from '~/lib/schema';
 import { toAbsoluteUrl } from '~/lib/url';
+import { SANITY_DOC_TYPE } from '~/lib/sanity-doc-types';
 
 // SSR per request so ExperimentResolver reads the visitor's AMP_* cookie and
 // resolves the variant on the server before HTML is sent (no client flicker).
@@ -36,7 +38,7 @@ export default async function Page(props: any) {
 		tags: ['goodpartyOrg_landingPages', 'policy'],
 	});
 
-	if (!page || !(page._type === 'goodpartyOrg_landingPages' || page._type === 'policy')) {
+	if (!page || !(page._type === SANITY_DOC_TYPE.LANDING_PAGE || page._type === SANITY_DOC_TYPE.POLICY)) {
 		notFound();
 	}
 
@@ -45,7 +47,7 @@ export default async function Page(props: any) {
 		? stegaClean(page.seo.field_metaDescription)
 		: undefined;
 
-	if (page._type === 'goodpartyOrg_landingPages') {
+	if (page._type === SANITY_DOC_TYPE.LANDING_PAGE) {
 		const controlSections = page.pageSections?.list_pageSections;
 		const landingName = page.detailPageOverviewNoHero?.field_pageName
 			? stegaClean(page.detailPageOverviewNoHero.field_pageName)
@@ -64,7 +66,7 @@ export default async function Page(props: any) {
 			</>
 		);
 	}
-	if (page._type === 'policy') {
+	if (page._type === SANITY_DOC_TYPE.POLICY) {
 		const policyName = page.policyOverview?.field_policyName
 			? stegaClean(page.policyOverview.field_policyName)
 			: slug;
@@ -72,7 +74,7 @@ export default async function Page(props: any) {
 			? stegaClean(page.policyOverview.field_policySummary)
 			: undefined;
 		const lastUpdated = page.policyOverview?.field_lastUpdated
-			? new Date(stegaClean(page.policyOverview.field_lastUpdated)).toISOString()
+			? parseISO(stegaClean(page.policyOverview.field_lastUpdated)).toISOString()
 			: undefined;
 		const policySchema = buildWebPageSchema({
 			url: pageUrl,
@@ -84,15 +86,15 @@ export default async function Page(props: any) {
 			<>
 				<PageSchema schema={policySchema} />
 				<Container className='bg-goodparty-cream py-(--container-padding) flex flex-col gap-12' size='xl'>
-					<HeaderBlock
-						title={page.policyOverview?.field_policyName}
-						copy={`${page.policyOverview?.field_policySummary ?? ''}${
-							page.policyOverview?.field_lastUpdated
-								? ` | ${new Date(page.policyOverview.field_lastUpdated).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}`
-								: ''
-						}`}
-					/>
-					<RichTextContentSections contentSections={page.policySections?.block_policyText as any} />
+				<HeaderBlock
+					title={page.policyOverview?.field_policyName}
+					copy={`${page.policyOverview?.field_policySummary ?? ''}${
+						page.policyOverview?.field_lastUpdated
+							? ` | ${format(parseISO(stegaClean(page.policyOverview.field_lastUpdated)), 'MMM d, yyyy')}`
+							: ''
+					}`}
+				/>
+					<RichTextContentSections contentSections={page.policySections?.block_policyText} />
 				</Container>
 			</>
 		);
@@ -112,7 +114,7 @@ export async function generateMetadata(props: Params, parent: ResolvingMetadata)
 		tags: ['goodpartyOrg_landingPages', 'policy'],
 	});
 
-	if (page?._type === 'goodpartyOrg_landingPages') {
+	if (page?._type === SANITY_DOC_TYPE.LANDING_PAGE) {
 		return StructureMetaData(parentMetadata, {
 			name: page?.detailPageOverviewNoHero?.field_pageName,
 			seo: page?.seo,

--- a/src/app/blog/article/[slug]/page.tsx
+++ b/src/app/blog/article/[slug]/page.tsx
@@ -22,7 +22,15 @@ import { client } from '~/lib/client';
 import { format } from 'date-fns';
 import { stegaClean } from 'next-sanity';
 import { PageSchema } from '~/ui/PageSchema';
-import { DEFAULT_SHARE_IMAGE, getBaseUrl, getSanityImageUrl } from '~/lib/url';
+import { DEFAULT_SHARE_IMAGE, getBaseUrl, getSanityImageUrl, toAbsoluteUrl } from '~/lib/url';
+import {
+	buildArticleSchema,
+	buildBreadcrumbSchema,
+	buildFAQSchema,
+	buildSchemaGraph,
+	buildWebPageSchema,
+} from '~/lib/schema';
+import { resolveFAQItemsAsText } from '~/lib/resolveFAQItemsAsText';
 import { BlogBlock } from '~/ui/BlogBlock';
 import type { BlogCardProps } from '~/ui/BlogCard';
 import { resolveBlogCard } from '~/ui/_lib/resolveBlogCard';
@@ -68,21 +76,53 @@ export default async function Page(props: any) {
 	const publishedDate = page.editorialOverview?.field_publishedDate;
 	const updatedDate = page.editorialOverview?.field_lastUpdated;
 
-	const articleSchema = {
-		'@context': 'https://schema.org',
-		'@type': 'Article',
-		headline: page.editorialOverview?.field_editorialTitle ? stegaClean(page.editorialOverview.field_editorialTitle) : undefined,
-		...(page.editorialOverview?.ref_author?.personOverview?.field_personName && {
-			author: {
-				'@type': 'Person',
-				name: stegaClean(page.editorialOverview.ref_author.personOverview.field_personName),
-			},
-		}),
-		...(publishedDate && { datePublished: new Date(stegaClean(publishedDate)).toISOString() }),
-		...(updatedDate && { dateModified: new Date(stegaClean(updatedDate)).toISOString() }),
-		image: imageUrl,
+	const headline = page.editorialOverview?.field_editorialTitle
+		? stegaClean(page.editorialOverview.field_editorialTitle)
+		: '';
+	const metaDescription = page.seo?.field_metaDescription ? stegaClean(page.seo.field_metaDescription) : undefined;
+	const authorName = page.editorialOverview?.ref_author?.personOverview?.field_personName
+		? stegaClean(page.editorialOverview.ref_author.personOverview.field_personName)
+		: undefined;
+	const authorJobTitle = page.editorialOverview?.ref_author?.personOverview?.field_jobTitleOrRole
+		? stegaClean(page.editorialOverview.ref_author.personOverview.field_jobTitleOrRole)
+		: undefined;
+
+	const articleSchema = buildArticleSchema({
 		url: articleUrl,
-	};
+		headline,
+		description: metaDescription,
+		image: imageUrl,
+		datePublished: publishedDate ? new Date(stegaClean(publishedDate)).toISOString() : undefined,
+		dateModified: updatedDate ? new Date(stegaClean(updatedDate)).toISOString() : undefined,
+		authorName,
+		authorJobTitle,
+		pageType: 'BlogPosting',
+	});
+
+	const breadcrumbSchema = buildBreadcrumbSchema(breadcrumbs, toAbsoluteUrl);
+
+	const inlineFaqItems = ((page.contentSections?.block_editorialContentSections ?? []) as ReadonlyArray<
+		{ _type?: string | undefined }
+	>)
+		.filter(section => section?._type === 'faqs')
+		.flatMap(section =>
+			resolveFAQItemsAsText(
+				((section as { list_faQs?: unknown }).list_faQs ?? null) as Parameters<typeof resolveFAQItemsAsText>[0],
+			),
+		);
+	const faqSchema = buildFAQSchema(inlineFaqItems);
+
+	const articleGraph = buildSchemaGraph([
+		articleSchema,
+		breadcrumbSchema,
+		faqSchema,
+		buildWebPageSchema({
+			url: articleUrl,
+			name: headline || 'Article',
+			description: metaDescription,
+			image: imageUrl,
+		}),
+	]);
 
 	const relatedArticles = (page.relatedArticles?.list_relatedArticles ?? [])
 		.map(resolveBlogCard)
@@ -90,7 +130,7 @@ export default async function Page(props: any) {
 
 	return (
 		<>
-			<PageSchema schema={articleSchema} />
+			<PageSchema schema={articleGraph ?? undefined} />
 			<BlogArticleHero
 				title={page.editorialOverview?.field_editorialTitle}
 				tagline={{ label: page.editorialContentTags?.category?.tagOverview?.field_name, href: page.editorialContentTags?.category?.href }}

--- a/src/app/blog/article/[slug]/page.tsx
+++ b/src/app/blog/article/[slug]/page.tsx
@@ -19,7 +19,7 @@ import { EditorialLayout } from '~/components/EditorialLayout';
 import { resolveArticleNavigation } from '~/lib/resolveArticleNavigation';
 import { Author } from '~/ui/Author';
 import { client } from '~/lib/client';
-import { format } from 'date-fns';
+import { format, parseISO } from 'date-fns';
 import { stegaClean } from 'next-sanity';
 import { PageSchema } from '~/ui/PageSchema';
 import { DEFAULT_SHARE_IMAGE, getBaseUrl, getSanityImageUrl, toAbsoluteUrl } from '~/lib/url';
@@ -92,8 +92,8 @@ export default async function Page(props: any) {
 		headline,
 		description: metaDescription,
 		image: imageUrl,
-		datePublished: publishedDate ? new Date(stegaClean(publishedDate)).toISOString() : undefined,
-		dateModified: updatedDate ? new Date(stegaClean(updatedDate)).toISOString() : undefined,
+		datePublished: publishedDate ? parseISO(stegaClean(publishedDate)).toISOString() : undefined,
+		dateModified: updatedDate ? parseISO(stegaClean(updatedDate)).toISOString() : undefined,
 		authorName,
 		authorJobTitle,
 		pageType: 'BlogPosting',
@@ -140,11 +140,11 @@ export default async function Page(props: any) {
 					meta:
 						page.editorialOverview?.field_publishedDate || page.editorialOverview?.field_lastUpdated
 							? [
-									page.editorialOverview?.field_lastUpdated
-										? `Updated: ${format(new Date(stegaClean(page.editorialOverview?.field_lastUpdated)), 'MMM dd, yyyy')}`
-										: page.editorialOverview?.field_publishedDate
-											? format(new Date(stegaClean(page.editorialOverview?.field_publishedDate)), 'MMM dd, yyyy')
-											: '',
+							page.editorialOverview?.field_lastUpdated
+									? `Updated: ${format(parseISO(stegaClean(page.editorialOverview?.field_lastUpdated)), 'MMM dd, yyyy')}`
+									: page.editorialOverview?.field_publishedDate
+										? format(parseISO(stegaClean(page.editorialOverview?.field_publishedDate)), 'MMM dd, yyyy')
+										: '',
 								]
 							: undefined,
 				}}

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata, ResolvingMetadata } from 'next';
 import { notFound } from 'next/navigation';
+import { stegaClean } from 'next-sanity';
 import { goodpartyOrg_allArticlesQuery } from '~/sanity/groq';
 import { sanityFetch } from '~/sanity/sanityClient';
 import { PageSections } from '~/PageSections';
@@ -7,6 +8,9 @@ import { StructureMetaData } from '~/components/StructureMetadata';
 import type { Params } from '~/lib/types';
 import { getCachedArticles } from '~/lib/getCachedArticles';
 import { BlogHero } from '~/ui/BlogHero';
+import { PageSchema } from '~/ui/PageSchema';
+import { buildBreadcrumbSchema, buildSchemaGraph, buildWebPageSchema } from '~/lib/schema';
+import { toAbsoluteUrl } from '~/lib/url';
 
 export default async function Page(props: any) {
 	const page = await sanityFetch({
@@ -19,8 +23,28 @@ export default async function Page(props: any) {
 
 	const { articles } = await getCachedArticles();
 
+	const blogUrl = page.href ? toAbsoluteUrl(page.href) : toAbsoluteUrl('/blog');
+	const blogName = page.singlePageOverview?.field_pageName
+		? stegaClean(page.singlePageOverview.field_pageName)
+		: 'Blog';
+	const blogDescription = page.seo?.field_metaDescription
+		? stegaClean(page.seo.field_metaDescription)
+		: page.singlePageOverview?.field_summaryDescription
+			? stegaClean(page.singlePageOverview.field_summaryDescription)
+			: undefined;
+	const blogGraph = buildSchemaGraph([
+		buildWebPageSchema({
+			url: blogUrl,
+			name: blogName,
+			description: blogDescription,
+			pageType: 'CollectionPage',
+		}),
+		buildBreadcrumbSchema([{ href: '/blog', label: blogName }]),
+	]);
+
 	return (
 		<>
+			<PageSchema schema={blogGraph ?? undefined} />
 			<BlogHero
 				articles={articles}
 				title={page.singlePageOverview?.field_pageTitle ?? page.singlePageOverview?.field_pageName}

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata, ResolvingMetadata } from 'next';
 import { notFound } from 'next/navigation';
+import { stegaClean } from 'next-sanity';
 
 import { goodpartyOrg_contactQuery } from '~/sanity/groq';
 import { sanityFetch } from '~/sanity/sanityClient';
@@ -8,9 +9,11 @@ import { StructureMetaData } from '~/components/StructureMetadata';
 
 import { HeaderBlock } from '~/ui/HeaderBlock';
 import { Container } from '~/ui/Container';
-import { resolveTextSize } from '~/ui/_lib/resolveTextSize';
 
 import { PageSections } from '~/PageSections';
+import { PageSchema } from '~/ui/PageSchema';
+import { buildWebPageSchema } from '~/lib/schema';
+import { toAbsoluteUrl } from '~/lib/url';
 
 export default async function Page() {
 	const page = await sanityFetch({
@@ -21,8 +24,26 @@ export default async function Page() {
 	if (!page) {
 		notFound();
 	}
+
+	const contactUrl = page.href ? toAbsoluteUrl(page.href) : toAbsoluteUrl('/contact');
+	const contactName = page['contactPageOverview']?.field_pageTitle
+		? stegaClean(page['contactPageOverview'].field_pageTitle)
+		: 'Contact';
+	const contactDescription = page.seo?.field_metaDescription
+		? stegaClean(page.seo.field_metaDescription)
+		: page['contactPageOverview']?.field_summaryDescription
+			? stegaClean(page['contactPageOverview'].field_summaryDescription)
+			: undefined;
+	const contactSchema = buildWebPageSchema({
+		url: contactUrl,
+		name: contactName,
+		description: contactDescription,
+		pageType: 'ContactPage',
+	});
+
 	return (
 		<div className='bg-goodparty-cream'>
+			<PageSchema schema={contactSchema} />
 			<Container size='xl' className='py-(--container-padding) grid md:grid-cols-2'>
 				<HeaderBlock
 					title={page['contactPageOverview']?.field_pageTitle}

--- a/src/app/elections/[state]/[county]/[city]/page.tsx
+++ b/src/app/elections/[state]/[county]/[city]/page.tsx
@@ -29,6 +29,9 @@ import { ElectionsLandingWithSearch } from '~/ui/ElectionsLandingWithSearch';
 import { LocationFactsBlock } from '~/ui/LocationFactsBlock';
 import { Carousel } from '~/ui/Carousel';
 import { StepperBlock } from '~/ui/StepperBlock';
+import { PageSchema } from '~/ui/PageSchema';
+import { buildBreadcrumbSchema, buildSchemaGraph, buildWebPageSchema } from '~/lib/schema';
+import { toAbsoluteUrl } from '~/lib/url';
 
 export const revalidate = 3600;
 
@@ -186,8 +189,20 @@ export default async function Page({
 		: (dataYears[0] ?? currentYear);
 	const availableYears = dataYears.length > 0 ? dataYears : [currentYear];
 
+	const pageUrl = toAbsoluteUrl(`/elections/${fullSlug}`);
+	const cityGraph = buildSchemaGraph([
+		buildWebPageSchema({
+			url: pageUrl,
+			name: `Elections in ${cityName}, ${stateName}`,
+			description: `Browse elections and local positions in ${cityName}, ${countyPlace.name}, ${stateName}.`,
+			pageType: 'CollectionPage',
+		}),
+		buildBreadcrumbSchema(breadcrumbs, toAbsoluteUrl),
+	]);
+
 	return (
 		<>
+			<PageSchema schema={cityGraph ?? undefined} />
 			<BreadcrumbBlock backgroundColor="midnight" breadcrumbs={breadcrumbs} />
 			<ElectionsLandingWithSearch
 				heroProps={{

--- a/src/app/elections/[state]/[county]/page.tsx
+++ b/src/app/elections/[state]/[county]/page.tsx
@@ -32,6 +32,9 @@ import { LocationFactsBlock } from '~/ui/LocationFactsBlock';
 import { Carousel } from '~/ui/Carousel';
 import { StepperBlock } from '~/ui/StepperBlock';
 import { ElectionsIndexBlock } from '~/ui/ElectionsIndexBlock';
+import { PageSchema } from '~/ui/PageSchema';
+import { buildBreadcrumbSchema, buildSchemaGraph, buildWebPageSchema } from '~/lib/schema';
+import { toAbsoluteUrl } from '~/lib/url';
 
 export const revalidate = 3600;
 
@@ -151,8 +154,22 @@ export default async function Page({
 		: (dataYears[0] ?? currentYear);
 	const availableYears = dataYears.length > 0 ? dataYears : [currentYear];
 
+	const pageUrl = toAbsoluteUrl(`/elections/${fullSlug}`);
+	const countyGraph = buildSchemaGraph([
+		buildWebPageSchema({
+			url: pageUrl,
+			name: `Elections in ${placeName}, ${stateName}`,
+			description: isDistrict
+				? `Browse elections and positions in ${placeName}, ${stateName}.`
+				: `Browse elections, positions, and cities in ${placeName}, ${stateName}.`,
+			pageType: 'CollectionPage',
+		}),
+		buildBreadcrumbSchema(breadcrumbs, toAbsoluteUrl),
+	]);
+
 	return (
 		<>
+			<PageSchema schema={countyGraph ?? undefined} />
 			<BreadcrumbBlock backgroundColor="midnight" breadcrumbs={breadcrumbs} />
 			<ElectionsLandingWithSearch
 				heroProps={{

--- a/src/app/elections/[state]/page.tsx
+++ b/src/app/elections/[state]/page.tsx
@@ -26,6 +26,9 @@ import { Carousel } from '~/ui/Carousel';
 import { StepperBlock } from '~/ui/StepperBlock';
 import { ElectionsIndexBlock } from '~/ui/ElectionsIndexBlock';
 import { US_STATE_CODES } from '~/lib/sitemap-entries';
+import { PageSchema } from '~/ui/PageSchema';
+import { buildBreadcrumbSchema, buildSchemaGraph, buildWebPageSchema } from '~/lib/schema';
+import { toAbsoluteUrl } from '~/lib/url';
 
 export const revalidate = 3600;
 
@@ -152,8 +155,20 @@ export default async function Page({
 		: (dataYears[0] ?? currentYear);
 	const availableYears = dataYears.length > 0 ? dataYears : [currentYear];
 
+	const pageUrl = toAbsoluteUrl(`/elections/${state.toLowerCase()}`);
+	const stateSchema = buildSchemaGraph([
+		buildWebPageSchema({
+			url: pageUrl,
+			name: `Elections in ${stateName}`,
+			description: `Browse elections and positions in ${stateName}.`,
+			pageType: 'CollectionPage',
+		}),
+		buildBreadcrumbSchema(breadcrumbs, toAbsoluteUrl),
+	]);
+
 	return (
 		<>
+			<PageSchema schema={stateSchema ?? undefined} />
 			<BreadcrumbBlock backgroundColor="midnight" breadcrumbs={breadcrumbs} />
 			<ElectionsLandingWithSearch
 				heroProps={{

--- a/src/app/elections/page.tsx
+++ b/src/app/elections/page.tsx
@@ -1,9 +1,13 @@
 import type { Metadata, ResolvingMetadata } from 'next';
 import { notFound } from 'next/navigation';
+import { stegaClean } from 'next-sanity';
 import { PageSections } from '~/PageSections';
 import { sanityFetch } from '~/sanity/sanityClient';
 import { goodpartyOrg_electionsQuery } from '~/sanity/groq';
 import { StructureMetaData } from '~/components/StructureMetadata';
+import { PageSchema } from '~/ui/PageSchema';
+import { buildBreadcrumbSchema, buildSchemaGraph, buildWebPageSchema } from '~/lib/schema';
+import { toAbsoluteUrl } from '~/lib/url';
 
 export default async function Page() {
 	const page = await sanityFetch({ query: goodpartyOrg_electionsQuery, tags: ['goodpartyOrg_landingPages'] });
@@ -12,7 +16,29 @@ export default async function Page() {
 		notFound();
 	}
 
-	return <PageSections pageSections={page.pageSections?.list_pageSections} />;
+	const electionsUrl = page.href ? toAbsoluteUrl(page.href) : toAbsoluteUrl('/elections');
+	const electionsName = page.detailPageOverviewNoHero?.field_pageName
+		? stegaClean(page.detailPageOverviewNoHero.field_pageName)
+		: 'Elections';
+	const electionsDescription = page.seo?.field_metaDescription
+		? stegaClean(page.seo.field_metaDescription)
+		: undefined;
+	const electionsGraph = buildSchemaGraph([
+		buildWebPageSchema({
+			url: electionsUrl,
+			name: electionsName,
+			description: electionsDescription,
+			pageType: 'CollectionPage',
+		}),
+		buildBreadcrumbSchema([{ href: '/elections', label: electionsName }]),
+	]);
+
+	return (
+		<>
+			<PageSchema schema={electionsGraph ?? undefined} />
+			<PageSections pageSections={page.pageSections?.list_pageSections} />
+		</>
+	);
 }
 
 export async function generateMetadata(parent: ResolvingMetadata): Promise<Metadata> {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -10,6 +10,9 @@ import { Amplitude } from '~/ui/Amplitude';
 import { ScrollDepthTracker } from '~/ui/ScrollDepthTracker';
 import { PageSchema } from '~/ui/PageSchema';
 import { getBaseUrl } from '~/lib/url';
+import { buildOrganizationSchema, buildSchemaGraph, buildWebSiteSchema, resolveSameAs } from '~/lib/schema';
+import { sanityFetch } from '~/sanity/sanityClient';
+import { goodpartyOrg_socialChannelsQuery } from '~/sanity/groq';
 import { FacebookPixel } from '~/ui/FacebookPixel';
 import { GTM } from '~/ui/GTM';
 import { Segment } from '~/ui/Segment';
@@ -52,15 +55,33 @@ export const metadata: Metadata = {
 	},
 };
 
-const organizationSchema = {
-	'@context': 'https://schema.org',
-	'@type': 'Organization',
-	name: 'GoodParty.org',
-	url: getBaseUrl(),
-	logo: `${getBaseUrl()}/web-app-manifest-192x192.png`,
-};
+type SocialChannelRecord = { field_socialChannelUrl?: string | null; field_socialChannel?: string | null };
+
+async function getSiteSocialChannels(): Promise<Array<{ url?: string | null; name?: string | null }>> {
+	try {
+		const result = (await sanityFetch({
+			query: goodpartyOrg_socialChannelsQuery,
+			tags: ['goodpartyOrg_socialChannels'],
+		})) as { socialChannels?: { list_socialChannels?: SocialChannelRecord[] | null } | null } | null;
+		const list = result?.socialChannels?.list_socialChannels ?? [];
+		return list.map((entry) => ({
+			url: entry?.field_socialChannelUrl ?? undefined,
+			name: entry?.field_socialChannel ?? undefined,
+		}));
+	} catch {
+		// Best-effort: schema must still render even if the singleton has no document yet.
+		return [];
+	}
+}
 
 export default async function RootLayout({ children }: Props) {
+	const baseUrl = getBaseUrl();
+	const socialChannels = await getSiteSocialChannels();
+	const sameAs = resolveSameAs(socialChannels);
+	const siteSchema = buildSchemaGraph([
+		buildOrganizationSchema({ baseUrl, sameAs }),
+		buildWebSiteSchema({ baseUrl }),
+	]);
 	return (
 		<html
 			lang='en-US'
@@ -70,7 +91,7 @@ export default async function RootLayout({ children }: Props) {
 				<VWOScript accountId='757033' />
 			</head>
 			<body className='flex min-h-screen flex-col'>
-				<PageSchema schema={organizationSchema} />
+				<PageSchema schema={siteSchema ?? undefined} />
 				<GTM />
 				<FacebookPixel />
 				<Segment />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,12 +1,20 @@
 import type { ResolvingMetadata } from 'next';
 import type { Params } from '~/lib/types';
 import { Suspense } from 'react';
+import { stegaClean } from 'next-sanity';
 import { PageSections } from '~/PageSections';
 import { sanityFetch } from '~/sanity/sanityClient';
 import { goodpartyOrg_homeQuery } from '~/sanity/groq';
 import { notFound } from 'next/navigation';
 import { StructureMetaData } from '~/components/StructureMetadata';
 import { ExperimentResolver } from '~/experiments/ExperimentResolver';
+import { PageSchema } from '~/ui/PageSchema';
+import {
+	buildSchemaGraph,
+	buildSoftwareApplicationSchema,
+	buildWebPageSchema,
+} from '~/lib/schema';
+import { getBaseUrl } from '~/lib/url';
 
 export default async function Page() {
 	const page = await sanityFetch({ query: goodpartyOrg_homeQuery, tags: ['goodpartyOrg_home'] });
@@ -17,10 +25,33 @@ export default async function Page() {
 
 	const controlSections = page.pageSections?.list_pageSections;
 
+	const baseUrl = getBaseUrl();
+	const homeDescription = page.seo?.field_metaDescription
+		? stegaClean(page.seo.field_metaDescription)
+		: 'GoodParty.org empowers independent candidates to run, win and serve. Access campaign tools, voter data, and support to level the playing field without deep pockets.';
+	const homeName = page.singlePageOverviewNoHero?.field_pageName
+		? stegaClean(page.singlePageOverviewNoHero.field_pageName)
+		: 'GoodParty.org';
+
+	const homeSchema = buildSchemaGraph([
+		buildWebPageSchema({
+			url: baseUrl,
+			name: homeName,
+			description: homeDescription,
+		}),
+		buildSoftwareApplicationSchema({
+			baseUrl,
+			description: homeDescription,
+		}),
+	]);
+
 	return (
-		<Suspense fallback={<PageSections pageSections={controlSections} />}>
-			<ExperimentResolver pageId={page._id} controlSections={controlSections} />
-		</Suspense>
+		<>
+			<PageSchema schema={homeSchema ?? undefined} />
+			<Suspense fallback={<PageSections pageSections={controlSections} />}>
+				<ExperimentResolver pageId={page._id} controlSections={controlSections} />
+			</Suspense>
+		</>
 	);
 }
 

--- a/src/app/political-terms/[slug]/page.tsx
+++ b/src/app/political-terms/[slug]/page.tsx
@@ -18,6 +18,15 @@ import { client } from '~/lib/client';
 import { cn } from '~/ui/_lib/utils';
 import { resolveComponentColor } from '~/ui/_lib/resolveComponentColor';
 import { BreadcrumbBlock } from '~/ui/BreadcrumbBlock';
+import { PageSchema } from '~/ui/PageSchema';
+import {
+	buildBreadcrumbSchema,
+	buildDefinedTermSchema,
+	buildSchemaGraph,
+	buildWebPageSchema,
+} from '~/lib/schema';
+import { toAbsoluteUrl } from '~/lib/url';
+import { stegaClean } from 'next-sanity';
 
 export async function generateStaticParams() {
 	const entries = await client.fetch<Array<{ _id: string; title: string; slug: string }>>(
@@ -129,17 +138,45 @@ export default async function Page(props: any) {
 	}
 
 	const letter = page.glossaryTermOverview?.field_glossaryTerm?.charAt(0).toLowerCase() ?? '';
+	const termHref = page.href ?? `/political-terms/${slug}`;
 	const breadcrumbs = [
 		{ href: '/political-terms', label: 'Political Terms' },
 		...(letter ? [{ href: `/political-terms/${letter}`, label: letter.toUpperCase() }] : []),
 		{
-			href: page.href ?? `/political-terms/${slug}`,
+			href: termHref,
 			label: page.glossaryTermOverview?.field_glossaryTerm ?? '',
 		},
 	];
 
+	const termName = page.glossaryTermOverview?.field_glossaryTerm
+		? stegaClean(page.glossaryTermOverview.field_glossaryTerm)
+		: '';
+	const termDefinition = page.glossaryTermOverview?.block_glossaryTermDefinition
+		? toPlainText(page.glossaryTermOverview.block_glossaryTermDefinition as any).replace(/\s+/g, ' ').trim()
+		: '';
+	const termSchemaGraph = termName
+		? buildSchemaGraph([
+				buildWebPageSchema({
+					url: termHref,
+					name: termName,
+					description: termDefinition || undefined,
+				}),
+				termDefinition
+					? buildDefinedTermSchema({
+							url: termHref,
+							term: termName,
+							description: termDefinition,
+							inDefinedTermSetName: 'Political Terms Glossary',
+							inDefinedTermSetUrl: '/political-terms',
+						})
+					: null,
+				buildBreadcrumbSchema(breadcrumbs, toAbsoluteUrl),
+			])
+		: null;
+
 	return (
 		<>
+			<PageSchema schema={termSchemaGraph ?? undefined} />
 			<BreadcrumbBlock
 				backgroundColor='cream'
 				breadcrumbs={breadcrumbs}

--- a/src/app/political-terms/page.tsx
+++ b/src/app/political-terms/page.tsx
@@ -13,6 +13,10 @@ import { transformButtons, type ButtonType } from '~/lib/buttonTransformer';
 import { CTAImageBlock } from '~/ui/CTAImageBlock';
 import { toPlainText } from '@portabletext/react';
 import { resolveComponentColor } from '~/ui/_lib/resolveComponentColor';
+import { PageSchema } from '~/ui/PageSchema';
+import { buildBreadcrumbSchema, buildSchemaGraph, buildWebPageSchema } from '~/lib/schema';
+import { toAbsoluteUrl } from '~/lib/url';
+import { stegaClean } from 'next-sanity';
 
 export default async function Page() {
 	const page = await sanityFetch({
@@ -26,8 +30,28 @@ export default async function Page() {
 
 	const searchTerms = (await getCachedTerms()).terms;
 
+	const glossaryUrl = toAbsoluteUrl(page.href ?? '/political-terms');
+	const glossaryName = page.glossaryOverview?.field_name
+		? stegaClean(page.glossaryOverview.field_name)
+		: 'Political Terms Glossary';
+	const glossaryDescription = page.seo?.field_metaDescription
+		? stegaClean(page.seo.field_metaDescription)
+		: page.glossaryOverview?.field_pageSubtitle
+			? stegaClean(page.glossaryOverview.field_pageSubtitle)
+			: undefined;
+	const glossarySchema = buildSchemaGraph([
+		buildWebPageSchema({
+			url: glossaryUrl,
+			name: glossaryName,
+			description: glossaryDescription,
+			pageType: 'CollectionPage',
+		}),
+		buildBreadcrumbSchema([{ href: '/political-terms', label: glossaryName }]),
+	]);
+
 	return (
 		<>
+			<PageSchema schema={glossarySchema ?? undefined} />
 			<GlossaryHero
 				title={page.glossaryOverview?.field_name ?? 'Terms Glossary'}
 				copy={page.glossaryOverview?.field_pageSubtitle}

--- a/src/lib/redirect-map.ts
+++ b/src/lib/redirect-map.ts
@@ -32,15 +32,45 @@ export function entriesToRedirectMap(entries: RedirectEntry[] | null | undefined
 	return map;
 }
 
+const REDIRECT_MAP_TTL_MS = 60_000;
+
+let cachedMap: RedirectMap | null = null;
+let cachedAt = 0;
+let inflightPromise: Promise<RedirectMap> | null = null;
+
 /**
- * Load redirect rules from Sanity without calling this app’s `/api/redirects`.
+ * Load redirect rules from Sanity without calling this app's `/api/redirects`.
  * Same-origin fetches from middleware deadlock Next.js dev (e.g. Bun + Turbopack).
+ *
+ * Results are cached in-memory for {@link REDIRECT_MAP_TTL_MS} to avoid an
+ * uncached cross-network round-trip on every request. The `next.revalidate`
+ * hint is also passed so Vercel's Edge Data Cache can layer additional caching.
  */
 export async function fetchRedirectMapFromSanityCdn(): Promise<RedirectMap> {
-	const query = encodeURIComponent(REDIRECTS_GROQ);
-	const url = `https://${projectId}.apicdn.sanity.io/v${SANITY_QUERY_API_VERSION}/data/query/${dataset}?query=${query}`;
-	const res = await fetch(url, { headers: { Accept: 'application/json' } });
-	if (!res.ok) throw new Error(`Sanity CDN responded ${res.status}`);
-	const data = (await res.json()) as { result: RedirectEntry[] | null };
-	return entriesToRedirectMap(data.result);
+	const now = Date.now();
+	if (cachedMap && now - cachedAt < REDIRECT_MAP_TTL_MS) {
+		return cachedMap;
+	}
+
+	if (inflightPromise) return inflightPromise;
+
+	inflightPromise = (async () => {
+		try {
+			const query = encodeURIComponent(REDIRECTS_GROQ);
+			const url = `https://${projectId}.apicdn.sanity.io/v${SANITY_QUERY_API_VERSION}/data/query/${dataset}?query=${query}`;
+			const res = await fetch(url, {
+				headers: { Accept: 'application/json' },
+				next: { revalidate: 60, tags: ['goodpartyOrg_redirects'] },
+			});
+			if (!res.ok) throw new Error(`Sanity CDN responded ${res.status}`);
+			const data = (await res.json()) as { result: RedirectEntry[] | null };
+			cachedMap = entriesToRedirectMap(data.result);
+			cachedAt = Date.now();
+			return cachedMap;
+		} finally {
+			inflightPromise = null;
+		}
+	})();
+
+	return inflightPromise;
 }

--- a/src/lib/resolveFAQItemsAsText.test.ts
+++ b/src/lib/resolveFAQItemsAsText.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from 'bun:test';
+import { resolveFAQItemsAsText } from './resolveFAQItemsAsText';
+
+function block(text: string) {
+	return {
+		_type: 'block',
+		style: 'normal',
+		children: [{ _type: 'span', text, marks: [] }],
+	};
+}
+
+describe('resolveFAQItemsAsText', () => {
+	test('returns empty array for nullish input', () => {
+		expect(resolveFAQItemsAsText(null)).toEqual([]);
+		expect(resolveFAQItemsAsText(undefined)).toEqual([]);
+		expect(resolveFAQItemsAsText([])).toEqual([]);
+	});
+
+	test('extracts plain-text Q/A and skips button blocks in the answer', () => {
+		const items = resolveFAQItemsAsText([
+			{
+				faqOverview: {
+					field_question: 'How do I run for office?',
+					block_answer: [
+						block('You can start by checking eligibility'),
+						{ _type: 'button', label: 'Get started' },
+						block('and filing the required paperwork.'),
+					],
+				},
+			},
+		]);
+		expect(items.length).toBe(1);
+		expect(items[0]?.title).toBe('How do I run for office?');
+		expect(items[0]?.copy).toBe('You can start by checking eligibility and filing the required paperwork.');
+	});
+
+	test('skips entries missing either question or answer', () => {
+		const items = resolveFAQItemsAsText([
+			{ faqOverview: { field_question: 'Q1', block_answer: [block('A1')] } },
+			{ faqOverview: { field_question: '', block_answer: [block('orphan')] } },
+			{ faqOverview: { field_question: 'Q3', block_answer: [] } },
+			{ faqOverview: { field_question: 'Q4', block_answer: [block('   ')] } },
+		]);
+		expect(items.map(i => i.title)).toEqual(['Q1']);
+	});
+});

--- a/src/lib/resolveFAQItemsAsText.ts
+++ b/src/lib/resolveFAQItemsAsText.ts
@@ -1,0 +1,47 @@
+import { toPlainText } from '@portabletext/toolkit';
+import { stegaClean } from 'next-sanity';
+import type { FAQItemLike } from './schema';
+
+type SanityFAQLike = {
+	faqOverview?: {
+		field_question?: unknown;
+		block_answer?: unknown;
+	} | null;
+} | null | undefined;
+
+function readString(value: unknown): string {
+	if (typeof value !== 'string') return '';
+	const cleaned = stegaClean(value);
+	return typeof cleaned === 'string' ? cleaned.trim() : '';
+}
+
+function readAnswerPlainText(blocks: unknown): string {
+	if (!Array.isArray(blocks) || blocks.length === 0) return '';
+	const textBlocks = blocks.filter(
+		(b): b is { _type?: unknown } => Boolean(b) && typeof b === 'object' && (b as { _type?: unknown })._type !== 'button',
+	);
+	try {
+		const text = toPlainText(textBlocks as Parameters<typeof toPlainText>[0]);
+		return typeof text === 'string' ? text.replace(/\s+/g, ' ').trim() : '';
+	} catch {
+		return '';
+	}
+}
+
+/**
+ * Converts a list of Sanity FAQ documents (as returned by `faQGroq`) into the
+ * plain-text question/answer pairs required by `buildFAQSchema`. Skips entries
+ * missing either a question or an answer so the resulting `FAQPage` schema
+ * mirrors only visible, complete on-page content.
+ */
+export function resolveFAQItemsAsText(items: ReadonlyArray<SanityFAQLike> | null | undefined): FAQItemLike[] {
+	if (!items) return [];
+	const out: FAQItemLike[] = [];
+	for (const item of items) {
+		const question = readString(item?.faqOverview?.field_question);
+		const answer = readAnswerPlainText(item?.faqOverview?.block_answer);
+		if (!question || !answer) continue;
+		out.push({ title: question, copy: answer });
+	}
+	return out;
+}

--- a/src/lib/sanity-doc-types.ts
+++ b/src/lib/sanity-doc-types.ts
@@ -1,0 +1,14 @@
+export const SANITY_DOC_TYPE = {
+	LANDING_PAGE: 'goodpartyOrg_landingPages',
+	POLICY: 'policy',
+	ARTICLE: 'article',
+	CATEGORIES: 'categories',
+	TOPICS: 'topics',
+	GLOSSARY: 'glossary',
+	GLOSSARY_TERM: 'glossaryTerm',
+	HOME: 'goodpartyOrg_home',
+	ALL_ARTICLES: 'goodpartyOrg_allArticles',
+	CONTACT: 'goodpartyOrg_contact',
+	ALL_COMPONENTS: 'goodpartyOrg_allComponents',
+	NOT_FOUND: 'goodpartyOrg_404Page',
+} as const;

--- a/src/lib/schema.test.ts
+++ b/src/lib/schema.test.ts
@@ -1,0 +1,241 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import {
+	buildArticleSchema,
+	buildBreadcrumbSchema,
+	buildDefinedTermSchema,
+	buildFAQSchema,
+	buildOrganizationSchema,
+	buildSchemaGraph,
+	buildSoftwareApplicationSchema,
+	buildWebPageSchema,
+	buildWebSiteSchema,
+	organizationId,
+	resolveSameAs,
+	softwareApplicationId,
+	webSiteId,
+} from './schema';
+
+const envKeys = ['NEXT_PUBLIC_APP_BASE', 'NEXT_PUBLIC_SITE_URL', 'VERCEL_ENV', 'VERCEL_URL', 'NODE_ENV'] as const;
+
+let snapshot: Partial<Record<(typeof envKeys)[number], string | undefined>>;
+
+beforeEach(() => {
+	snapshot = {};
+	for (const k of envKeys) snapshot[k] = process.env[k];
+	process.env['NODE_ENV'] = 'development';
+	delete process.env['VERCEL_ENV'];
+	process.env['NEXT_PUBLIC_SITE_URL'] = 'https://goodparty.org';
+});
+
+afterEach(() => {
+	for (const k of envKeys) {
+		const v = snapshot[k];
+		if (v === undefined) delete process.env[k];
+		else process.env[k] = v;
+	}
+});
+
+function asRecord(schema: object): Record<string, unknown> {
+	return schema as Record<string, unknown>;
+}
+
+describe('organization id helpers', () => {
+	test('organizationId is stable per base URL', () => {
+		expect(organizationId('https://goodparty.org')).toBe('https://goodparty.org/#organization');
+		expect(organizationId('https://goodparty.org/')).toBe('https://goodparty.org/#organization');
+	});
+
+	test('webSiteId and softwareApplicationId share base URL', () => {
+		expect(webSiteId('https://goodparty.org')).toBe('https://goodparty.org/#website');
+		expect(softwareApplicationId('https://goodparty.org')).toBe('https://goodparty.org/#software-application');
+	});
+});
+
+describe('resolveSameAs', () => {
+	test('keeps only absolute URLs, dedupes, and preserves order', () => {
+		const out = resolveSameAs([
+			{ url: 'https://example.com/a', name: 'X' },
+			{ url: '  not a url  ', name: 'Y' },
+			{ url: 'https://example.com/a', name: 'Z' },
+			{ url: 'https://example.com/b', name: 'Q' },
+		]);
+		expect(out).toEqual(['https://example.com/a', 'https://example.com/b']);
+	});
+
+	test('handles null/undefined safely', () => {
+		expect(resolveSameAs(undefined)).toEqual([]);
+		expect(resolveSameAs(null)).toEqual([]);
+		expect(resolveSameAs([])).toEqual([]);
+	});
+});
+
+describe('buildOrganizationSchema', () => {
+	test('includes stable @id, logo, and url', () => {
+		const schema = asRecord(buildOrganizationSchema());
+		expect(schema['@type']).toBe('Organization');
+		expect(schema['@id']).toBe('https://goodparty.org/#organization');
+		expect(schema['url']).toBe('https://goodparty.org');
+		expect((schema['logo'] as Record<string, unknown>)['@type']).toBe('ImageObject');
+	});
+
+	test('emits sameAs only when provided', () => {
+		const without = asRecord(buildOrganizationSchema());
+		expect('sameAs' in without).toBe(false);
+
+		const withChannels = asRecord(
+			buildOrganizationSchema({ socialChannels: [{ url: 'https://twitter.com/goodparty' }] }),
+		);
+		expect(withChannels['sameAs']).toEqual(['https://twitter.com/goodparty']);
+	});
+});
+
+describe('buildWebSiteSchema', () => {
+	test('publisher references the Organization @id', () => {
+		const schema = asRecord(buildWebSiteSchema());
+		expect(schema['@type']).toBe('WebSite');
+		expect((schema['publisher'] as Record<string, unknown>)['@id']).toBe(
+			'https://goodparty.org/#organization',
+		);
+	});
+});
+
+describe('buildWebPageSchema', () => {
+	test('absolutizes relative urls and references publisher Organization', () => {
+		const schema = asRecord(
+			buildWebPageSchema({ url: '/about', name: 'About', description: 'About GoodParty' }),
+		);
+		expect(schema['url']).toBe('https://goodparty.org/about');
+		expect(schema['@id']).toBe('https://goodparty.org/about#webpage');
+		expect((schema['publisher'] as Record<string, unknown>)['@id']).toBe(
+			'https://goodparty.org/#organization',
+		);
+		expect(schema['description']).toBe('About GoodParty');
+	});
+
+	test('respects custom pageType', () => {
+		const schema = asRecord(buildWebPageSchema({ url: '/blog', name: 'Blog', pageType: 'CollectionPage' }));
+		expect(schema['@type']).toBe('CollectionPage');
+	});
+});
+
+describe('buildArticleSchema', () => {
+	test('sets mainEntityOfPage, publisher and optional author Person', () => {
+		const schema = asRecord(
+			buildArticleSchema({
+				url: '/blog/article/foo',
+				headline: 'Foo',
+				description: 'Bar',
+				datePublished: '2026-01-01',
+				dateModified: '2026-01-02',
+				authorName: 'Jane Doe',
+				authorJobTitle: 'Civic Editor',
+			}),
+		);
+		expect(schema['@type']).toBe('Article');
+		expect(schema['headline']).toBe('Foo');
+		expect((schema['mainEntityOfPage'] as Record<string, unknown>)['@id']).toBe(
+			'https://goodparty.org/blog/article/foo',
+		);
+		const author = schema['author'] as Record<string, unknown>;
+		expect(author['@type']).toBe('Person');
+		expect(author['name']).toBe('Jane Doe');
+		expect(author['jobTitle']).toBe('Civic Editor');
+		expect(schema['datePublished']).toBe('2026-01-01');
+		expect(schema['dateModified']).toBe('2026-01-02');
+	});
+});
+
+describe('buildBreadcrumbSchema', () => {
+	test('positions are 1-indexed and items only set when href is present', () => {
+		const schema = asRecord(
+			buildBreadcrumbSchema([
+				{ href: '/blog', label: 'Blog' },
+				{ href: '', label: 'Current' },
+			]),
+		);
+		const items = schema['itemListElement'] as Array<Record<string, unknown>>;
+		expect(items[0]?.['position']).toBe(1);
+		expect(items[0]?.['item']).toBe('https://goodparty.org/blog');
+		expect(items[1]?.['position']).toBe(2);
+		expect('item' in (items[1] ?? {})).toBe(false);
+	});
+});
+
+describe('buildFAQSchema', () => {
+	test('returns null when no valid pairs remain', () => {
+		expect(buildFAQSchema([])).toBeNull();
+		expect(buildFAQSchema([{ title: '', copy: 'a' }, { title: 'q', copy: '' }])).toBeNull();
+	});
+
+	test('emits FAQPage with cleaned question/answer pairs', () => {
+		const schema = asRecord(
+			buildFAQSchema([
+				{ title: '  Q1  ', copy: '  A1  ' },
+				{ title: 'Q2', copy: 'A2' },
+			]) as object,
+		);
+		expect(schema['@type']).toBe('FAQPage');
+		const entity = schema['mainEntity'] as Array<Record<string, unknown>>;
+		expect(entity.length).toBe(2);
+		expect(entity[0]?.['name']).toBe('Q1');
+		expect((entity[0]?.['acceptedAnswer'] as Record<string, unknown>)['text']).toBe('A1');
+	});
+});
+
+describe('buildDefinedTermSchema', () => {
+	test('includes name, description, url and optional set', () => {
+		const schema = asRecord(
+			buildDefinedTermSchema({
+				url: '/political-terms/civic-tech',
+				term: 'Civic Tech',
+				description: 'Technology for civic engagement.',
+				inDefinedTermSetName: 'Political Terms Glossary',
+				inDefinedTermSetUrl: '/political-terms',
+			}),
+		);
+		expect(schema['@type']).toBe('DefinedTerm');
+		expect(schema['name']).toBe('Civic Tech');
+		expect(schema['url']).toBe('https://goodparty.org/political-terms/civic-tech');
+		const set = schema['inDefinedTermSet'] as Record<string, unknown>;
+		expect(set['@type']).toBe('DefinedTermSet');
+		expect(set['url']).toBe('https://goodparty.org/political-terms');
+	});
+});
+
+describe('buildSoftwareApplicationSchema', () => {
+	test('uses sensible defaults and references publisher Organization', () => {
+		const schema = asRecord(
+			buildSoftwareApplicationSchema({ description: 'Free campaign tools for independents.' }),
+		);
+		expect(schema['@type']).toBe('SoftwareApplication');
+		expect(schema['applicationCategory']).toBe('BusinessApplication');
+		expect((schema['offers'] as Record<string, unknown>)['price']).toBe('0');
+		expect((schema['publisher'] as Record<string, unknown>)['@id']).toBe(
+			'https://goodparty.org/#organization',
+		);
+	});
+});
+
+describe('buildSchemaGraph', () => {
+	test('strips inner @context fields and wraps results', () => {
+		const graph = asRecord(
+			buildSchemaGraph([
+				buildOrganizationSchema(),
+				buildBreadcrumbSchema([{ href: '/blog', label: 'Blog' }]),
+				null,
+				undefined,
+			]) as object,
+		);
+		expect(graph['@context']).toBe('https://schema.org');
+		const entries = graph['@graph'] as Array<Record<string, unknown>>;
+		expect(entries.length).toBe(2);
+		expect('@context' in entries[0]!).toBe(false);
+		expect('@context' in entries[1]!).toBe(false);
+		expect(entries[0]!['@type']).toBe('Organization');
+		expect(entries[1]!['@type']).toBe('BreadcrumbList');
+	});
+
+	test('returns null when all entries are nullish', () => {
+		expect(buildSchemaGraph([null, undefined])).toBeNull();
+	});
+});

--- a/src/lib/schema.test.ts
+++ b/src/lib/schema.test.ts
@@ -12,6 +12,7 @@ import {
 	organizationId,
 	resolveSameAs,
 	softwareApplicationId,
+	webPageId,
 	webSiteId,
 } from './schema';
 
@@ -48,6 +49,13 @@ describe('organization id helpers', () => {
 	test('webSiteId and softwareApplicationId share base URL', () => {
 		expect(webSiteId('https://goodparty.org')).toBe('https://goodparty.org/#website');
 		expect(softwareApplicationId('https://goodparty.org')).toBe('https://goodparty.org/#software-application');
+	});
+
+	test('webPageId matches WebPage schema node ids', () => {
+		expect(webPageId('/blog/article/foo')).toBe('https://goodparty.org/blog/article/foo#webpage');
+		expect(webPageId('https://goodparty.org/blog/article/foo')).toBe(
+			'https://goodparty.org/blog/article/foo#webpage',
+		);
 	});
 });
 
@@ -134,7 +142,7 @@ describe('buildArticleSchema', () => {
 		expect(schema['@type']).toBe('Article');
 		expect(schema['headline']).toBe('Foo');
 		expect((schema['mainEntityOfPage'] as Record<string, unknown>)['@id']).toBe(
-			'https://goodparty.org/blog/article/foo',
+			'https://goodparty.org/blog/article/foo#webpage',
 		);
 		const author = schema['author'] as Record<string, unknown>;
 		expect(author['@type']).toBe('Person');
@@ -217,6 +225,20 @@ describe('buildSoftwareApplicationSchema', () => {
 });
 
 describe('buildSchemaGraph', () => {
+	test('links Article mainEntityOfPage to the matching WebPage node id', () => {
+		const graph = asRecord(
+			buildSchemaGraph([
+				buildArticleSchema({ url: '/blog/article/foo', headline: 'Foo' }),
+				buildWebPageSchema({ url: '/blog/article/foo', name: 'Foo' }),
+			]) as object,
+		);
+		const entries = graph['@graph'] as Array<Record<string, unknown>>;
+		const article = entries.find(entry => entry['@type'] === 'Article');
+		const webPage = entries.find(entry => entry['@type'] === 'WebPage');
+
+		expect((article?.['mainEntityOfPage'] as Record<string, unknown>)['@id']).toBe(webPage?.['@id']);
+	});
+
 	test('strips inner @context fields and wraps results', () => {
 		const graph = asRecord(
 			buildSchemaGraph([

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -2,6 +2,7 @@ import { getBaseUrl, toAbsoluteUrl, DEFAULT_SHARE_IMAGE } from './url';
 
 const ORGANIZATION_ID_FRAGMENT = '#organization';
 const WEBSITE_ID_FRAGMENT = '#website';
+const WEBPAGE_ID_FRAGMENT = '#webpage';
 const SOFTWARE_APPLICATION_ID_FRAGMENT = '#software-application';
 
 function trimTrailingSlash(value: string): string {
@@ -16,6 +17,12 @@ export function organizationId(baseUrl: string = getBaseUrl()): string {
 /** Stable `@id` for the WebSite entity. */
 export function webSiteId(baseUrl: string = getBaseUrl()): string {
 	return `${trimTrailingSlash(baseUrl)}/${WEBSITE_ID_FRAGMENT}`;
+}
+
+/** Stable `@id` for a WebPage entity at the given URL. */
+export function webPageId(url: string): string {
+	const absoluteUrl = url.startsWith('http') ? url : toAbsoluteUrl(url);
+	return `${absoluteUrl}${WEBPAGE_ID_FRAGMENT}`;
 }
 
 /** Stable `@id` for the SoftwareApplication entity (campaign platform). */
@@ -131,7 +138,7 @@ export function buildWebPageSchema(params: WebPageSchemaParams): object {
 	const schema: Record<string, unknown> = {
 		'@context': 'https://schema.org',
 		'@type': params.pageType ?? 'WebPage',
-		'@id': `${url}#webpage`,
+		'@id': webPageId(url),
 		url,
 		name: params.name,
 		isPartOf: { '@id': params.isPartOfId ?? webSiteId(baseUrl) },
@@ -170,7 +177,7 @@ export function buildArticleSchema(params: ArticleSchemaParams): object {
 		'@type': params.pageType ?? 'Article',
 		headline: params.headline,
 		url,
-		mainEntityOfPage: { '@type': 'WebPage', '@id': url },
+		mainEntityOfPage: { '@type': 'WebPage', '@id': webPageId(url) },
 		publisher: { '@id': params.publisherId ?? organizationId(baseUrl) },
 	};
 

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -1,0 +1,337 @@
+import { getBaseUrl, toAbsoluteUrl, DEFAULT_SHARE_IMAGE } from './url';
+
+const ORGANIZATION_ID_FRAGMENT = '#organization';
+const WEBSITE_ID_FRAGMENT = '#website';
+const SOFTWARE_APPLICATION_ID_FRAGMENT = '#software-application';
+
+function trimTrailingSlash(value: string): string {
+	return value.replace(/\/$/, '');
+}
+
+/** Stable `@id` for the global Organization entity. Used to link other schema back to one canonical node. */
+export function organizationId(baseUrl: string = getBaseUrl()): string {
+	return `${trimTrailingSlash(baseUrl)}/${ORGANIZATION_ID_FRAGMENT}`;
+}
+
+/** Stable `@id` for the WebSite entity. */
+export function webSiteId(baseUrl: string = getBaseUrl()): string {
+	return `${trimTrailingSlash(baseUrl)}/${WEBSITE_ID_FRAGMENT}`;
+}
+
+/** Stable `@id` for the SoftwareApplication entity (campaign platform). */
+export function softwareApplicationId(baseUrl: string = getBaseUrl()): string {
+	return `${trimTrailingSlash(baseUrl)}/${SOFTWARE_APPLICATION_ID_FRAGMENT}`;
+}
+
+export type SocialChannelLike = {
+	url?: string | null | undefined;
+	name?: string | null | undefined;
+};
+
+/** Resolves a list of verified absolute `sameAs` URLs from Sanity social channel records. */
+export function resolveSameAs(channels: ReadonlyArray<SocialChannelLike> | null | undefined): string[] {
+	if (!channels) return [];
+	const seen = new Set<string>();
+	const out: string[] = [];
+	for (const channel of channels) {
+		const url = channel?.url;
+		if (typeof url !== 'string') continue;
+		const trimmed = url.trim();
+		if (!trimmed || !trimmed.startsWith('http')) continue;
+		if (seen.has(trimmed)) continue;
+		seen.add(trimmed);
+		out.push(trimmed);
+	}
+	return out;
+}
+
+export type OrganizationSchemaParams = {
+	baseUrl?: string;
+	name?: string;
+	legalName?: string;
+	logoUrl?: string;
+	description?: string;
+	sameAs?: ReadonlyArray<string>;
+	socialChannels?: ReadonlyArray<SocialChannelLike>;
+};
+
+/**
+ * Schema.org Organization with stable `@id` so other page schemas can reference it
+ * with `{ "@id": organizationId() }` and avoid duplicating brand fields.
+ */
+export function buildOrganizationSchema(params: OrganizationSchemaParams = {}): object {
+	const baseUrl = trimTrailingSlash(params.baseUrl ?? getBaseUrl());
+	const name = params.name ?? 'GoodParty.org';
+	const logo = params.logoUrl ?? `${baseUrl}/web-app-manifest-192x192.png`;
+	const explicitSameAs = params.sameAs ? [...params.sameAs] : [];
+	const fromChannels = resolveSameAs(params.socialChannels);
+	const sameAs = Array.from(new Set([...explicitSameAs, ...fromChannels]));
+
+	const schema: Record<string, unknown> = {
+		'@context': 'https://schema.org',
+		'@type': 'Organization',
+		'@id': organizationId(baseUrl),
+		name,
+		url: baseUrl,
+		logo: {
+			'@type': 'ImageObject',
+			url: logo,
+		},
+	};
+
+	if (params.legalName) schema['legalName'] = params.legalName;
+	if (params.description) schema['description'] = params.description;
+	if (sameAs.length > 0) schema['sameAs'] = sameAs;
+
+	return schema;
+}
+
+export type WebSiteSchemaParams = {
+	baseUrl?: string;
+	name?: string;
+	description?: string;
+	publisherId?: string;
+};
+
+/**
+ * Schema.org WebSite entity. Lets AI engines understand the site root and link
+ * the publisher Organization via `@id` reference.
+ */
+export function buildWebSiteSchema(params: WebSiteSchemaParams = {}): object {
+	const baseUrl = trimTrailingSlash(params.baseUrl ?? getBaseUrl());
+	const schema: Record<string, unknown> = {
+		'@context': 'https://schema.org',
+		'@type': 'WebSite',
+		'@id': webSiteId(baseUrl),
+		url: baseUrl,
+		name: params.name ?? 'GoodParty.org',
+		publisher: { '@id': params.publisherId ?? organizationId(baseUrl) },
+	};
+	if (params.description) schema['description'] = params.description;
+	return schema;
+}
+
+export type WebPageSchemaParams = {
+	url: string;
+	name: string;
+	description?: string;
+	image?: string;
+	datePublished?: string;
+	dateModified?: string;
+	/** Schema type override; defaults to `WebPage`. Use `CollectionPage` for index/archive pages. */
+	pageType?: 'WebPage' | 'CollectionPage' | 'AboutPage' | 'ContactPage' | 'FAQPage';
+	publisherId?: string;
+	isPartOfId?: string;
+};
+
+/** Generic WebPage builder reused across Sanity-driven marketing pages. */
+export function buildWebPageSchema(params: WebPageSchemaParams): object {
+	const url = params.url.startsWith('http') ? params.url : toAbsoluteUrl(params.url);
+	const baseUrl = getBaseUrl();
+	const schema: Record<string, unknown> = {
+		'@context': 'https://schema.org',
+		'@type': params.pageType ?? 'WebPage',
+		'@id': `${url}#webpage`,
+		url,
+		name: params.name,
+		isPartOf: { '@id': params.isPartOfId ?? webSiteId(baseUrl) },
+		publisher: { '@id': params.publisherId ?? organizationId(baseUrl) },
+	};
+	if (params.description) schema['description'] = params.description;
+	if (params.image) schema['primaryImageOfPage'] = { '@type': 'ImageObject', url: params.image };
+	if (params.datePublished) schema['datePublished'] = params.datePublished;
+	if (params.dateModified) schema['dateModified'] = params.dateModified;
+	return schema;
+}
+
+export type ArticleSchemaParams = {
+	url: string;
+	headline: string;
+	description?: string;
+	image?: string;
+	datePublished?: string;
+	dateModified?: string;
+	authorName?: string;
+	authorUrl?: string;
+	authorJobTitle?: string;
+	publisherId?: string;
+	pageType?: 'Article' | 'BlogPosting' | 'NewsArticle';
+};
+
+/**
+ * Enriched Article schema with publisher reference, mainEntityOfPage, and optional Person author.
+ * Uses `BlogPosting` when called from the blog routes for higher AI-citation specificity.
+ */
+export function buildArticleSchema(params: ArticleSchemaParams): object {
+	const url = params.url.startsWith('http') ? params.url : toAbsoluteUrl(params.url);
+	const baseUrl = getBaseUrl();
+	const schema: Record<string, unknown> = {
+		'@context': 'https://schema.org',
+		'@type': params.pageType ?? 'Article',
+		headline: params.headline,
+		url,
+		mainEntityOfPage: { '@type': 'WebPage', '@id': url },
+		publisher: { '@id': params.publisherId ?? organizationId(baseUrl) },
+	};
+
+	if (params.description) schema['description'] = params.description;
+	if (params.image) schema['image'] = params.image;
+	if (params.datePublished) schema['datePublished'] = params.datePublished;
+	if (params.dateModified) schema['dateModified'] = params.dateModified;
+
+	if (params.authorName) {
+		const author: Record<string, unknown> = { '@type': 'Person', name: params.authorName };
+		if (params.authorUrl) author['url'] = params.authorUrl;
+		if (params.authorJobTitle) author['jobTitle'] = params.authorJobTitle;
+		schema['author'] = author;
+	}
+
+	return schema;
+}
+
+export type BreadcrumbItem = { href: string; label: string };
+
+/**
+ * Schema.org BreadcrumbList built from breadcrumb items. Items without an `href`
+ * are still emitted (no `item` field) so the trail count matches the visible UI.
+ */
+export function buildBreadcrumbSchema(
+	breadcrumbs: ReadonlyArray<BreadcrumbItem>,
+	toAbsolute: (path: string) => string = toAbsoluteUrl,
+): object {
+	return {
+		'@context': 'https://schema.org',
+		'@type': 'BreadcrumbList',
+		itemListElement: breadcrumbs.map((crumb, i) => ({
+			'@type': 'ListItem',
+			position: i + 1,
+			name: crumb.label,
+			...(crumb.href && { item: toAbsolute(crumb.href) }),
+		})),
+	};
+}
+
+export type FAQItemLike = { title: string; copy: string };
+
+/**
+ * Schema.org FAQPage built from plain-text question/answer pairs.
+ * Items missing either side are dropped; returns `null` if no usable items remain
+ * so callers can skip emitting an empty `FAQPage`.
+ */
+export function buildFAQSchema(items: ReadonlyArray<FAQItemLike>): object | null {
+	const filtered = items
+		.map(item => ({
+			title: typeof item?.title === 'string' ? item.title.trim() : '',
+			copy: typeof item?.copy === 'string' ? item.copy.trim() : '',
+		}))
+		.filter(item => item.title && item.copy);
+
+	if (filtered.length === 0) return null;
+
+	return {
+		'@context': 'https://schema.org',
+		'@type': 'FAQPage',
+		mainEntity: filtered.map(item => ({
+			'@type': 'Question',
+			name: item.title,
+			acceptedAnswer: {
+				'@type': 'Answer',
+				text: item.copy,
+			},
+		})),
+	};
+}
+
+export type DefinedTermSchemaParams = {
+	url: string;
+	term: string;
+	description: string;
+	inDefinedTermSetName?: string;
+	inDefinedTermSetUrl?: string;
+};
+
+/** Schema.org DefinedTerm — the canonical type for glossary entries. */
+export function buildDefinedTermSchema(params: DefinedTermSchemaParams): object {
+	const url = params.url.startsWith('http') ? params.url : toAbsoluteUrl(params.url);
+	const schema: Record<string, unknown> = {
+		'@context': 'https://schema.org',
+		'@type': 'DefinedTerm',
+		'@id': `${url}#term`,
+		name: params.term,
+		description: params.description,
+		url,
+	};
+
+	if (params.inDefinedTermSetName || params.inDefinedTermSetUrl) {
+		const set: Record<string, unknown> = { '@type': 'DefinedTermSet' };
+		if (params.inDefinedTermSetName) set['name'] = params.inDefinedTermSetName;
+		if (params.inDefinedTermSetUrl) {
+			set['url'] = params.inDefinedTermSetUrl.startsWith('http')
+				? params.inDefinedTermSetUrl
+				: toAbsoluteUrl(params.inDefinedTermSetUrl);
+		}
+		schema['inDefinedTermSet'] = set;
+	}
+
+	return schema;
+}
+
+export type SoftwareApplicationSchemaParams = {
+	baseUrl?: string;
+	name?: string;
+	description: string;
+	applicationCategory?: string;
+	operatingSystem?: string;
+	offerPrice?: string;
+	offerCurrency?: string;
+	image?: string;
+	publisherId?: string;
+};
+
+/**
+ * Schema.org SoftwareApplication for the GoodParty.org candidate platform.
+ * Only emit when on-page copy clearly identifies the campaign tools product so
+ * the schema mirrors visible content.
+ */
+export function buildSoftwareApplicationSchema(params: SoftwareApplicationSchemaParams): object {
+	const baseUrl = trimTrailingSlash(params.baseUrl ?? getBaseUrl());
+	const schema: Record<string, unknown> = {
+		'@context': 'https://schema.org',
+		'@type': 'SoftwareApplication',
+		'@id': softwareApplicationId(baseUrl),
+		name: params.name ?? 'GoodParty.org Campaign Platform',
+		description: params.description,
+		url: baseUrl,
+		applicationCategory: params.applicationCategory ?? 'BusinessApplication',
+		operatingSystem: params.operatingSystem ?? 'Web',
+		publisher: { '@id': params.publisherId ?? organizationId(baseUrl) },
+		image: params.image ?? DEFAULT_SHARE_IMAGE,
+		offers: {
+			'@type': 'Offer',
+			price: params.offerPrice ?? '0',
+			priceCurrency: params.offerCurrency ?? 'USD',
+		},
+	};
+	return schema;
+}
+
+/**
+ * Bundle multiple schema objects into a single JSON-LD `@graph`.
+ * Strips per-entry `@context` since it is hoisted to the wrapper.
+ * Returns `null` when no usable entries remain so callers can skip rendering.
+ */
+export function buildSchemaGraph(entries: ReadonlyArray<object | null | undefined>): object | null {
+	const cleaned = entries
+		.filter((entry): entry is object => entry !== null && entry !== undefined)
+		.map(entry => {
+			const { ['@context']: _ignored, ...rest } = entry as Record<string, unknown>;
+			return rest;
+		});
+
+	if (cleaned.length === 0) return null;
+
+	return {
+		'@context': 'https://schema.org',
+		'@graph': cleaned,
+	};
+}

--- a/src/ui/CandidatesPageContent.tsx
+++ b/src/ui/CandidatesPageContent.tsx
@@ -11,6 +11,9 @@ import {
 	CANDIDATES_PAGE_TWO_UP_CARD,
 } from '~/constants/candidatesPageStaticSections';
 import { primaryButtonStyleType } from '~/ui/_lib/designTypesStore';
+import { PageSchema } from '~/ui/PageSchema';
+import { buildBreadcrumbSchema, buildSchemaGraph, buildWebPageSchema } from '~/lib/schema';
+import { toAbsoluteUrl } from '~/lib/url';
 
 export type CandidatesPageContentProps = {
 	officeName: string;
@@ -53,8 +56,23 @@ export function CandidatesPageContent(props: CandidatesPageContentProps) {
 	const ctaImageTitle = replacePlaceholders(CANDIDATES_PAGE_CTA_IMAGE.title, replacements);
 	const ctaImageCopy = replacePlaceholders(CANDIDATES_PAGE_CTA_IMAGE.copy, replacements);
 
+	const lastCrumbHref = breadcrumbs[breadcrumbs.length - 1]?.href;
+	const candidatesPageUrl = lastCrumbHref ? toAbsoluteUrl(lastCrumbHref) : undefined;
+	const candidatesGraph = buildSchemaGraph([
+		candidatesPageUrl
+			? buildWebPageSchema({
+					url: candidatesPageUrl,
+					name: `Candidates for ${officeName} in ${locationName}`,
+					description: `Candidates running for ${officeName} in ${locationName}.`,
+					pageType: 'CollectionPage',
+				})
+			: null,
+		buildBreadcrumbSchema(breadcrumbs, toAbsoluteUrl),
+	]);
+
 	return (
 		<>
+			<PageSchema schema={candidatesGraph ?? undefined} />
 			<BreadcrumbBlock backgroundColor="midnight" breadcrumbs={breadcrumbs} />
 			<ElectionsPositionHero
 				backgroundColor="midnight"


### PR DESCRIPTION
- Introduced `PageSchema` integration in multiple components to improve structured data representation.
- Added `buildFAQSchema` and `resolveFAQItemsAsText` for better FAQ handling in the FAQBlockSection.
- Implemented schema generation for blog, elections, political terms, and contact pages, ensuring consistent metadata across the application.
- Added tests for new schema functions to ensure reliability and correctness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it adds new JSON-LD generation across many routes and introduces an additional Sanity fetch in `RootLayout`, which could affect SSR performance/caching and emit incorrect structured data if inputs are malformed.
> 
> **Overview**
> Adds a shared `src/lib/schema.ts` builder layer for JSON-LD (Organization/WebSite/WebPage/Article/Breadcrumb/FAQ/DefinedTerm/SoftwareApplication) and a `buildSchemaGraph` helper so pages can emit a single `@graph` instead of ad-hoc schema objects.
> 
> Wires `PageSchema` into the home page, dynamic landing/policy pages, blog index + article pages (including extracting inline FAQ blocks into `FAQPage` schema), elections routes, contact page, candidates page, and political terms pages (including `DefinedTerm` schema for individual glossary entries).
> 
> Introduces `resolveFAQItemsAsText` to convert Sanity FAQ blocks into plain-text Q/A for schema emission, and updates `RootLayout` to fetch social channels from Sanity to populate `Organization.sameAs`. Adds Bun tests covering schema builders and FAQ text extraction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 080c71a1296222cede941f6db01631120a68a4ac. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->