### PR TITLE
Update references to Good Party to GoodParty.org

### DIFF
--- a/src/app/llms.txt/route.ts
+++ b/src/app/llms.txt/route.ts
@@ -1,6 +1,6 @@
 /**
  * Serves /llms.txt per https://llmstxt.org/ — a curated, AI-friendly index of
- * the most important Good Party content. Preview/staging hosts return a stub
+ * the most important GoodParty.org content. Preview/staging hosts return a stub
  * matching the gating in src/app/robots.ts so draft content is not exposed.
  */
 
@@ -11,7 +11,7 @@ import { getBaseUrl, isPreviewBaseUrl } from '~/lib/url';
 export const revalidate = 3600;
 
 const PREVIEW_BODY =
-	'# Good Party (preview)\n\n> Preview environment. Crawling and AI discovery are disabled here.\n';
+	'# GoodParty.org (preview)\n\n> Preview environment. Crawling and AI discovery are disabled here.\n';
 
 const TEXT_HEADERS = {
 	'Content-Type': 'text/plain; charset=utf-8',

--- a/src/lib/llms-txt-entries.test.ts
+++ b/src/lib/llms-txt-entries.test.ts
@@ -180,6 +180,8 @@ describe('buildLlmsTxtDoc', () => {
 			emptyData({
 				landingPages: [
 					{ slug: 'about', title: 'About', description: null },
+					{ slug: 'framework', title: 'Our Framework for Change', description: null },
+					{ slug: 'redraft-platform', title: 'Redraft Your Platform', description: null },
 					{ slug: 'homepage-frame', title: 'Homepage Frame', description: null },
 					{ slug: 'candidate-draft', title: 'Candidate Draft Page', description: null },
 					{ slug: 'lowercase-frame', title: 'internal frame example', description: null },
@@ -187,7 +189,7 @@ describe('buildLlmsTxtDoc', () => {
 			}),
 		);
 		const urls = getSection(doc, 'Pages').items.map(i => i.url);
-		expect(urls).toEqual([`${BASE}/about`]);
+		expect(urls).toEqual([`${BASE}/about`, `${BASE}/framework`, `${BASE}/redraft-platform`]);
 	});
 
 	test('skips rows with missing slug or missing title', () => {

--- a/src/lib/llms-txt-entries.test.ts
+++ b/src/lib/llms-txt-entries.test.ts
@@ -94,15 +94,15 @@ describe('normalizeDescription', () => {
 describe('buildLlmsTxtDoc', () => {
 	test('emits hard-coded site title and summary', () => {
 		const doc = buildLlmsTxtDoc(BASE, emptyData());
-		expect(doc.title).toBe('Good Party');
+		expect(doc.title).toBe('GoodParty.org');
 		expect(doc.summary.length).toBeGreaterThan(0);
 	});
 
-	test('includes hard-coded Elections and Candidates entries even with no Sanity data', () => {
+	test('includes hard-coded Elections entry and omits Candidates', () => {
 		const doc = buildLlmsTxtDoc(BASE, emptyData());
 		const urls = getSection(doc, 'Top-level pages').items.map(i => i.url);
 		expect(urls).toContain(`${BASE}/elections`);
-		expect(urls).toContain(`${BASE}/candidates`);
+		expect(urls).not.toContain(`${BASE}/candidates`);
 	});
 
 	test('omits Home/Blog/Glossary/Contact when their singletons are missing', () => {
@@ -172,6 +172,22 @@ describe('buildLlmsTxtDoc', () => {
 		);
 		expect(firstItem(getSection(doc, 'Pages').items).url).toBe(`${BASE}/about`);
 		expect(firstItem(getSection(doc, 'Policies').items).url).toBe(`${BASE}/privacy`);
+	});
+
+	test('omits landing pages with Frame or Draft in the title', () => {
+		const doc = buildLlmsTxtDoc(
+			BASE,
+			emptyData({
+				landingPages: [
+					{ slug: 'about', title: 'About', description: null },
+					{ slug: 'homepage-frame', title: 'Homepage Frame', description: null },
+					{ slug: 'candidate-draft', title: 'Candidate Draft Page', description: null },
+					{ slug: 'lowercase-frame', title: 'internal frame example', description: null },
+				],
+			}),
+		);
+		const urls = getSection(doc, 'Pages').items.map(i => i.url);
+		expect(urls).toEqual([`${BASE}/about`]);
 	});
 
 	test('skips rows with missing slug or missing title', () => {
@@ -272,7 +288,7 @@ describe('buildLlmsTxtDoc', () => {
 describe('renderLlmsTxt', () => {
 	function makeDoc(overrides: Partial<LlmsTxtDoc> = {}): LlmsTxtDoc {
 		return {
-			title: 'Good Party',
+			title: 'GoodParty.org',
 			summary: 'Site summary.',
 			sections: [],
 			...overrides,
@@ -282,7 +298,7 @@ describe('renderLlmsTxt', () => {
 	test('starts with the H1 title and a blockquote summary line', () => {
 		const out = renderLlmsTxt(makeDoc());
 		const lines = out.split('\n');
-		expect(lines[0]).toBe('# Good Party');
+		expect(lines[0]).toBe('# GoodParty.org');
 		expect(lines[1]).toBe('');
 		expect(lines[2]).toBe('> Site summary.');
 	});
@@ -349,7 +365,7 @@ describe('renderLlmsTxt', () => {
 			policies: [],
 		});
 		const out = renderLlmsTxt(doc);
-		expect(out.split('\n')[0]).toBe('# Good Party');
+		expect(out.split('\n')[0]).toBe('# GoodParty.org');
 		expect(out).toMatch(/^>\s.+/m);
 		expect(out).toContain('## Top-level pages');
 		expect(out).toContain('## Articles');

--- a/src/lib/llms-txt-entries.ts
+++ b/src/lib/llms-txt-entries.ts
@@ -42,10 +42,11 @@ export type LlmsTxtSourceData = {
 	policies: SlugTitleDescRow[];
 };
 
-const SITE_TITLE = 'Good Party';
+const SITE_TITLE = 'GoodParty.org';
 const SITE_SUMMARY =
 	'Nonpartisan tools, guides, and data that help independent and third-party candidates run for office and help voters discover them.';
 const MAX_DESCRIPTION_LENGTH = 200;
+const EXCLUDED_PAGE_TITLE_TERMS = ['frame', 'draft'] as const;
 
 /**
  * Removes a trailing slash and joins a path onto an absolute base URL.
@@ -89,6 +90,13 @@ function rowsToItems(
 	return items;
 }
 
+function excludeInternalLandingPages(items: LlmsTxtItem[]): LlmsTxtItem[] {
+	return items.filter(item => {
+		const title = item.title.toLowerCase();
+		return !EXCLUDED_PAGE_TITLE_TERMS.some(term => title.includes(term));
+	});
+}
+
 /**
  * Pure transformation: source data + base URL → structured llms.txt doc.
  */
@@ -101,7 +109,7 @@ export function buildLlmsTxtDoc(
 		topLevel.push({
 			title: 'Home',
 			url: joinUrl(baseUrl, '/'),
-			description: 'Good Party homepage and mission overview.',
+			description: 'GoodParty.org homepage and mission overview.',
 		});
 	}
 	if (data.singletons.blog) {
@@ -123,16 +131,11 @@ export function buildLlmsTxtDoc(
 		url: joinUrl(baseUrl, '/elections'),
 		description: 'State, county, and local election guides for US voters.',
 	});
-	topLevel.push({
-		title: 'Candidates',
-		url: joinUrl(baseUrl, '/candidates'),
-		description: 'Independent and third-party candidates running for office.',
-	});
 	if (data.singletons.contact) {
 		topLevel.push({
 			title: 'Contact',
 			url: joinUrl(baseUrl, '/contact'),
-			description: 'Get in touch with Good Party.',
+			description: 'Get in touch with GoodParty.org.',
 		});
 	}
 
@@ -154,7 +157,7 @@ export function buildLlmsTxtDoc(
 	pushSection('Top-level pages', topLevel);
 	pushSection('Articles', rowsToItems(baseUrl, data.articles, '/blog/article'));
 	pushSection('Political terms', rowsToItems(baseUrl, data.glossary, '/political-terms'));
-	pushSection('Pages', rowsToItems(baseUrl, data.landingPages, ''));
+	pushSection('Pages', excludeInternalLandingPages(rowsToItems(baseUrl, data.landingPages, '')));
 	pushSection('Policies', rowsToItems(baseUrl, data.policies, ''));
 
 	return {

--- a/src/lib/llms-txt-entries.ts
+++ b/src/lib/llms-txt-entries.ts
@@ -47,6 +47,7 @@ const SITE_SUMMARY =
 	'Nonpartisan tools, guides, and data that help independent and third-party candidates run for office and help voters discover them.';
 const MAX_DESCRIPTION_LENGTH = 200;
 const EXCLUDED_PAGE_TITLE_TERMS = ['frame', 'draft'] as const;
+const EXCLUDED_PAGE_TITLE_PATTERN = new RegExp(`\\b(?:${EXCLUDED_PAGE_TITLE_TERMS.join('|')})\\b`, 'i');
 
 /**
  * Removes a trailing slash and joins a path onto an absolute base URL.
@@ -92,8 +93,7 @@ function rowsToItems(
 
 function excludeInternalLandingPages(items: LlmsTxtItem[]): LlmsTxtItem[] {
 	return items.filter(item => {
-		const title = item.title.toLowerCase();
-		return !EXCLUDED_PAGE_TITLE_TERMS.some(term => title.includes(term));
+		return !EXCLUDED_PAGE_TITLE_PATTERN.test(item.title);
 	});
 }
 


### PR DESCRIPTION
And enhance landing page filtering:

- Changed all instances of "Good Party" to "GoodParty.org" in route and documentation.
- Updated tests to reflect the new site title and modified the logic to exclude landing pages with "Frame" or "Draft" in their titles.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the public `/llms.txt` output by renaming the site title, dropping the hard-coded `Candidates` link, and filtering some landing pages; this can affect what content is exposed for crawling/AI discovery.
> 
> **Overview**
> Updates `/llms.txt` branding to **`GoodParty.org`** (including the preview stub) and updates tests accordingly.
> 
> Adjusts the generated llms.txt document to **remove the hard-coded `Candidates` top-level entry** and to **exclude landing pages whose titles contain `frame` or `draft` (case-insensitive)** from the `Pages` section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d87bfd0e604d956cae3779530d058224027b9665. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->