### PR TITLE
Update Team Values Block content and styles; enhance card interactions

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -22,7 +22,11 @@
       "mcp__Amplitude__create_flags",
       "mcp__Sanity__query_documents",
       "mcp__Sanity__create_documents_from_json",
-      "Bash(git checkout *)"
+      "Bash(git checkout *)",
+      "Bash(xargs ls)",
+      "Bash(npx tsc *)",
+      "Bash(bun install *)",
+      "Bash(bun storybook *)"
     ]
   }
 }

--- a/src/ui/TeamValuesBlock.stories.tsx
+++ b/src/ui/TeamValuesBlock.stories.tsx
@@ -15,34 +15,39 @@ type Story = StoryObj<typeof meta>;
 
 const defaultCards: TeamValuesCardProps[] = [
 	{
-		heading: 'Compassion',
+		heading: 'People First',
 		icon: 'heart-handshake',
 		color: 'waxflower',
-		backCopy: 'We lead with empathy and listen first, centering people in every decision we make.',
+		backCopy:
+			'Our priority is to make systems serve people, not the other way around. We center on our shared humanity and integrate diverse perspectives in pursuit of the greater good.',
 	},
 	{
-		heading: 'Integrity',
-		icon: 'shield-check',
+		heading: 'Direct, Open and Honest',
+		icon: 'message-circle',
 		color: 'blue',
-		backCopy: 'We act with honesty and accountability, even when it is difficult or inconvenient.',
+		backCopy:
+			'Anti-political in all the right ways: we operate with integrity, engage in direct civil discourse and openly give and receive honest feedback.',
 	},
 	{
-		heading: 'Innovation',
-		icon: 'lightbulb',
+		heading: 'Empowered Ownership',
+		icon: 'key',
 		color: 'lavender',
-		backCopy: 'We challenge assumptions and test new ideas to deliver better outcomes over time.',
+		backCopy:
+			'We are high-agency problem solvers – independent thinkers, empowered with freedom to act, and responsibility to deliver results that advance our mission.',
 	},
 	{
-		heading: 'Community',
-		icon: 'users',
+		heading: 'Iterate for Impact',
+		icon: 'rocket',
 		color: 'halo-green',
-		backCopy: 'We collaborate with and for people, building trust through shared purpose and action.',
+		backCopy:
+			'We work with urgency and purpose. We rapidly ideate, test, learn and improve everything we do to maximize positive impact.',
 	},
 	{
-		heading: 'Transparency',
-		icon: 'eye',
+		heading: 'Fun Is Fuel',
+		icon: 'party-popper',
 		color: 'bright-yellow',
-		backCopy: 'We communicate clearly about what we know, what we do not, and why choices are made.',
+		backCopy:
+			"Our work is hard. That's why having fun, celebrating each other and our successes is important. It fuels our humanity, keeping us optimistic and connected. Besides, everybody loves a good party!",
 	},
 ];
 

--- a/src/ui/TeamValuesBlock.tsx
+++ b/src/ui/TeamValuesBlock.tsx
@@ -39,7 +39,7 @@ const cardStyles = tv({
 			'relative rounded-3xl p-6 h-full min-h-64',
 			'transition-transform duration-normal ease-smooth',
 			'[@media(hover:hover)]:group-hover/card:[transform:rotateY(180deg)]',
-			'[@media(hover:none)]:group-data-[flipped=true]/card:[transform:rotateY(180deg)]',
+			'group-data-[flipped=true]/card:[transform:rotateY(180deg)]',
 		],
 		face: [
 			'absolute inset-0 rounded-3xl p-6 flex flex-col items-start',

--- a/src/ui/TeamValuesBlock.tsx
+++ b/src/ui/TeamValuesBlock.tsx
@@ -10,6 +10,7 @@ import { FadeIn } from './FadeIn.tsx';
 import { HeaderBlock, type HeaderBlockProps } from './HeaderBlock.tsx';
 import { type IconType } from './IconResolver.tsx';
 import { Text } from './Text.tsx';
+import { ArrowRightIcon } from './icons/ArrowRightIcon.tsx';
 
 export type TeamValuesCardColor = 'waxflower' | 'blue' | 'lavender' | 'halo-green' | 'bright-yellow';
 
@@ -35,9 +36,10 @@ const cardStyles = tv({
 			'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-midnight-900 focus-visible:ring-offset-4',
 		],
 		cardInner: [
-			'relative rounded-3xl p-6 h-full',
-			'transition-transform duration-normal ease-smooth hover:-translate-y-1',
-			'min-h-64',
+			'relative rounded-3xl p-6 h-full min-h-64',
+			'transition-transform duration-normal ease-smooth',
+			'[@media(hover:hover)]:group-hover/card:[transform:rotateY(180deg)]',
+			'[@media(hover:none)]:group-data-[flipped=true]/card:[transform:rotateY(180deg)]',
 		],
 		face: [
 			'absolute inset-0 rounded-3xl p-6 flex flex-col items-start',
@@ -78,20 +80,18 @@ export function TeamValuesCard(props: TeamValuesCardProps) {
 			: 'Show details';
 
 	return (
-		<div className={cn('w-full [perspective:1200px]', props.className)}>
+		<div className={cn('w-full h-full [perspective:1200px]', props.className)}>
 			<button
 				type='button'
 				className={cardButton()}
 				onClick={() => props.onToggle?.()}
 				aria-pressed={isFlipped}
 				aria-label={ariaLabel}
+				data-flipped={isFlipped}
 			>
 				<div
 					className={cardInner()}
-					style={{
-						transformStyle: 'preserve-3d',
-						transform: isFlipped ? 'rotateY(180deg)' : 'rotateY(0deg)',
-					}}
+					style={{ transformStyle: 'preserve-3d' }}
 				>
 					<div
 						className={cn(face(), frontFace())}
@@ -100,12 +100,12 @@ export function TeamValuesCard(props: TeamValuesCardProps) {
 						<div className={top()}>
 							<CircleIcon icon={props.icon ?? 'heart-handshake'} iconBg='cream' />
 							{props.heading && (
-								// Keep value names whole and on one line; adjust grid min width before allowing wrap fallback.
-								<Text as='h3' styleType='heading-sm' className='whitespace-nowrap break-normal'>
+								<Text as='h3' styleType='heading-sm'>
 									{props.heading}
 								</Text>
 							)}
 						</div>
+						<ArrowRightIcon size={20} className='self-end' aria-hidden />
 					</div>
 					<div
 						className={cn(face(), backFace())}


### PR DESCRIPTION
Adding a Team Values Block content with enhanced card interactions

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Marketing UI and Storybook copy only; no auth, data, or API changes.
> 
> **Overview**
> Refreshes the **Team Values** block to match the current company values: Storybook defaults now use five renamed values (e.g. **People First**, **Fun Is Fuel**) with updated icons and back-of-card copy.
> 
> Card interaction changes in `TeamValuesBlock`: **3D flip on hover** for pointer devices, **tap-to-flip** on touch via `data-flipped` and existing click state; the old lift-on-hover is removed. The card front adds an **arrow** cue, and value titles no longer force single-line `whitespace-nowrap`.
> 
> Local **Claude** allowlist adds a few dev commands (`bun`, `tsc`, Storybook, etc.).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f79074e8accad0c6eca20df67cdf77979a500c15. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->