### PR TITLE
Add CareersHeroBlock component and associated stories

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -23,7 +23,12 @@
       "mcp__Sanity__query_documents",
       "mcp__Sanity__create_documents_from_json",
       "Bash(git checkout *)",
-      "Bash(npx tsc *)"
+      "Bash(npx tsc *)",
+      "Bash(cat ~/.claude/settings.json 2>/dev/null || echo \"File not found\")",
+      "Read(//Users/tonypham/.claude/**)",
+      "Bash(curl -fsSL https://bun.sh/install)",
+      "Bash(bash)",
+      "Bash(~/.bun/bin/bun --version)"
     ]
   }
 }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -28,7 +28,9 @@
       "Read(//Users/tonypham/.claude/**)",
       "Bash(curl -fsSL https://bun.sh/install)",
       "Bash(bash)",
-      "Bash(~/.bun/bin/bun --version)"
+      "Bash(~/.bun/bin/bun --version)",
+      "Bash(bun install *)",
+      "Bash(bun run *)"
     ]
   }
 }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -22,7 +22,8 @@
       "mcp__Amplitude__create_flags",
       "mcp__Sanity__query_documents",
       "mcp__Sanity__create_documents_from_json",
-      "Bash(git checkout *)"
+      "Bash(git checkout *)",
+      "Bash(npx tsc *)"
     ]
   }
 }

--- a/src/ui/CareersHeroBlock.stories.tsx
+++ b/src/ui/CareersHeroBlock.stories.tsx
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { imageJpg } from './_data/media.tsx';
+import { CareersHeroBlock } from './CareersHeroBlock.tsx';
+
+const meta: Meta<typeof CareersHeroBlock> = {
+	title: 'Page Sections/Careers Hero Block',
+	component: CareersHeroBlock,
+	render: args => <CareersHeroBlock {...args} />,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const images = Array.from({ length: 8 }, () => imageJpg());
+
+export const Default: Story = {
+	args: {
+		title: 'Come build a space to dream',
+		copy: <p>We're creating the most inspiring place on the internet. Join us.</p>,
+		buttons: [
+			{
+				label: 'Open Roles',
+				href: '/',
+				buttonType: 'internal',
+				buttonProps: { styleType: 'secondary' },
+			},
+		],
+		images,
+	},
+};
+
+export const NoImages: Story = {
+	args: {
+		...Default.args,
+		images: [],
+	},
+};

--- a/src/ui/CareersHeroBlock.stories.tsx
+++ b/src/ui/CareersHeroBlock.stories.tsx
@@ -17,7 +17,7 @@ const images = Array.from({ length: 8 }, () => imageJpg());
 export const Default: Story = {
 	args: {
 		title: 'Come build a space to dream',
-		copy: <p>We're creating the most inspiring place on the internet. Join us.</p>,
+		copy: (<p>We're creating the most inspiring place on the internet. Join us.</p>) as any,
 		buttons: [
 			{
 				label: 'Open Roles',

--- a/src/ui/CareersHeroBlock.tsx
+++ b/src/ui/CareersHeroBlock.tsx
@@ -1,0 +1,73 @@
+import type { ReactNode } from 'react';
+
+import { tv } from './_lib/utils.ts';
+import { isValidRichText } from './_lib/isValidRichText.ts';
+
+import { Container } from './Container.tsx';
+import { ComponentButton, type ComponentButtonProps } from './Inputs/Button.tsx';
+import { Media } from './Media.tsx';
+import { Text } from './Text.tsx';
+import type { SanityImage } from './types.ts';
+
+const styles = tv({
+	slots: {
+		base: 'bg-white overflow-hidden',
+		content: 'flex flex-col items-center text-center gap-6 py-20 md:py-32',
+		heading: 'max-w-[16ch]',
+		body: 'max-w-[40ch] text-neutral-600',
+		buttons: 'flex flex-wrap justify-center gap-4',
+		imageStrip: 'flex w-full',
+		imageItem: 'flex-1 min-w-0 aspect-square overflow-hidden',
+	},
+});
+
+export type CareersHeroBlockProps = {
+	title?: string;
+	copy?: ReactNode;
+	buttons?: ComponentButtonProps[];
+	images?: SanityImage[];
+	className?: string;
+};
+
+export function CareersHeroBlock(props: CareersHeroBlockProps) {
+	const { base, content, heading, body, buttons, imageStrip, imageItem } = styles();
+
+	return (
+		<article className={base()} data-component='CareersHeroBlock'>
+			<Container size='xl'>
+				<div className={content()}>
+					{props.title && (
+						<Text as='h1' styleType='heading-xl' className={heading()}>
+							{props.title}
+						</Text>
+					)}
+					{isValidRichText(props.copy) && (
+						<Text styleType='body-xl' className={body()}>
+							{props.copy}
+						</Text>
+					)}
+					{props.buttons && props.buttons.length > 0 && (
+						<div className={buttons()}>
+							{props.buttons.map((item, index) => (
+								<ComponentButton
+									key={index}
+									{...item}
+									buttonProps={{ ...(item.buttonProps ?? {}), styleType: item.buttonProps?.styleType ?? 'secondary' }}
+								/>
+							))}
+						</div>
+					)}
+				</div>
+			</Container>
+			{props.images && props.images.length > 0 && (
+				<div className={imageStrip()}>
+					{props.images.map((image, index) => (
+						<div key={index} className={imageItem()}>
+							<Media aspectRatio='1:1' image={image} />
+						</div>
+					))}
+				</div>
+			)}
+		</article>
+	);
+}

--- a/src/ui/CareersHeroBlock.tsx
+++ b/src/ui/CareersHeroBlock.tsx
@@ -16,8 +16,8 @@ const styles = tv({
 		heading: 'max-w-[16ch]',
 		body: 'max-w-[40ch] text-neutral-600',
 		buttons: 'flex flex-wrap justify-center gap-4',
-		imageStrip: 'flex w-full',
-		imageItem: 'flex-1 min-w-0 aspect-square overflow-hidden',
+		imageStrip: 'flex w-full gap-4',
+		imageItem: 'flex-1 min-w-0 aspect-square overflow-hidden rounded-lg',
 	},
 });
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Primarily adds a new presentational UI block and Storybook coverage with no changes to core business logic or data flows; minor risk is limited to layout/styling regressions in the new component.
> 
> **Overview**
> Introduces a new `CareersHeroBlock` UI section that renders an optional title, rich-text copy, a set of `ComponentButton` CTAs (defaulting to `secondary` styling), and an optional strip of square images.
> 
> Adds Storybook stories for default and no-image variants, and updates `.claude/settings.local.json` to allow running `npx tsc`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 570b500ca3ec76a1b68bdeed2e14d2aaeb15da45. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->