### PR TITLE
fix(candidate-profile): align QA template layout and link breadcrumbs to position candidates Fix/candidate spacing template

### DIFF
--- a/bun-env.d.ts
+++ b/bun-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="bun-types" />

--- a/bun.lock
+++ b/bun.lock
@@ -103,6 +103,7 @@
         "@sanity/eslint-config-studio": "^5.0.2",
         "@typescript-eslint/eslint-plugin": "^8.50.0",
         "@typescript-eslint/parser": "^8.50.0",
+        "bun-types": "^1.3.14",
         "eslint": "^9.39.2",
         "eslint-config-next": "^15.5.4",
         "eslint-plugin-storybook": "10.0.0-beta.9",
@@ -1833,6 +1834,8 @@
     "buffer-xor": ["buffer-xor@1.0.3", "", {}, "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ=="],
 
     "builtin-status-codes": ["builtin-status-codes@3.0.0", "", {}, "sha512-HpGFw18DgFWlncDfjTa2rcQ4W88O1mC8e8yZ2AvQY5KDaktSTwo+KRf6nHK6FRI5FyRyb/5T6+TSxfP7QyGsmQ=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "bundle-name": ["bundle-name@4.1.0", "", { "dependencies": { "run-applescript": "^7.0.0" } }, "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q=="],
 

--- a/package.json
+++ b/package.json
@@ -126,12 +126,13 @@
     "vwo-smartcode-nextjs": "^1.4.2"
   },
   "devDependencies": {
-    "@playwright/test": "^1.49.0",
     "@eslint/eslintrc": "^3.3.1",
     "@next/bundle-analyzer": "^15.5.4",
+    "@playwright/test": "^1.49.0",
     "@sanity/eslint-config-studio": "^5.0.2",
     "@typescript-eslint/eslint-plugin": "^8.50.0",
     "@typescript-eslint/parser": "^8.50.0",
+    "bun-types": "^1.3.14",
     "eslint": "^9.39.2",
     "eslint-config-next": "^15.5.4",
     "eslint-plugin-storybook": "10.0.0-beta.9",

--- a/src/PageSections/BreadcrumbBlockSection.tsx
+++ b/src/PageSections/BreadcrumbBlockSection.tsx
@@ -1,22 +1,30 @@
 import { stegaClean } from 'next-sanity';
-import type { Sections } from '~/PageSections';
+import type { SectionOverrides, Sections } from '~/PageSections';
 import { resolveBg } from '~/ui/_lib/resolveBg';
 import { BreadcrumbBlock } from '~/ui/BreadcrumbBlock';
 
-export function BreadcrumbBlockSection(section: Extract<Sections, { _type: 'component_breadcrumbBlock' }>) {
+type Props = Extract<Sections, { _type: 'component_breadcrumbBlock' }> & {
+	breadcrumbOverride?: SectionOverrides['component_breadcrumbBlock'];
+};
+
+export function BreadcrumbBlockSection({ breadcrumbOverride, ...section }: Props) {
 	const backgroundColor = section.breadcrumbBlockDesignSettings?.field_blockColorCreamMidnight
 		? resolveBg(stegaClean(section.breadcrumbBlockDesignSettings.field_blockColorCreamMidnight))
 		: 'cream';
 
-	// TODO: Generate breadcrumbs from page context/hierarchy
-	// For now, this returns an empty array. When integrated into Position Pages,
-	// the breadcrumbs should be generated from the location hierarchy
-	// (state > county > city > office)
-	const breadcrumbs = [];
+	const breadcrumbs = breadcrumbOverride?.breadcrumbs ?? [];
+
+	if (breadcrumbs.length === 0) {
+		return null;
+	}
 
 	return (
 		<section id={stegaClean(section.componentSettings?.field_anchorId)} data-section='Breadcrumb Block'>
-			<BreadcrumbBlock backgroundColor={backgroundColor} breadcrumbs={breadcrumbs} />
+			<BreadcrumbBlock
+				backgroundColor={backgroundColor}
+				breadcrumbs={breadcrumbs}
+				className='pb-4 md:pb-6'
+			/>
 		</section>
 	);
 }

--- a/src/PageSections/CTACardsBlockSection.test.ts
+++ b/src/PageSections/CTACardsBlockSection.test.ts
@@ -29,4 +29,16 @@ describe('resolveCtaCardHref', () => {
 	test('returns undefined when no href and no fallback', () => {
 		expect(resolveCtaCardHref({ action: 'Internal', link: { href: '' }, _key: 'x' })).toBeUndefined();
 	});
+
+	test('uses label fallback for static mock shape without GROQ action alias', () => {
+		const href = resolveCtaCardHref(
+			{
+				field_ctaActionWithShared: 'Internal',
+				field_buttonText: 'Explore candidates running near you',
+				text: 'Explore candidates running near you',
+			},
+			{ label: 'Candidates', href: '/candidates' },
+		);
+		expect(href).toBe('/candidates');
+	});
 });

--- a/src/PageSections/CTACardsBlockSection.test.ts
+++ b/src/PageSections/CTACardsBlockSection.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from 'bun:test';
+import { resolveCtaCardHref } from './CTACardsBlockSection';
+
+describe('resolveCtaCardHref', () => {
+	test('uses label fallback when internal href is empty', () => {
+		const href = resolveCtaCardHref(
+			{
+				action: 'Internal',
+				link: { href: '' },
+				_key: 'x',
+			},
+			{ label: 'Candidates', href: '/candidates' },
+		);
+		expect(href).toBe('/candidates');
+	});
+
+	test('returns resolved href when present', () => {
+		const href = resolveCtaCardHref(
+			{
+				action: 'Internal',
+				link: { href: '/blog' },
+				_key: 'x',
+			},
+			{ label: 'Candidates', href: '/candidates' },
+		);
+		expect(href).toBe('/blog');
+	});
+
+	test('returns undefined when no href and no fallback', () => {
+		expect(resolveCtaCardHref({ action: 'Internal', link: { href: '' }, _key: 'x' })).toBeUndefined();
+	});
+});

--- a/src/PageSections/CTACardsBlockSection.tsx
+++ b/src/PageSections/CTACardsBlockSection.tsx
@@ -1,11 +1,19 @@
 import type { Sections } from '~/PageSections';
 
-import { isButtonType, transformButton } from '~/lib/buttonTransformer';
+import { isButtonType, resolveButtonHref } from '~/lib/buttonTransformer';
 
 import { resolveBg } from '~/ui/_lib/resolveBg';
 import { resolveComponentColor } from '~/ui/_lib/resolveComponentColor';
 import { CTACardBlock } from '~/ui/CTACardBlock';
 import { stegaClean } from 'next-sanity';
+
+export function resolveCtaCardHref(
+	cta: unknown,
+	labelFallback?: { label: string; href: string },
+): string | undefined {
+	const href = cta && isButtonType(cta) ? resolveButtonHref(cta) : undefined;
+	return href ?? (labelFallback ? labelFallback.href : undefined);
+}
 
 export function CTACardsBlockSection(section: Extract<Sections, { _type: 'component_ctaCardsBlock' }>) {
 	const backgroundColor = section.ctaCardsBlockDesignSettings?.field_blockColorCreamMidnight
@@ -14,10 +22,19 @@ export function CTACardsBlockSection(section: Extract<Sections, { _type: 'compon
 
 	const cardOneCta = section.ctaCardOne?.ctaActionWithShared;
 	const cardTwoCta = section.ctaCardTwo?.ctaActionWithShared;
-	const cardOneHref =
-		cardOneCta && isButtonType(cardOneCta) ? transformButton(cardOneCta)?.href : undefined;
-	const cardTwoHref =
-		cardTwoCta && isButtonType(cardTwoCta) ? transformButton(cardTwoCta)?.href : undefined;
+	const cardOneHref = resolveCtaCardHref(
+		cardOneCta,
+		section.ctaCardOne?.field_label === 'Candidates' ? { label: 'Candidates', href: '/candidates' } : undefined,
+	);
+	const cardTwoHref = resolveCtaCardHref(
+		cardTwoCta,
+		section.ctaCardTwo?.field_label === 'Upcoming elections'
+			? { label: 'Upcoming elections', href: '/elections' }
+			: undefined,
+	);
+
+	const cardOneTitle = section.ctaCardOne?.ctaActionWithShared?.text;
+	const cardTwoTitle = section.ctaCardTwo?.ctaActionWithShared?.text;
 
 	return (
 		<section id={stegaClean(section.componentSettings?.field_anchorId)} data-section='CTA Cards Block'>
@@ -27,13 +44,13 @@ export function CTACardsBlockSection(section: Extract<Sections, { _type: 'compon
 					color: resolveComponentColor(stegaClean(section.ctaCardOne?.field_componentColor6ColorsInverse), backgroundColor),
 					href: cardOneHref,
 					label: section.ctaCardOne?.field_label,
-					title: section.ctaCardOne?.ctaActionWithShared?.text ?? undefined,
+					title: cardOneTitle ?? undefined,
 				}}
 				card2={{
 					color: resolveComponentColor(stegaClean(section.ctaCardTwo?.field_componentColor6ColorsInverse), backgroundColor),
 					href: cardTwoHref,
 					label: section.ctaCardTwo?.field_label,
-					title: section.ctaCardTwo?.ctaActionWithShared?.text ?? undefined,
+					title: cardTwoTitle ?? undefined,
 				}}
 			/>
 		</section>

--- a/src/PageSections/CTACardsBlockSection.tsx
+++ b/src/PageSections/CTACardsBlockSection.tsx
@@ -1,6 +1,11 @@
 import type { Sections } from '~/PageSections';
 
-import { isButtonType, resolveButtonHref } from '~/lib/buttonTransformer';
+import {
+	isUsableHref,
+	normalizeRawCtaToButton,
+	resolveButtonHref,
+	type RawCtaInput,
+} from '~/lib/buttonTransformer';
 
 import { resolveBg } from '~/ui/_lib/resolveBg';
 import { resolveComponentColor } from '~/ui/_lib/resolveComponentColor';
@@ -11,8 +16,9 @@ export function resolveCtaCardHref(
 	cta: unknown,
 	labelFallback?: { label: string; href: string },
 ): string | undefined {
-	const href = cta && isButtonType(cta) ? resolveButtonHref(cta) : undefined;
-	return href ?? (labelFallback ? labelFallback.href : undefined);
+	const button = cta ? normalizeRawCtaToButton(cta as RawCtaInput, 'cta-card') : undefined;
+	const href = button ? resolveButtonHref(button) : undefined;
+	return isUsableHref(href) ? href : labelFallback?.href;
 }
 
 export function CTACardsBlockSection(section: Extract<Sections, { _type: 'component_ctaCardsBlock' }>) {

--- a/src/PageSections/ClaimProfileBlockSection.test.ts
+++ b/src/PageSections/ClaimProfileBlockSection.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from 'bun:test';
+import { resolveExampleCardPartyAffiliation } from './ClaimProfileBlockSection';
+
+describe('resolveExampleCardPartyAffiliation', () => {
+	test('returns override when present', () => {
+		expect(
+			resolveExampleCardPartyAffiliation('Independent', {
+				field_partyAffiliation: 'City Council Member',
+				field_secondaryText: 'Additional info',
+			}),
+		).toBe('Independent');
+	});
+
+	test('falls back to field_partyAffiliation', () => {
+		expect(
+			resolveExampleCardPartyAffiliation(undefined, {
+				field_partyAffiliation: 'School Board Trustee',
+			}),
+		).toBe('School Board Trustee');
+	});
+
+	test('does not use field_secondaryText', () => {
+		expect(
+			resolveExampleCardPartyAffiliation(undefined, {
+				field_secondaryText: 'Additional info',
+			}),
+		).toBe('');
+	});
+
+	test('returns empty string when all values are absent', () => {
+		expect(resolveExampleCardPartyAffiliation(undefined, undefined)).toBe('');
+		expect(resolveExampleCardPartyAffiliation(undefined, {})).toBe('');
+	});
+});

--- a/src/PageSections/ClaimProfileBlockSection.test.ts
+++ b/src/PageSections/ClaimProfileBlockSection.test.ts
@@ -1,5 +1,30 @@
 import { describe, expect, test } from 'bun:test';
-import { resolveExampleCardPartyAffiliation } from './ClaimProfileBlockSection';
+import {
+	resolveClaimProfileBlockBackgroundColor,
+	resolveExampleCardPartyAffiliation,
+} from './ClaimProfileBlockSection';
+
+describe('resolveClaimProfileBlockBackgroundColor', () => {
+	test('maps CMS midnight value', () => {
+		expect(resolveClaimProfileBlockBackgroundColor('midnight')).toBe('midnight');
+	});
+
+	test('maps legacy MidnightDark value from static templates', () => {
+		expect(resolveClaimProfileBlockBackgroundColor('MidnightDark')).toBe('midnight');
+	});
+
+	test('maps CMS cream value', () => {
+		expect(resolveClaimProfileBlockBackgroundColor('cream')).toBe('cream');
+	});
+
+	test('maps legacy Cream value from static templates', () => {
+		expect(resolveClaimProfileBlockBackgroundColor('Cream')).toBe('cream');
+	});
+
+	test('defaults to cream when unset', () => {
+		expect(resolveClaimProfileBlockBackgroundColor(undefined)).toBe('cream');
+	});
+});
 
 describe('resolveExampleCardPartyAffiliation', () => {
 	test('returns override when present', () => {

--- a/src/PageSections/ClaimProfileBlockSection.tsx
+++ b/src/PageSections/ClaimProfileBlockSection.tsx
@@ -3,15 +3,27 @@ import { isButtonType, transformButton } from '~/lib/buttonTransformer';
 import { ClaimProfileBlock } from '~/ui/ClaimProfileBlock';
 import { resolveBg } from '~/ui/_lib/resolveBg';
 import { stegaClean } from 'next-sanity';
+import type { Field_blockColorCreamMidnight } from 'sanity.types';
 
 type Props = Extract<Sections, { _type: 'component_claimProfileBlock' }> & {
 	claimProfileOverride?: SectionOverrides['component_claimProfileBlock'];
 };
 
+export function resolveExampleCardPartyAffiliation(
+	override?: string,
+	exampleCard?: { field_partyAffiliation?: string; field_secondaryText?: string },
+): string {
+	return override ?? exampleCard?.field_partyAffiliation ?? '';
+}
+
 export function ClaimProfileBlockSection({ claimProfileOverride, ...section }: Props) {
-	const backgroundColor = section.claimProfileBlockDesignSettings?.field_blockColorCreamMidnight
-		? resolveBg(stegaClean(section.claimProfileBlockDesignSettings.field_blockColorCreamMidnight))
-		: 'cream';
+	const bgValue = stegaClean(section.claimProfileBlockDesignSettings?.field_blockColorCreamMidnight);
+	const backgroundColor =
+		bgValue === 'midnight'
+			? 'midnight'
+			: bgValue
+				? resolveBg(bgValue as Field_blockColorCreamMidnight)
+				: 'cream';
 
 	const ctaButton = section.ctaAction;
 	const claimButton =
@@ -26,6 +38,7 @@ export function ClaimProfileBlockSection({ claimProfileOverride, ...section }: P
 			data-section='Claim Profile Block'
 		>
 			<ClaimProfileBlock
+				layout={claimProfileOverride?.layout ?? 'card'}
 				backgroundColor={backgroundColor}
 				headline={section.claimProfileBlockContent?.field_headline}
 				body={section.claimProfileBlockContent?.field_body}
@@ -36,12 +49,23 @@ export function ClaimProfileBlockSection({ claimProfileOverride, ...section }: P
 						label: ctaButton?.text || 'View Claims',
 					}
 				}
-				exampleCard={{
-					name: claimProfileOverride?.candidateName ?? exampleCard?.field_name ?? 'Firstname Lastname',
-					partyAffiliation: claimProfileOverride?.partyAffiliation ?? exampleCard?.field_partyAffiliation,
-					secondaryText: exampleCard?.field_secondaryText,
-					showBadge: exampleCard?.field_showBadge ?? true,
-				}}
+				// Maps CMS exampleCard → CandidatesCardProps (no secondaryText on card UI)
+				exampleCard={
+					claimProfileOverride?.layout === 'banner'
+						? undefined
+						: {
+								name:
+									claimProfileOverride?.candidateName ??
+									exampleCard?.field_name ??
+									'Firstname Lastname',
+								partyAffiliation: resolveExampleCardPartyAffiliation(
+									claimProfileOverride?.partyAffiliation,
+									exampleCard,
+								),
+								href: '#',
+								isGoodPartyCandidate: exampleCard?.field_showBadge ?? true,
+							}
+				}
 			/>
 		</section>
 	);

--- a/src/PageSections/ClaimProfileBlockSection.tsx
+++ b/src/PageSections/ClaimProfileBlockSection.tsx
@@ -1,9 +1,7 @@
 import type { SectionOverrides, Sections } from '~/PageSections';
 import { isButtonType, transformButton } from '~/lib/buttonTransformer';
 import { ClaimProfileBlock } from '~/ui/ClaimProfileBlock';
-import { resolveBg } from '~/ui/_lib/resolveBg';
 import { stegaClean } from 'next-sanity';
-import type { Field_blockColorCreamMidnight } from 'sanity.types';
 
 type Props = Extract<Sections, { _type: 'component_claimProfileBlock' }> & {
 	claimProfileOverride?: SectionOverrides['component_claimProfileBlock'];
@@ -16,14 +14,18 @@ export function resolveExampleCardPartyAffiliation(
 	return override ?? exampleCard?.field_partyAffiliation ?? '';
 }
 
+export function resolveClaimProfileBlockBackgroundColor(
+	bgValue: ReturnType<typeof stegaClean<string | undefined>>,
+): 'cream' | 'midnight' {
+	if (bgValue === 'midnight' || bgValue === 'MidnightDark') {
+		return 'midnight';
+	}
+	return 'cream';
+}
+
 export function ClaimProfileBlockSection({ claimProfileOverride, ...section }: Props) {
 	const bgValue = stegaClean(section.claimProfileBlockDesignSettings?.field_blockColorCreamMidnight);
-	const backgroundColor =
-		bgValue === 'midnight'
-			? 'midnight'
-			: bgValue
-				? resolveBg(bgValue as Field_blockColorCreamMidnight)
-				: 'cream';
+	const backgroundColor = resolveClaimProfileBlockBackgroundColor(bgValue);
 
 	const ctaButton = section.ctaAction;
 	const claimButton =

--- a/src/PageSections/GoodPartyOrgPledgeSection.tsx
+++ b/src/PageSections/GoodPartyOrgPledgeSection.tsx
@@ -1,8 +1,7 @@
 import { stegaClean } from 'next-sanity';
 
 import type { Sections } from '~/PageSections';
-
-import { transformButtons } from '~/lib/buttonTransformer.tsx';
+import { transformButtons, normalizeRawCtaToButton } from '~/lib/buttonTransformer.tsx';
 import { resolveBg } from '~/ui/_lib/resolveBg.ts';
 import { resolveIconColor } from '~/ui/_lib/resolveComponentColor.tsx';
 import { resolveTextSize } from '~/ui/_lib/resolveTextSize.ts';
@@ -15,9 +14,10 @@ export function GoodPartyOrgPledgeSection(section: Extract<Sections, { _type: 'c
 		? resolveBg(stegaClean(section.goodPartyOrgPledgeDesignSettings.field_blockColorCreamMidnight))
 		: 'cream';
 
-	const iconColor = section.goodPartyOrgPledgeDesignSettings?.field_iconColor6ColorsWhiteMixed
+	const resolvedIconColor = section.goodPartyOrgPledgeDesignSettings?.field_iconColor6ColorsWhiteMixed
 		? resolveIconColor(stegaClean(section.goodPartyOrgPledgeDesignSettings.field_iconColor6ColorsWhiteMixed))
 		: 'blue';
+	const iconColor = resolvedIconColor === 'white' ? 'blue' : resolvedIconColor;
 
 	return (
 		<section id={stegaClean(section.componentSettings?.field_anchorId)} data-section='GoodParty.org Pledge'>
@@ -32,21 +32,19 @@ export function GoodPartyOrgPledgeSection(section: Extract<Sections, { _type: 'c
 					buttons: transformButtons(section.summaryInfo?.list_buttons),
 					textSize: resolveTextSize(section.summaryInfo?.field_textSize),
 				}}
-				pledgeCards={section.goodPartyOrgPledgeItems?.list_pledgeCards?.map(card => ({
-					icon: card.field_icon,
-					title: card.field_title,
-					content: <RichData value={card.block_summaryText} />,
-					button: card.ctaActionWithShared
-						? {
-								label: card.ctaActionWithShared.text,
-								buttonType: 'internal',
-								href: card.ctaActionWithShared.link?.href || '#',
-								buttonProps: {
-									styleType: 'min-ghost',
-								},
-						  }
-						: undefined,
-				}))}
+				pledgeCards={section.goodPartyOrgPledgeItems?.list_pledgeCards?.map(card => {
+					const cta = card.ctaActionWithShared;
+					const pledgeButton = cta
+						? normalizeRawCtaToButton(cta, `${card._key ?? ''}-pledge-cta`)
+						: undefined;
+
+					return {
+						icon: card.field_icon,
+						title: card.field_title,
+						content: <RichData value={card.block_summaryText} />,
+						button: pledgeButton ? transformButtons([pledgeButton])?.[0] : undefined,
+					};
+				})}
 			/>
 		</section>
 	);

--- a/src/PageSections/IconContentBlockSection.tsx
+++ b/src/PageSections/IconContentBlockSection.tsx
@@ -2,7 +2,7 @@ import { stegaClean } from 'next-sanity';
 
 import type { Sections } from '~/PageSections';
 
-import { transformButtons } from '~/lib/buttonTransformer';
+import { normalizeRawCtaToButton, transformButtons } from '~/lib/buttonTransformer';
 import { resolveBg } from '~/ui/_lib/resolveBg';
 import { resolveIconColor } from '~/ui/_lib/resolveComponentColor';
 import { resolveTextSize } from '~/ui/_lib/resolveTextSize';
@@ -29,14 +29,18 @@ export function IconContentBlockSection(section: Extract<Sections, { _type: 'com
 				}}
 				columns={resolveColumns(stegaClean(section.iconContentBlockDesignSettings?.field_columnLayout234Columns))}
 				color={resolveIconColor(stegaClean(section.iconContentBlockDesignSettings?.field_iconColor6ColorsWhiteMixed))}
-				items={section.iconContentBlockItems?.list_iconContentItems?.map(item => ({
-					copy: <RichData value={item.block_summaryText} />,
-					icon: item.field_icon,
-					title: item?.field_title,
-					button: item.ctaActionWithShared?.action
-						? transformButtons([{ ...item.ctaActionWithShared, _key: `${item._key ?? ''}-icon-cta` }])?.[0]
-						: undefined,
-				}))}
+				items={section.iconContentBlockItems?.list_iconContentItems?.map(item => {
+					const button = item.ctaActionWithShared
+						? normalizeRawCtaToButton(item.ctaActionWithShared, `${item._key ?? ''}-icon-cta`)
+						: undefined;
+
+					return {
+						copy: <RichData value={item.block_summaryText} />,
+						icon: item.field_icon,
+						title: item?.field_title,
+						button: button ? transformButtons([button])?.[0] : undefined,
+					};
+				})}
 			/>
 		</section>
 	);

--- a/src/PageSections/TabbedImageBlockSection.tsx
+++ b/src/PageSections/TabbedImageBlockSection.tsx
@@ -2,7 +2,7 @@ import { stegaClean } from 'next-sanity';
 
 import type { Sections } from '~/PageSections';
 
-import { transformButtons } from '~/lib/buttonTransformer';
+import { normalizeRawCtaToButton, transformButtons } from '~/lib/buttonTransformer';
 import { resolveBg } from '~/ui/_lib/resolveBg';
 import { resolveTextSize } from '~/ui/_lib/resolveTextSize';
 
@@ -15,20 +15,24 @@ export function TabbedImageBlockSection(section: Extract<Sections, { _type: 'com
 		: 'cream';
 
 	const items = section.tabbedImageBlockItems?.list_tabbedImageItems
-		?.map(item =>
-			item.field_title
-				? {
-						_key: item._key,
-						title: item.field_title,
-						copy: item.field_summaryDescription,
-						image: item.img_image,
-						showFullImage: item.showFullImage,
-						button: item.ctaActionWithShared?.action
-							? transformButtons([{ ...item.ctaActionWithShared, _key: item._key + 'TabbedImageBlockButton' }])?.[0]
-							: undefined,
-					}
-				: undefined,
-		)
+		?.map(item => {
+			if (!item.field_title) {
+				return undefined;
+			}
+
+			const button = item.ctaActionWithShared
+				? normalizeRawCtaToButton(item.ctaActionWithShared, `${item._key}-tabbed-image-cta`)
+				: undefined;
+
+			return {
+				_key: item._key,
+				title: item.field_title,
+				copy: item.field_summaryDescription,
+				image: item.img_image,
+				showFullImage: item.showFullImage,
+				button: button ? transformButtons([button])?.[0] : undefined,
+			};
+		})
 		.filter(Boolean);
 
 	if (!(items && items.length > 0)) return null;

--- a/src/PageSections/index.tsx
+++ b/src/PageSections/index.tsx
@@ -66,10 +66,14 @@ export type SectionOverrides = {
 		profileData?: import('~/PageSections/ProfileContentBlockSection').ProfileData;
 		officeData?: import('~/PageSections/ProfileContentBlockSection').OfficeData;
 	};
+	component_breadcrumbBlock?: {
+		breadcrumbs: import('~/ui/BreadcrumbBlock').BreadcrumbItem[];
+	};
 	component_claimProfileBlock?: {
 		claimed?: boolean;
 		candidateName?: string;
 		partyAffiliation?: string;
+		layout?: 'card' | 'banner';
 	};
 };
 
@@ -96,7 +100,10 @@ export function PageSections(props: Props) {
 					case 'component_breadcrumbBlock':
 						return (
 							<ComponentErrorBoundary key={section._key} componentName='Breadcrumb Block'>
-								<BreadcrumbBlockSection {...section} />
+								<BreadcrumbBlockSection
+									{...section}
+									breadcrumbOverride={props.sectionOverrides?.component_breadcrumbBlock}
+								/>
 							</ComponentErrorBoundary>
 						);
 					case 'component_blogBlock':

--- a/src/app/candidate/[...slug]/page.tsx
+++ b/src/app/candidate/[...slug]/page.tsx
@@ -1,12 +1,11 @@
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
-import { getCandidateBySlug, findCampaignByRace } from '~/lib/electionsApi';
+import { getCandidateBySlug, findCampaignByRace, resolveRaceElectionHrefs } from '~/lib/electionsApi';
 import {
 	formatElectionDateFromApi,
 	formatSidebarLinkLabel,
 	formatTermLength,
 	inferSidebarLinkIcon,
-	buildRacePositionHref,
 	prependClaimedWebsiteIfNew,
 } from '~/lib/electionsHelpers';
 import { PageSections } from '~/PageSections';
@@ -24,6 +23,7 @@ export async function generateStaticParams(): Promise<{ slug: string[] }[]> {
 function buildSectionOverrides(
 	candidate: CandidacyItem,
 	claimed: FindByRaceIdResponse | null,
+	electionHrefs: { positionHref?: string; candidatesHref?: string },
 ): SectionOverrides {
 	const candidateName = [candidate.firstName, candidate.lastName].filter(Boolean).join(' ') || 'Candidate';
 	const office = candidate.positionName ?? 'Office';
@@ -58,7 +58,7 @@ function buildSectionOverrides(
 		links.push(...merged);
 	}
 
-	const racePositionHref = buildRacePositionHref(candidate.Race?.slug);
+	const racePositionHref = electionHrefs.positionHref;
 
 	const officeData: OfficeData = {
 		links: links.length ? links : undefined,
@@ -75,7 +75,9 @@ function buildSectionOverrides(
 		component_breadcrumbBlock: {
 			breadcrumbs: [
 				{ href: '/', label: 'Home' },
-				{ href: '/candidates', label: 'Candidates' },
+				...(electionHrefs.candidatesHref
+					? [{ href: electionHrefs.candidatesHref, label: 'Candidates' }]
+					: [{ label: 'Candidates' }]),
 				{ label: candidateName },
 			],
 		},
@@ -151,7 +153,11 @@ export default async function Page({
 		});
 	}
 
-	const sectionOverrides = buildSectionOverrides(candidate, claimed);
+	const sectionOverrides = buildSectionOverrides(
+		candidate,
+		claimed,
+		await resolveRaceElectionHrefs(candidate.Race?.slug, candidate.Race?.positionLevel),
+	);
 
 	return (
 		<PageSections

--- a/src/app/candidate/[...slug]/page.tsx
+++ b/src/app/candidate/[...slug]/page.tsx
@@ -7,6 +7,7 @@ import {
 	formatTermLength,
 	inferSidebarLinkIcon,
 	buildRacePositionHref,
+	prependClaimedWebsiteIfNew,
 } from '~/lib/electionsHelpers';
 import { PageSections } from '~/PageSections';
 import type { SectionOverrides } from '~/PageSections';
@@ -52,14 +53,9 @@ function buildSectionOverrides(
 		});
 	}
 	if (claimed?.details?.website) {
-		const hasWebsite = links.some((l) => l.label === 'Website');
-		if (!hasWebsite) {
-			links.unshift({
-				label: 'Website',
-				icon: inferSidebarLinkIcon(claimed.details.website),
-				href: claimed.details.website,
-			});
-		}
+		const merged = prependClaimedWebsiteIfNew(links ?? [], claimed.details.website);
+		links.length = 0;
+		links.push(...merged);
 	}
 
 	const racePositionHref = buildRacePositionHref(candidate.Race?.slug);

--- a/src/app/candidate/[...slug]/page.tsx
+++ b/src/app/candidate/[...slug]/page.tsx
@@ -1,7 +1,13 @@
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import { getCandidateBySlug, findCampaignByRace } from '~/lib/electionsApi';
-import { formatElectionDateFromApi } from '~/lib/electionsHelpers';
+import {
+	formatElectionDateFromApi,
+	formatSidebarLinkLabel,
+	formatTermLength,
+	inferSidebarLinkIcon,
+	buildRacePositionHref,
+} from '~/lib/electionsHelpers';
 import { PageSections } from '~/PageSections';
 import type { SectionOverrides } from '~/PageSections';
 import type { CandidacyItem, FindByRaceIdResponse } from '~/types/elections';
@@ -23,7 +29,7 @@ function buildSectionOverrides(
 	const isClaimed = !!claimed;
 
 	const profileData: ProfileData = {
-		aboutMe: candidate.about,
+		aboutMe: candidate.about ?? undefined,
 		whyRunning: claimed?.details?.pastExperience,
 		topIssues: buildTopIssues(candidate, claimed),
 	};
@@ -32,7 +38,8 @@ function buildSectionOverrides(
 	if (candidate.urls?.length) {
 		candidate.urls.forEach((url, i) => {
 			links.push({
-				label: i === 0 ? 'Website' : `Link ${i + 1}`,
+				label: formatSidebarLinkLabel(url, i),
+				icon: inferSidebarLinkIcon(url),
 				href: url,
 			});
 		});
@@ -40,24 +47,42 @@ function buildSectionOverrides(
 	if (candidate.email) {
 		links.push({
 			label: 'Email',
+			icon: 'mail',
 			href: `mailto:${candidate.email}`,
 		});
 	}
 	if (claimed?.details?.website) {
 		const hasWebsite = links.some((l) => l.label === 'Website');
 		if (!hasWebsite) {
-			links.unshift({ label: 'Website', href: claimed.details.website });
+			links.unshift({
+				label: 'Website',
+				icon: inferSidebarLinkIcon(claimed.details.website),
+				href: claimed.details.website,
+			});
 		}
 	}
 
+	const racePositionHref = buildRacePositionHref(candidate.Race?.slug);
+
 	const officeData: OfficeData = {
 		links: links.length ? links : undefined,
+		aboutOffice: candidate.positionDescription ?? candidate.Race?.positionDescription,
+		termLength: formatTermLength(candidate.electionFrequency ?? candidate.Race?.frequency),
 		electionDate: candidate.Race?.electionDate
 			? formatElectionDateFromApi(candidate.Race.electionDate)
 			: undefined,
+		ctaHref: racePositionHref,
+		ctaLabel: racePositionHref ? 'View office details' : undefined,
 	};
 
 	return {
+		component_breadcrumbBlock: {
+			breadcrumbs: [
+				{ href: '/', label: 'Home' },
+				{ href: '/candidates', label: 'Candidates' },
+				{ label: candidateName },
+			],
+		},
 		component_profileHero: {
 			candidateName,
 			office,
@@ -72,6 +97,7 @@ function buildSectionOverrides(
 			claimed: isClaimed,
 			candidateName,
 			partyAffiliation: claimed?.details?.party ?? candidate.party,
+			layout: 'banner',
 		},
 	};
 }

--- a/src/app/candidate/[...slug]/profilePageSections.ts
+++ b/src/app/candidate/[...slug]/profilePageSections.ts
@@ -4,11 +4,18 @@ import type { Sections } from '~/PageSections';
  * Static profile page section layout (from profile.json template).
  * Used when Sanity profile landing page is not available.
  */
-export const PROFILE_PAGE_SECTIONS: Sections[] = [
+export const PROFILE_PAGE_SECTIONS = [
 	{
 		_key: 'a154f5843c8d',
 		_type: 'component_breadcrumbBlock',
 		breadcrumbBlockDesignSettings: {
+			field_blockColorCreamMidnight: 'MidnightDark',
+		},
+	},
+	{
+		_key: 'ca7f2bfda6dc',
+		_type: 'component_profileHero',
+		profileHeroDesignSettings: {
 			field_blockColorCreamMidnight: 'MidnightDark',
 		},
 	},
@@ -23,7 +30,7 @@ export const PROFILE_PAGE_SECTIONS: Sections[] = [
 			field_headline: 'This profile is unclaimed',
 		},
 		claimProfileBlockDesignSettings: {
-			field_blockColorCreamMidnight: 'midnight',
+			field_blockColorCreamMidnight: 'Cream',
 		},
 		ctaAction: {
 			_type: 'ctaActionWithShared',
@@ -38,13 +45,6 @@ export const PROFILE_PAGE_SECTIONS: Sections[] = [
 			anchor: null,
 			ref_download: null,
 			formId: null,
-		},
-	},
-	{
-		_key: 'ca7f2bfda6dc',
-		_type: 'component_profileHero',
-		profileHeroDesignSettings: {
-			field_blockColorCreamMidnight: 'MidnightDark',
 		},
 	},
 	{
@@ -87,6 +87,9 @@ export const PROFILE_PAGE_SECTIONS: Sections[] = [
 					],
 					ctaActionWithShared: {
 						_type: 'ctaActionWithShared',
+						action: 'Internal',
+						text: 'Learn more',
+						link: { href: '/candidates' },
 						field_buttonText: 'Learn more',
 						field_ctaActionWithShared: 'Internal',
 						field_internalLink: { _type: 'field_internalLink', href: { _ref: '19a8efe4-5a87-4ea5-ae0e-42656ea7c7f8', _type: 'reference' } },
@@ -115,6 +118,9 @@ export const PROFILE_PAGE_SECTIONS: Sections[] = [
 					],
 					ctaActionWithShared: {
 						_type: 'ctaActionWithShared',
+						action: 'Internal',
+						text: 'Learn more',
+						link: { href: '/candidates' },
 						field_buttonText: 'Learn more',
 						field_ctaActionWithShared: 'Internal',
 						field_internalLink: { _type: 'field_internalLink', href: { _ref: '19a8efe4-5a87-4ea5-ae0e-42656ea7c7f8', _type: 'reference' } },
@@ -143,6 +149,9 @@ export const PROFILE_PAGE_SECTIONS: Sections[] = [
 					],
 					ctaActionWithShared: {
 						_type: 'ctaActionWithShared',
+						action: 'Internal',
+						text: 'Learn more',
+						link: { href: '/candidates' },
 						field_buttonText: 'Learn more',
 						field_ctaActionWithShared: 'Internal',
 						field_internalLink: { _type: 'field_internalLink', href: { _ref: '19a8efe4-5a87-4ea5-ae0e-42656ea7c7f8', _type: 'reference' } },
@@ -171,6 +180,9 @@ export const PROFILE_PAGE_SECTIONS: Sections[] = [
 					],
 					ctaActionWithShared: {
 						_type: 'ctaActionWithShared',
+						action: 'Internal',
+						text: 'Learn more',
+						link: { href: '/candidates' },
 						field_buttonText: 'Learn more',
 						field_ctaActionWithShared: 'Internal',
 						field_internalLink: { _type: 'field_internalLink', href: { _ref: '19a8efe4-5a87-4ea5-ae0e-42656ea7c7f8', _type: 'reference' } },
@@ -368,6 +380,7 @@ export const PROFILE_PAGE_SECTIONS: Sections[] = [
 			ctaActionWithShared: {
 				_type: 'ctaActionWithShared',
 				field_buttonText: 'Explore candidates running near you',
+				text: 'Explore candidates running near you',
 				field_ctaActionWithShared: 'Internal',
 			},
 			field_componentColor6ColorsInverse: 'BrightYellow',
@@ -378,6 +391,7 @@ export const PROFILE_PAGE_SECTIONS: Sections[] = [
 			ctaActionWithShared: {
 				_type: 'ctaActionWithShared',
 				field_buttonText: 'Explore upcoming elections near you',
+				text: 'Explore upcoming elections near you',
 				field_ctaActionWithShared: 'Internal',
 			},
 			field_componentColor6ColorsInverse: 'HaloGreen',
@@ -388,4 +402,4 @@ export const PROFILE_PAGE_SECTIONS: Sections[] = [
 			field_blockColorCreamMidnight: 'Cream',
 		},
 	},
-];
+] as unknown as Sections[];

--- a/src/lib/buttonTransformer.test.ts
+++ b/src/lib/buttonTransformer.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from 'bun:test';
+import {
+	isButtonType,
+	normalizeRawCtaToButton,
+	resolveButtonHref,
+	transformButtons,
+} from './buttonTransformer';
+
+describe('isButtonType', () => {
+	test('rejects action: null', () => {
+		expect(isButtonType({ action: null, _key: 'x' })).toBe(false);
+	});
+
+	test('rejects missing action', () => {
+		expect(isButtonType({ _key: 'x' })).toBe(false);
+	});
+
+	test('accepts valid action', () => {
+		expect(isButtonType({ action: 'Internal', _key: 'x' })).toBe(true);
+	});
+});
+
+describe('normalizeRawCtaToButton', () => {
+	test('maps field_* aliases to action and text', () => {
+		const button = normalizeRawCtaToButton(
+			{
+				field_ctaActionWithShared: 'Internal',
+				field_buttonText: 'Learn more',
+			},
+			'card-cta',
+		);
+		expect(button?.action).toBe('Internal');
+		expect(button?.text).toBe('Learn more');
+		expect(button?._key).toBe('card-cta');
+	});
+
+	test('returns undefined when action is missing', () => {
+		expect(normalizeRawCtaToButton({ field_buttonText: 'Learn more' }, 'card-cta')).toBeUndefined();
+	});
+
+	test('prefers GROQ action alias over field_ctaActionWithShared', () => {
+		const button = normalizeRawCtaToButton(
+			{
+				action: 'SignUp',
+				field_ctaActionWithShared: 'Internal',
+				text: 'Sign up',
+			},
+			'card-cta',
+		);
+		expect(button?.action).toBe('SignUp');
+	});
+
+	test('preserves link and other ButtonType fields for transformButtons', () => {
+		const button = normalizeRawCtaToButton(
+			{
+				action: 'Internal',
+				text: 'Learn more',
+				link: { href: '/candidates', title: 'Candidates', name: null },
+			},
+			'card-cta',
+		);
+		expect(button?.link?.href).toBe('/candidates');
+
+		const transformed = button ? transformButtons([button])?.[0] : undefined;
+		expect(transformed?.href).toBe('/candidates');
+		expect(transformed?.label).toBe('Learn more');
+	});
+});
+
+describe('resolveButtonHref', () => {
+	test('treats empty string internal href as undefined', () => {
+		const href = resolveButtonHref({
+			action: 'Internal',
+			link: { href: '' },
+			_key: 'x',
+		} as Parameters<typeof resolveButtonHref>[0]);
+		expect(href).toBeUndefined();
+	});
+
+	test('returns internal link href when present', () => {
+		const href = resolveButtonHref({
+			action: 'Internal',
+			link: { href: '/candidates' },
+			_key: 'x',
+		} as Parameters<typeof resolveButtonHref>[0]);
+		expect(href).toBe('/candidates');
+	});
+});

--- a/src/lib/buttonTransformer.test.ts
+++ b/src/lib/buttonTransformer.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, test } from 'bun:test';
 import {
 	isButtonType,
+	isUsableHref,
 	normalizeRawCtaToButton,
 	resolveButtonHref,
+	transformButton,
 	transformButtons,
 } from './buttonTransformer';
 
@@ -65,16 +67,43 @@ describe('normalizeRawCtaToButton', () => {
 		expect(transformed?.href).toBe('/candidates');
 		expect(transformed?.label).toBe('Learn more');
 	});
+
+	test('static mock shape with field_ctaActionWithShared only produces a button', () => {
+		const button = normalizeRawCtaToButton(
+			{
+				field_ctaActionWithShared: 'Internal',
+				field_buttonText: 'Learn more',
+				link: { href: '/candidates' },
+			},
+			'pledge-cta',
+		);
+		expect(button?.action).toBe('Internal');
+
+		const transformed = button ? transformButtons([button])?.[0] : undefined;
+		expect(transformed?.href).toBe('/candidates');
+		expect(transformed?.label).toBe('Learn more');
+	});
+});
+
+describe('isUsableHref', () => {
+	test('rejects undefined and empty string', () => {
+		expect(isUsableHref(undefined)).toBe(false);
+		expect(isUsableHref('')).toBe(false);
+	});
+
+	test('accepts non-empty href', () => {
+		expect(isUsableHref('/candidates')).toBe(true);
+	});
 });
 
 describe('resolveButtonHref', () => {
-	test('treats empty string internal href as undefined', () => {
+	test('preserves empty string internal href', () => {
 		const href = resolveButtonHref({
 			action: 'Internal',
 			link: { href: '' },
 			_key: 'x',
 		} as Parameters<typeof resolveButtonHref>[0]);
-		expect(href).toBeUndefined();
+		expect(href).toBe('');
 	});
 
 	test('returns internal link href when present', () => {
@@ -84,5 +113,30 @@ describe('resolveButtonHref', () => {
 			_key: 'x',
 		} as Parameters<typeof resolveButtonHref>[0]);
 		expect(href).toBe('/candidates');
+	});
+});
+
+describe('transformButton', () => {
+	test('returns undefined when internal href is empty', () => {
+		const result = transformButton({
+			action: 'Internal',
+			link: { href: '' },
+			text: 'Learn more',
+			_key: 'x',
+		} as Parameters<typeof transformButton>[0]);
+		expect(result).toBeUndefined();
+	});
+
+	test('returns undefined when normalizeRawCtaToButton yields empty link href', () => {
+		const button = normalizeRawCtaToButton(
+			{
+				action: 'Internal',
+				text: 'Learn more',
+				link: { href: '' },
+			},
+			'card-cta',
+		);
+		expect(button).toBeDefined();
+		expect(transformButton(button!)).toBeUndefined();
 	});
 });

--- a/src/lib/buttonTransformer.tsx
+++ b/src/lib/buttonTransformer.tsx
@@ -7,6 +7,17 @@ export type ButtonsType = Exclude<Extract<Sections, { _type: 'component_hero' }>
 
 export type ButtonType = Exclude<ButtonsType, null | undefined>[number];
 
+export type RawCtaFields = {
+	action?: ButtonType['action'];
+	field_ctaActionWithShared?: ButtonType['action'];
+	text?: string | null;
+	field_buttonText?: string | null;
+	_key?: string | null;
+};
+
+/** Raw Sanity/GROQ CTA payload; may include link, anchor, etc. preserved via spread. */
+export type RawCtaInput = RawCtaFields & Partial<Omit<ButtonType, '_key' | 'action' | 'text'>>;
+
 /**
  * Type guard for raw CTA/button data from Sanity (e.g. ctaAction, ctaActionWithShared).
  * Ensures the value has the minimal shape expected by transformButton and transformButtons.
@@ -16,7 +27,23 @@ export function isButtonType(value: unknown): value is ButtonType {
 		return false;
 	}
 	const obj = value as Record<string, unknown>;
-	return 'action' in obj && typeof obj.action !== 'undefined';
+	return 'action' in obj && obj.action != null;
+}
+
+export function normalizeRawCtaToButton(
+	raw: RawCtaInput,
+	keySuffix: string,
+): ButtonType | undefined {
+	const action = raw.action ?? raw.field_ctaActionWithShared;
+	if (action == null) {
+		return undefined;
+	}
+	return {
+		...raw,
+		action,
+		text: raw.text ?? raw.field_buttonText ?? null,
+		_key: keySuffix,
+	} as ButtonType;
 }
 
 function resolveHierarchy(
@@ -31,24 +58,36 @@ function resolveHierarchy(
 
 export function resolveButtonHref(button: ButtonType): string | undefined {
 	const action = stegaClean(button.action);
+	let href: string | undefined;
 
 	switch (action) {
 		case 'Internal':
 		case 'Contact':
-			return button.link && 'href' in button.link ? (button.link.href as string | undefined) ?? undefined : undefined;
+			href =
+				button.link && 'href' in button.link
+					? ((button.link.href as string | undefined) ?? undefined)
+					: undefined;
+			break;
 		case 'External':
-			return button.field_externalLink ?? undefined;
+			href = button.field_externalLink ?? undefined;
+			break;
 		case 'Anchor':
-			return button.anchor ?? undefined;
+			href = button.anchor ?? undefined;
+			break;
 		case 'Download':
-			return button.ref_download?.file?.url ?? undefined;
+			href = button.ref_download?.file?.url ?? undefined;
+			break;
 		case 'LogIn':
-			return 'https://app.goodparty.org/login';
+			href = 'https://app.goodparty.org/login';
+			break;
 		case 'SignUp':
-			return 'https://app.goodparty.org/sign-up';
+			href = 'https://app.goodparty.org/sign-up';
+			break;
 		default:
-			return undefined;
+			href = undefined;
 	}
+
+	return href || undefined;
 }
 
 export function transformButton(button: ButtonType): ComponentButtonProps | undefined {

--- a/src/lib/buttonTransformer.tsx
+++ b/src/lib/buttonTransformer.tsx
@@ -87,7 +87,12 @@ export function resolveButtonHref(button: ButtonType): string | undefined {
 			href = undefined;
 	}
 
-	return href || undefined;
+	return href;
+}
+
+/** True when href is a non-empty string suitable for navigation or fallback decisions. */
+export function isUsableHref(href: string | undefined): href is string {
+	return href != null && href !== '';
 }
 
 export function transformButton(button: ButtonType): ComponentButtonProps | undefined {
@@ -96,7 +101,7 @@ export function transformButton(button: ButtonType): ComponentButtonProps | unde
 
 	switch (action) {
 		case 'Internal':
-			if (!href) return undefined;
+			if (!isUsableHref(href)) return undefined;
 			return {
 				_key: button._key,
 				formId: (button as { formId?: string }).formId,
@@ -108,7 +113,7 @@ export function transformButton(button: ButtonType): ComponentButtonProps | unde
 				},
 			};
 		case 'Contact':
-			if (!href) return undefined;
+			if (!isUsableHref(href)) return undefined;
 			return {
 				_key: button._key,
 				formId: (button as { formId?: string }).formId,
@@ -120,7 +125,7 @@ export function transformButton(button: ButtonType): ComponentButtonProps | unde
 				},
 			};
 		case 'External':
-			if (!href) return undefined;
+			if (!isUsableHref(href)) return undefined;
 			return {
 				_key: button._key,
 				formId: (button as { formId?: string }).formId,
@@ -132,7 +137,7 @@ export function transformButton(button: ButtonType): ComponentButtonProps | unde
 				},
 			};
 		case 'Anchor':
-			if (!href) return undefined;
+			if (!isUsableHref(href)) return undefined;
 			return {
 				_key: button._key,
 				formId: (button as { formId?: string }).formId,
@@ -144,7 +149,7 @@ export function transformButton(button: ButtonType): ComponentButtonProps | unde
 				},
 			};
 		case 'Download':
-			if (!href) return undefined;
+			if (!isUsableHref(href)) return undefined;
 			return {
 				_key: button._key,
 				formId: (button as { formId?: string }).formId,
@@ -156,7 +161,7 @@ export function transformButton(button: ButtonType): ComponentButtonProps | unde
 				},
 			};
 		case 'LogIn':
-			if (!href) return undefined;
+			if (!isUsableHref(href)) return undefined;
 			return {
 				_key: button._key,
 				formId: (button as { formId?: string }).formId,
@@ -168,7 +173,7 @@ export function transformButton(button: ButtonType): ComponentButtonProps | unde
 				},
 			};
 		case 'SignUp':
-			if (!href) return undefined;
+			if (!isUsableHref(href)) return undefined;
 			return {
 				_key: button._key,
 				formId: (button as { formId?: string }).formId,

--- a/src/lib/electionsApi.test.ts
+++ b/src/lib/electionsApi.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import type { PlaceItem } from '~/types/elections';
-import { getCountyChildPlaces, isStateIndexDistrictPlace } from './electionsApi';
+import {
+	getCountyChildPlaces,
+	isStateIndexDistrictPlace,
+	resolveCountySlugForPlace,
+	resolveRaceElectionHrefs,
+} from './electionsApi';
 
 type FetchMockResponse = {
 	match: (url: string) => boolean;
@@ -278,6 +283,99 @@ describe('getCountyChildPlaces', () => {
 		expect(slugs(result).sort()).toEqual(
 			['me/androscoggin-county/auburn-town', 'me/androscoggin-county/lisbon-town', 'me/androscoggin-county/sabattus-town', 'me/lewiston'].sort(),
 		);
+	});
+});
+
+describe('resolveCountySlugForPlace', () => {
+	test('matches county name to county place slug', async () => {
+		withFetchMock([
+			{
+				match: url =>
+					url.includes('/v1/places?') && url.includes('state=MI') && url.includes('mtfcc=G4020'),
+				body: [
+					{ slug: 'mi/wayne-county', name: 'Wayne County', mtfcc: 'G4020', state: 'MI' },
+					{ slug: 'mi/oakland-county', name: 'Oakland County', mtfcc: 'G4020', state: 'MI' },
+				],
+			},
+		]);
+
+		await expect(resolveCountySlugForPlace('MI', 'Wayne')).resolves.toBe('mi/wayne-county');
+	});
+});
+
+describe('resolveRaceElectionHrefs', () => {
+	test('returns generic path for LOCAL school district without county expansion', async () => {
+		withFetchMock([
+			{
+				match: url => url.includes('/v1/races?') && url.includes('ok%2Ftecumseh-public-schools'),
+				body: [
+					{
+						slug: 'ok/tecumseh-public-schools/local-school-board',
+						state: 'OK',
+						positionLevel: 'LOCAL',
+						Place: {
+							slug: 'ok/tecumseh-public-schools',
+							mtfcc: 'G5420',
+							countyName: 'Pottawatomie',
+						},
+					},
+				],
+			},
+		]);
+
+		await expect(
+			resolveRaceElectionHrefs(
+				'ok/tecumseh-public-schools/local-school-board',
+				'LOCAL',
+			),
+		).resolves.toEqual({
+			positionHref: '/elections/ok/tecumseh-public-schools/position/local-school-board',
+			candidatesHref:
+				'/elections/ok/tecumseh-public-schools/position/local-school-board/candidates',
+		});
+	});
+
+	test('expands CITY race to canonical 4-level candidates URL', async () => {
+		withFetchMock([
+			{
+				match: url => url.includes('/v1/races?') && url.includes('mi%2Fnorthville'),
+				body: [
+					{
+						slug: 'mi/northville/city-legislature',
+						state: 'MI',
+						positionLevel: 'CITY',
+						Place: {
+							slug: 'mi/northville',
+							mtfcc: 'G4110',
+							countyName: 'Wayne',
+						},
+					},
+				],
+			},
+			{
+				match: url =>
+					url.includes('/v1/places?') && url.includes('state=MI') && url.includes('mtfcc=G4020'),
+				body: [{ slug: 'mi/wayne-county', name: 'Wayne County', mtfcc: 'G4020', state: 'MI' }],
+			},
+		]);
+
+		await expect(
+			resolveRaceElectionHrefs('mi/northville/city-legislature', 'CITY'),
+		).resolves.toEqual({
+			positionHref: '/elections/mi/wayne-county/northville/position/city-legislature',
+			candidatesHref: '/elections/mi/wayne-county/northville/position/city-legislature/candidates',
+		});
+	});
+
+	test('returns empty object when race slug is missing', async () => {
+		await expect(resolveRaceElectionHrefs(undefined)).resolves.toEqual({});
+	});
+
+	test('builds state-level paths without race fetch', async () => {
+		await expect(resolveRaceElectionHrefs('az/governor', 'STATE')).resolves.toEqual({
+			positionHref: '/elections/az/position/governor',
+			candidatesHref: '/elections/az/position/governor/candidates',
+		});
 	});
 });
 

--- a/src/lib/electionsApi.test.ts
+++ b/src/lib/electionsApi.test.ts
@@ -367,6 +367,38 @@ describe('resolveRaceElectionHrefs', () => {
 		});
 	});
 
+	test('expands CITY race when positionLevel is empty string and falls back to race fetch', async () => {
+		withFetchMock([
+			{
+				match: url => url.includes('/v1/races?') && url.includes('mi%2Fnorthville'),
+				body: [
+					{
+						slug: 'mi/northville/city-legislature',
+						state: 'MI',
+						positionLevel: 'CITY',
+						Place: {
+							slug: 'mi/northville',
+							mtfcc: 'G4110',
+							countyName: 'Wayne',
+						},
+					},
+				],
+			},
+			{
+				match: url =>
+					url.includes('/v1/places?') && url.includes('state=MI') && url.includes('mtfcc=G4020'),
+				body: [{ slug: 'mi/wayne-county', name: 'Wayne County', mtfcc: 'G4020', state: 'MI' }],
+			},
+		]);
+
+		await expect(
+			resolveRaceElectionHrefs('mi/northville/city-legislature', ''),
+		).resolves.toEqual({
+			positionHref: '/elections/mi/wayne-county/northville/position/city-legislature',
+			candidatesHref: '/elections/mi/wayne-county/northville/position/city-legislature/candidates',
+		});
+	});
+
 	test('returns empty object when race slug is missing', async () => {
 		await expect(resolveRaceElectionHrefs(undefined)).resolves.toEqual({});
 	});

--- a/src/lib/electionsApi.ts
+++ b/src/lib/electionsApi.ts
@@ -364,7 +364,7 @@ export async function resolveRaceElectionHrefs(
 	}
 
 	const fullRace = await getRaceBySlug(raceSlug);
-	const effectiveLevel = (positionLevel ?? fullRace?.positionLevel ?? '').toUpperCase();
+	const effectiveLevel = (positionLevel || fullRace?.positionLevel || '').toUpperCase();
 	if (effectiveLevel !== 'CITY' && effectiveLevel !== 'LOCAL') {
 		const positionHref = buildElectionPositionHrefFromRaceSlug({
 			slug: raceSlug,

--- a/src/lib/electionsApi.ts
+++ b/src/lib/electionsApi.ts
@@ -10,7 +10,12 @@ import type {
 	RaceDetail,
 	RaceNode,
 } from '~/types/elections';
-import { canonicalizeCountyEquivalentName } from '~/lib/electionsHelpers';
+import {
+	buildElectionPositionHrefFromRaceSlug,
+	buildRaceCandidatesHref,
+	canonicalizeCountyEquivalentName,
+	stripCountySuffix,
+} from '~/lib/electionsHelpers';
 
 const BASE_URL =
 	process.env['ELECTIONS_API_BASE_URL'] ?? 'https://election-api.goodparty.org';
@@ -311,4 +316,106 @@ export async function getPlaceBySlug(params: {
 	const url = `${BASE_URL}/v1/places?${searchParams}`;
 	const data = await fetchJson<PlaceWithFacts[]>(url, CACHE_OPTIONS);
 	return Array.isArray(data) && data.length > 0 ? (data[0] ?? null) : null;
+}
+
+/** Resolves a county place slug from a state code and county name on a city/town place. */
+export async function resolveCountySlugForPlace(
+	state: string,
+	countyName: string,
+): Promise<string | undefined> {
+	const counties = await getPlacesByState({ state, mtfcc: COUNTY_MTFCC });
+	const target = normalizeName(canonicalizeCountyEquivalentName(state, countyName).baseName);
+	for (const county of counties) {
+		if (!county.slug || !county.name) continue;
+		const countyBase = normalizeName(stripCountySuffix(county.name));
+		if (countyBase === target) return county.slug;
+	}
+	return undefined;
+}
+
+export type RaceElectionHrefs = {
+	positionHref?: string;
+	candidatesHref?: string;
+};
+
+/**
+ * Resolves canonical elections position and candidates listing paths for a race slug.
+ * Expands city/town 3-part slugs to 4-level URLs when county can be resolved.
+ */
+export async function resolveRaceElectionHrefs(
+	raceSlug: string | undefined,
+	positionLevel?: string,
+): Promise<RaceElectionHrefs> {
+	if (!raceSlug) return {};
+
+	const raceEntry = { slug: raceSlug, positionLevel };
+	const parts = raceSlug.split('/').filter(Boolean);
+	const prefixParts = parts.slice(0, -1);
+	const level = (positionLevel ?? '').toUpperCase();
+	const mightNeedCountyExpansion =
+		prefixParts.length === 2 && (level === '' || level === 'CITY' || level === 'LOCAL');
+
+	if (!mightNeedCountyExpansion) {
+		const positionHref = buildElectionPositionHrefFromRaceSlug(raceEntry);
+		return {
+			positionHref,
+			candidatesHref: buildRaceCandidatesHref(raceEntry),
+		};
+	}
+
+	const fullRace = await getRaceBySlug(raceSlug);
+	const effectiveLevel = (positionLevel ?? fullRace?.positionLevel ?? '').toUpperCase();
+	if (effectiveLevel !== 'CITY' && effectiveLevel !== 'LOCAL') {
+		const positionHref = buildElectionPositionHrefFromRaceSlug({
+			slug: raceSlug,
+			positionLevel: effectiveLevel,
+		});
+		return {
+			positionHref,
+			candidatesHref: positionHref ? `${positionHref}/candidates` : undefined,
+		};
+	}
+
+	if (!isCityOrTownMtfcc(fullRace?.Place?.mtfcc)) {
+		const positionHref = buildElectionPositionHrefFromRaceSlug({
+			slug: raceSlug,
+			positionLevel: effectiveLevel,
+		});
+		return {
+			positionHref,
+			candidatesHref: positionHref ? `${positionHref}/candidates` : undefined,
+		};
+	}
+
+	const countyName = fullRace?.Place?.countyName;
+	const state = fullRace?.state ?? prefixParts[0]?.toUpperCase();
+	if (!countyName || !state) {
+		const positionHref = buildElectionPositionHrefFromRaceSlug({
+			slug: raceSlug,
+			positionLevel: effectiveLevel,
+		});
+		return {
+			positionHref,
+			candidatesHref: positionHref ? `${positionHref}/candidates` : undefined,
+		};
+	}
+
+	const countySlug = await resolveCountySlugForPlace(state, countyName);
+	if (!countySlug) {
+		const positionHref = buildElectionPositionHrefFromRaceSlug({
+			slug: raceSlug,
+			positionLevel: effectiveLevel,
+		});
+		return {
+			positionHref,
+			candidatesHref: positionHref ? `${positionHref}/candidates` : undefined,
+		};
+	}
+
+	const citySlugToCountySlug = new Map([[prefixParts.join('/'), countySlug]]);
+	const expandedRace = { slug: raceSlug, positionLevel: effectiveLevel };
+	return {
+		positionHref: buildElectionPositionHrefFromRaceSlug(expandedRace, { citySlugToCountySlug }),
+		candidatesHref: buildRaceCandidatesHref(expandedRace, { citySlugToCountySlug }),
+	};
 }

--- a/src/lib/electionsHelpers.test.ts
+++ b/src/lib/electionsHelpers.test.ts
@@ -1,16 +1,21 @@
+/// <reference types="bun-types" />
 import { describe, expect, test } from 'bun:test';
 import {
 	buildFAQSchema,
 	buildJobPostingSchema,
+	buildRacePositionHref,
 	buildRaceSlug,
 	canonicalizeCountyEquivalentName,
 	findCityForDistrictName,
 	formatElectionDateFromApi,
 	formatFilingPeriodFromRace,
+	formatSidebarLinkLabel,
+	formatTermLength,
 	getCountySuffixLabel,
 	getStateName,
 	getYearFromDateString,
 	hasSuspiciousFactsMatch,
+	inferSidebarLinkIcon,
 	isCityOrTownMtfcc,
 	placeToFactsCards,
 	resolveLocalityName,
@@ -258,6 +263,14 @@ describe('formatElectionDateFromApi', () => {
 		expect(result).toMatch(/November/);
 		expect(result).toMatch(/2026/);
 	});
+
+	test('throws for invalid calendar date that matches date-only pattern', () => {
+		expect(() => formatElectionDateFromApi('2026-02-30')).toThrow('Invalid date-only string');
+	});
+
+	test('throws for invalid month in date-only string', () => {
+		expect(() => formatElectionDateFromApi('2026-13-01')).toThrow('Invalid date-only string');
+	});
 });
 
 describe('getYearFromDateString', () => {
@@ -498,7 +511,7 @@ describe('buildJobPostingSchema', () => {
 			...jobPostingBaseParams,
 		});
 		expect(schema).not.toBeNull();
-		expect((schema as Record<string, unknown>).datePosted).toBe('2026-01-15');
+		expect((schema as Record<string, unknown>)['datePosted']).toBe('2026-01-15');
 	});
 
 	test('includes datePosted from electionDate when filing start missing', () => {
@@ -507,7 +520,7 @@ describe('buildJobPostingSchema', () => {
 			...jobPostingBaseParams,
 		});
 		expect(schema).not.toBeNull();
-		expect((schema as Record<string, unknown>).datePosted).toBe('2026-11-03');
+		expect((schema as Record<string, unknown>)['datePosted']).toBe('2026-11-03');
 	});
 
 	test('filingDateStart takes precedence over electionDate', () => {
@@ -518,7 +531,7 @@ describe('buildJobPostingSchema', () => {
 			}),
 			...jobPostingBaseParams,
 		});
-		expect((schema as Record<string, unknown>).datePosted).toBe('2026-01-01');
+		expect((schema as Record<string, unknown>)['datePosted']).toBe('2026-01-01');
 	});
 
 	test('sets validThrough from filingDateEnd', () => {
@@ -529,7 +542,7 @@ describe('buildJobPostingSchema', () => {
 			}),
 			...jobPostingBaseParams,
 		});
-		expect((schema as Record<string, unknown>).validThrough).toBe('2026-02-01');
+		expect((schema as Record<string, unknown>)['validThrough']).toBe('2026-02-01');
 	});
 
 	test('validThrough falls back to electionDate when filingDateEnd missing', () => {
@@ -563,7 +576,7 @@ describe('buildJobPostingSchema', () => {
 			}),
 			...jobPostingBaseParams,
 		}) as Record<string, unknown>;
-		const addr = ((schema['jobLocation'] as Record<string, unknown>).address as Record<string, unknown>);
+		const addr = (schema['jobLocation'] as Record<string, unknown>)['address'] as Record<string, unknown>;
 		expect(addr['streetAddress']).toBe('123 Main St, Phoenix, AZ 85001');
 		expect(addr['postalCode']).toBe('85001');
 	});
@@ -576,7 +589,7 @@ describe('buildJobPostingSchema', () => {
 			}),
 			...jobPostingBaseParams,
 		}) as Record<string, unknown>;
-		const addr = ((schema['jobLocation'] as Record<string, unknown>).address as Record<string, unknown>);
+		const addr = (schema['jobLocation'] as Record<string, unknown>)['address'] as Record<string, unknown>;
 		expect(addr['postalCode']).toBe('20510-1234');
 	});
 
@@ -588,7 +601,7 @@ describe('buildJobPostingSchema', () => {
 			}),
 			...jobPostingBaseParams,
 		}) as Record<string, unknown>;
-		const addr = ((schema['jobLocation'] as Record<string, unknown>).address as Record<string, unknown>);
+		const addr = (schema['jobLocation'] as Record<string, unknown>)['address'] as Record<string, unknown>;
 		expect(addr['streetAddress']).toBe('Capitol Building, Phoenix, AZ');
 		expect(addr['postalCode']).toBeUndefined();
 	});
@@ -598,7 +611,7 @@ describe('buildJobPostingSchema', () => {
 			race: minimalRace({ filingDateStart: '2026-01-01' }),
 			...jobPostingBaseParams,
 		}) as Record<string, unknown>;
-		const addr = ((schema['jobLocation'] as Record<string, unknown>).address as Record<string, unknown>);
+		const addr = (schema['jobLocation'] as Record<string, unknown>)['address'] as Record<string, unknown>;
 		expect(addr['streetAddress']).toBeUndefined();
 		expect(addr['postalCode']).toBeUndefined();
 	});
@@ -626,7 +639,7 @@ describe('buildJobPostingSchema', () => {
 			stateName: '',
 			pageUrl: 'https://example.com/elections',
 		}) as Record<string, unknown>;
-		const addr = ((schema['jobLocation'] as Record<string, unknown>).address as Record<string, unknown>);
+		const addr = (schema['jobLocation'] as Record<string, unknown>)['address'] as Record<string, unknown>;
 		expect(addr['addressLocality']).toBe('Yuma County');
 	});
 
@@ -635,10 +648,10 @@ describe('buildJobPostingSchema', () => {
 			race: minimalRace({ filingDateStart: '2026-01-01', salary: '$50,000' }),
 			...jobPostingBaseParams,
 		});
-		const baseSalary = (schema as Record<string, unknown>).baseSalary as Record<string, unknown>;
+		const baseSalary = (schema as Record<string, unknown>)['baseSalary'] as Record<string, unknown>;
 		expect(baseSalary['@type']).toBe('MonetaryAmount');
-		const value = baseSalary.value as Record<string, unknown>;
-		expect(value.value).toBe(50000);
+		const value = baseSalary['value'] as Record<string, unknown>;
+		expect(value['value']).toBe(50000);
 	});
 
 	test('parses salary range', () => {
@@ -646,9 +659,9 @@ describe('buildJobPostingSchema', () => {
 			race: minimalRace({ filingDateStart: '2026-01-01', salary: '$50,000 - $75,000' }),
 			...jobPostingBaseParams,
 		});
-		const value = ((schema as Record<string, unknown>).baseSalary as Record<string, unknown>).value as Record<string, unknown>;
-		expect(value.minValue).toBe(50000);
-		expect(value.maxValue).toBe(75000);
+		const value = ((schema as Record<string, unknown>)['baseSalary'] as Record<string, unknown>)['value'] as Record<string, unknown>;
+		expect(value['minValue']).toBe(50000);
+		expect(value['maxValue']).toBe(75000);
 	});
 
 	test('uses HOUR unit when hourly cues present', () => {
@@ -656,9 +669,9 @@ describe('buildJobPostingSchema', () => {
 			race: minimalRace({ filingDateStart: '2026-01-01', salary: '$25/hr' }),
 			...jobPostingBaseParams,
 		});
-		const value = ((schema as Record<string, unknown>).baseSalary as Record<string, unknown>).value as Record<string, unknown>;
-		expect(value.unitText).toBe('HOUR');
-		expect(value.value).toBe(25);
+		const value = ((schema as Record<string, unknown>)['baseSalary'] as Record<string, unknown>)['value'] as Record<string, unknown>;
+		expect(value['unitText']).toBe('HOUR');
+		expect(value['value']).toBe(25);
 	});
 
 	test('parses bare integer salary (no $ prefix)', () => {
@@ -666,9 +679,9 @@ describe('buildJobPostingSchema', () => {
 			race: minimalRace({ filingDateStart: '2026-01-01', salary: '147175' }),
 			...jobPostingBaseParams,
 		});
-		const value = ((schema as Record<string, unknown>).baseSalary as Record<string, unknown>).value as Record<string, unknown>;
-		expect(value.value).toBe(147175);
-		expect(value.unitText).toBe('YEAR');
+		const value = ((schema as Record<string, unknown>)['baseSalary'] as Record<string, unknown>)['value'] as Record<string, unknown>;
+		expect(value['value']).toBe(147175);
+		expect(value['unitText']).toBe('YEAR');
 	});
 
 	test('picks annual amount from mixed annual+per-diem string', () => {
@@ -676,9 +689,9 @@ describe('buildJobPostingSchema', () => {
 			race: minimalRace({ filingDateStart: '2026-01-01', salary: '$7,200/year + $221/day' }),
 			...jobPostingBaseParams,
 		});
-		const value = ((schema as Record<string, unknown>).baseSalary as Record<string, unknown>).value as Record<string, unknown>;
-		expect(value.value).toBe(7200);
-		expect(value.unitText).toBe('YEAR');
+		const value = ((schema as Record<string, unknown>)['baseSalary'] as Record<string, unknown>)['value'] as Record<string, unknown>;
+		expect(value['value']).toBe(7200);
+		expect(value['unitText']).toBe('YEAR');
 	});
 
 	test('extracts salary embedded in prose', () => {
@@ -686,9 +699,9 @@ describe('buildJobPostingSchema', () => {
 			race: minimalRace({ filingDateStart: '2026-01-01', salary: 'The base salary was $141,000/year in 2011 (NRS 223.050).' }),
 			...jobPostingBaseParams,
 		});
-		const value = ((schema as Record<string, unknown>).baseSalary as Record<string, unknown>).value as Record<string, unknown>;
-		expect(value.value).toBe(141000);
-		expect(value.unitText).toBe('YEAR');
+		const value = ((schema as Record<string, unknown>)['baseSalary'] as Record<string, unknown>)['value'] as Record<string, unknown>;
+		expect(value['value']).toBe(141000);
+		expect(value['unitText']).toBe('YEAR');
 	});
 
 	test('maps Full-Time employment to FULL_TIME', () => {
@@ -696,7 +709,7 @@ describe('buildJobPostingSchema', () => {
 			race: minimalRace({ filingDateStart: '2026-01-01', employmentType: 'Full-Time' }),
 			...jobPostingBaseParams,
 		});
-		expect((schema as Record<string, unknown>).employmentType).toBe('FULL_TIME');
+		expect((schema as Record<string, unknown>)['employmentType']).toBe('FULL_TIME');
 	});
 
 	test('maps unknown employment to OTHER', () => {
@@ -704,7 +717,7 @@ describe('buildJobPostingSchema', () => {
 			race: minimalRace({ filingDateStart: '2026-01-01', employmentType: 'Rotating shift' }),
 			...jobPostingBaseParams,
 		});
-		expect((schema as Record<string, unknown>).employmentType).toBe('OTHER');
+		expect((schema as Record<string, unknown>)['employmentType']).toBe('OTHER');
 	});
 
 	test('omits baseSalary when salary unparseable', () => {
@@ -712,7 +725,7 @@ describe('buildJobPostingSchema', () => {
 			race: minimalRace({ filingDateStart: '2026-01-01', salary: 'TBD' }),
 			...jobPostingBaseParams,
 		});
-		expect((schema as Record<string, unknown>).baseSalary).toBeUndefined();
+		expect((schema as Record<string, unknown>)['baseSalary']).toBeUndefined();
 	});
 
 	test('wraps fallback description in paragraph HTML', () => {
@@ -723,7 +736,7 @@ describe('buildJobPostingSchema', () => {
 			countyName: 'Maricopa County',
 			pageUrl: 'https://example.com/elections',
 		}) as Record<string, unknown>;
-		const desc = String(schema.description);
+		const desc = String(schema['description']);
 		expect(desc.startsWith('<p>')).toBe(true);
 		expect(desc.endsWith('</p>')).toBe(true);
 		expect(desc).toContain('elected public office');
@@ -737,7 +750,7 @@ describe('buildJobPostingSchema', () => {
 			}),
 			...jobPostingBaseParams,
 		}) as Record<string, unknown>;
-		expect(String(schema.description)).toContain('&lt;script&gt;');
+		expect(String(schema['description'])).toContain('&lt;script&gt;');
 	});
 
 	test('passes through API HTML starting with block tag', () => {
@@ -749,7 +762,7 @@ describe('buildJobPostingSchema', () => {
 			}),
 			...jobPostingBaseParams,
 		}) as Record<string, unknown>;
-		expect(schema.description).toBe(raw);
+		expect(schema['description']).toBe(raw);
 	});
 
 	test('strips script tags from API HTML', () => {
@@ -760,8 +773,8 @@ describe('buildJobPostingSchema', () => {
 			}),
 			...jobPostingBaseParams,
 		}) as Record<string, unknown>;
-		expect(String(schema.description)).not.toContain('<script>');
-		expect(String(schema.description)).toContain('<p>Safe</p>');
+		expect(String(schema['description'])).not.toContain('<script>');
+		expect(String(schema['description'])).toContain('<p>Safe</p>');
 	});
 
 	test('escapes ampersands in plain positionDescription', () => {
@@ -772,7 +785,57 @@ describe('buildJobPostingSchema', () => {
 			}),
 			...jobPostingBaseParams,
 		}) as Record<string, unknown>;
-		expect(String(schema.description)).toContain('&amp;');
+		expect(String(schema['description'])).toContain('&amp;');
+	});
+});
+
+describe('formatTermLength', () => {
+	test('formats multiple years', () => {
+		expect(formatTermLength([4])).toBe('4 Years');
+		expect(formatTermLength([5])).toBe('5 Years');
+	});
+
+	test('formats single year', () => {
+		expect(formatTermLength([1])).toBe('1 Year');
+	});
+
+	test('returns undefined for empty or invalid input', () => {
+		expect(formatTermLength([])).toBeUndefined();
+		expect(formatTermLength(undefined)).toBeUndefined();
+		expect(formatTermLength(['invalid'])).toBeUndefined();
+	});
+});
+
+describe('inferSidebarLinkIcon', () => {
+	test('infers icons from URL patterns', () => {
+		expect(inferSidebarLinkIcon('mailto:test@example.com')).toBe('mail');
+		expect(inferSidebarLinkIcon('https://www.linkedin.com/in/user')).toBe('linkedin');
+		expect(inferSidebarLinkIcon('https://facebook.com/page')).toBe('facebook');
+		expect(inferSidebarLinkIcon('https://example.com')).toBe('globe');
+	});
+});
+
+describe('formatSidebarLinkLabel', () => {
+	test('uses Website for first link', () => {
+		expect(formatSidebarLinkLabel('https://example.com', 0)).toBe('Website');
+	});
+
+	test('detects platform labels', () => {
+		expect(formatSidebarLinkLabel('https://www.linkedin.com/in/user', 1)).toBe('LinkedIn');
+		expect(formatSidebarLinkLabel('mailto:a@b.com', 1)).toBe('Email');
+	});
+});
+
+describe('buildRacePositionHref', () => {
+	test('builds position page path from race slug', () => {
+		expect(buildRacePositionHref('ok/tecumseh-public-schools/local-school-board')).toBe(
+			'/elections/ok/tecumseh-public-schools/position/local-school-board',
+		);
+	});
+
+	test('returns undefined for invalid slug', () => {
+		expect(buildRacePositionHref(undefined)).toBeUndefined();
+		expect(buildRacePositionHref('single-part')).toBeUndefined();
 	});
 });
 

--- a/src/lib/electionsHelpers.test.ts
+++ b/src/lib/electionsHelpers.test.ts
@@ -1,8 +1,10 @@
 /// <reference types="bun-types" />
 import { describe, expect, test } from 'bun:test';
 import {
+	buildElectionPositionHrefFromRaceSlug,
 	buildFAQSchema,
 	buildJobPostingSchema,
+	buildRaceCandidatesHref,
 	buildRacePositionHref,
 	buildRaceSlug,
 	canonicalizeCountyEquivalentName,
@@ -915,6 +917,81 @@ describe('buildRacePositionHref', () => {
 	test('returns undefined for invalid slug', () => {
 		expect(buildRacePositionHref(undefined)).toBeUndefined();
 		expect(buildRacePositionHref('single-part')).toBeUndefined();
+	});
+});
+
+describe('buildElectionPositionHrefFromRaceSlug', () => {
+	const citySlugToCountySlug = new Map([
+		['mi/northville', 'mi/wayne-county'],
+		['az/buckeye', 'az/maricopa-county'],
+	]);
+
+	test('expands CITY 3-part slug with county mapping', () => {
+		expect(
+			buildElectionPositionHrefFromRaceSlug(
+				{ slug: 'mi/northville/city-legislature', positionLevel: 'CITY' },
+				{ citySlugToCountySlug },
+			),
+		).toBe('/elections/mi/wayne-county/northville/position/city-legislature');
+	});
+
+	test('keeps LOCAL school district at generic 3-level path without county mapping', () => {
+		expect(
+			buildElectionPositionHrefFromRaceSlug(
+				{ slug: 'ok/tecumseh-public-schools/local-school-board', positionLevel: 'LOCAL' },
+				{ citySlugToCountySlug },
+			),
+		).toBe('/elections/ok/tecumseh-public-schools/position/local-school-board');
+	});
+
+	test('builds STATE-level path', () => {
+		expect(
+			buildElectionPositionHrefFromRaceSlug({ slug: 'az/governor', positionLevel: 'STATE' }),
+		).toBe('/elections/az/position/governor');
+	});
+
+	test('builds 4-part WI city path from prefix', () => {
+		expect(
+			buildElectionPositionHrefFromRaceSlug(
+				{ slug: 'wi/adams-county/adams-town/city-clerk', positionLevel: 'CITY' },
+				{ citySlugToCountySlug },
+			),
+		).toBe('/elections/wi/adams-county/adams-town/position/city-clerk');
+	});
+
+	test('skips unmapped CITY 3-part slug when skipUnmappedCity is true', () => {
+		expect(
+			buildElectionPositionHrefFromRaceSlug(
+				{ slug: 'az/unknown-city/clerk', positionLevel: 'CITY' },
+				{ citySlugToCountySlug, skipUnmappedCity: true },
+			),
+		).toBeUndefined();
+	});
+
+	test('falls back to generic path for unmapped CITY when skipUnmappedCity is false', () => {
+		expect(
+			buildElectionPositionHrefFromRaceSlug(
+				{ slug: 'az/unknown-city/clerk', positionLevel: 'CITY' },
+				{ citySlugToCountySlug },
+			),
+		).toBe('/elections/az/unknown-city/position/clerk');
+	});
+});
+
+describe('buildRaceCandidatesHref', () => {
+	const citySlugToCountySlug = new Map([['mi/northville', 'mi/wayne-county']]);
+
+	test('appends /candidates to position path', () => {
+		expect(
+			buildRaceCandidatesHref(
+				{ slug: 'mi/northville/city-legislature', positionLevel: 'CITY' },
+				{ citySlugToCountySlug },
+			),
+		).toBe('/elections/mi/wayne-county/northville/position/city-legislature/candidates');
+	});
+
+	test('returns undefined for invalid slug', () => {
+		expect(buildRaceCandidatesHref({ slug: undefined })).toBeUndefined();
 	});
 });
 

--- a/src/lib/electionsHelpers.test.ts
+++ b/src/lib/electionsHelpers.test.ts
@@ -11,6 +11,9 @@ import {
 	formatFilingPeriodFromRace,
 	formatSidebarLinkLabel,
 	formatTermLength,
+	linkHrefAlreadyPresent,
+	normalizeLinkHrefForCompare,
+	prependClaimedWebsiteIfNew,
 	getCountySuffixLabel,
 	getStateName,
 	getYearFromDateString,
@@ -823,6 +826,82 @@ describe('formatSidebarLinkLabel', () => {
 	test('detects platform labels', () => {
 		expect(formatSidebarLinkLabel('https://www.linkedin.com/in/user', 1)).toBe('LinkedIn');
 		expect(formatSidebarLinkLabel('mailto:a@b.com', 1)).toBe('Email');
+	});
+});
+
+describe('normalizeLinkHrefForCompare', () => {
+	test('treats www and trailing slash as equivalent', () => {
+		expect(normalizeLinkHrefForCompare('https://same.com')).toBe(
+			normalizeLinkHrefForCompare('https://www.same.com/'),
+		);
+	});
+
+	test('normalizes mailto case-insensitively', () => {
+		expect(normalizeLinkHrefForCompare('mailto:Test@Example.com')).toBe(
+			normalizeLinkHrefForCompare('mailto:test@example.com'),
+		);
+	});
+});
+
+describe('prependClaimedWebsiteIfNew', () => {
+	test('prepends when candidate has different first URL labeled Website', () => {
+		const links = [
+			{
+				label: 'Website',
+				icon: 'globe',
+				href: 'https://old-campaign.com',
+			},
+		];
+		const result = prependClaimedWebsiteIfNew(links, 'https://new-campaign.com');
+		expect(result).toHaveLength(2);
+		expect(result[0]?.href).toBe('https://new-campaign.com');
+		expect(result[0]?.label).toBe('Website');
+		expect(result[1]?.href).toBe('https://old-campaign.com');
+	});
+
+	test('does not duplicate when claimed URL matches existing link (www variant)', () => {
+		const links = [
+			{
+				label: 'Website',
+				icon: 'globe',
+				href: 'https://same.com',
+			},
+		];
+		const result = prependClaimedWebsiteIfNew(links, 'https://www.same.com/');
+		expect(result).toHaveLength(1);
+		expect(result[0]?.href).toBe('https://same.com');
+	});
+
+	test('prepends when first candidate URL is not the claimed website', () => {
+		const links = [
+			{
+				label: 'Website',
+				icon: 'linkedin',
+				href: 'https://www.linkedin.com/in/jane',
+			},
+		];
+		const result = prependClaimedWebsiteIfNew(links, 'https://janeforoffice.com');
+		expect(result).toHaveLength(2);
+		expect(result[0]?.href).toBe('https://janeforoffice.com');
+		expect(result[1]?.label).toBe('Website');
+	});
+
+	test('adds claimed website when links array is empty', () => {
+		const result = prependClaimedWebsiteIfNew([], 'https://campaign.com');
+		expect(result).toHaveLength(1);
+		expect(result[0]).toEqual({
+			label: 'Website',
+			icon: 'globe',
+			href: 'https://campaign.com',
+		});
+	});
+});
+
+describe('linkHrefAlreadyPresent', () => {
+	test('returns false when href is not in links', () => {
+		expect(
+			linkHrefAlreadyPresent([{ href: 'https://example.com' }], 'https://other.com'),
+		).toBe(false);
 	});
 });
 

--- a/src/lib/electionsHelpers.ts
+++ b/src/lib/electionsHelpers.ts
@@ -128,8 +128,27 @@ const DATE_ONLY_REGEX = /^\d{4}-\d{2}-\d{2}$/;
  * Parses an ISO date-only string (YYYY-MM-DD) as local date to avoid UTC midnight shifting the day in western time zones.
  */
 function parseDateOnlyAsLocal(dateOnly: string): Date {
-	const [y, m, d] = dateOnly.split('-').map(Number);
-	return new Date(y, m - 1, d);
+	if (!DATE_ONLY_REGEX.test(dateOnly)) {
+		throw new Error(`Invalid date-only string: ${dateOnly}`);
+	}
+	const parts = dateOnly.split('-').map(Number);
+	const y = parts[0];
+	const m = parts[1];
+	const d = parts[2];
+	if (y === undefined || m === undefined || d === undefined) {
+		throw new Error(`Invalid date-only string: ${dateOnly}`);
+	}
+	if (!Number.isInteger(y) || !Number.isInteger(m) || !Number.isInteger(d)) {
+		throw new Error(`Invalid date-only string: ${dateOnly}`);
+	}
+	if (m < 1 || m > 12 || d < 1 || d > 31) {
+		throw new Error(`Invalid date-only string: ${dateOnly}`);
+	}
+	const date = new Date(y, m - 1, d);
+	if (date.getFullYear() !== y || date.getMonth() !== m - 1 || date.getDate() !== d) {
+		throw new Error(`Invalid date-only string: ${dateOnly}`);
+	}
+	return date;
 }
 
 const LOCALE_DATE_OPTIONS: Intl.DateTimeFormatOptions = {
@@ -222,7 +241,9 @@ export function findCityForDistrictName(
 	if (matching.length === 0) return null;
 	// Prefer longest base name match (e.g. "quincy township" over "quincy")
 	matching.sort((a, b) => b.baseName.length - a.baseName.length);
-	return { name: matching[0].name, slug: matching[0].slug };
+	const best = matching[0];
+	if (!best) return null;
+	return { name: best.name, slug: best.slug };
 }
 
 export function buildRaceSlug(
@@ -406,10 +427,10 @@ function parseSalaryString(salary: string): object | null {
 	function makeResult(unitText: 'HOUR' | 'YEAR', amounts: number[]): object {
 		const value: Record<string, unknown> = { '@type': 'QuantitativeValue', unitText };
 		if (amounts.length === 1) {
-			value.value = amounts[0];
+			value['value'] = amounts[0];
 		} else {
-			value.minValue = Math.min(...amounts);
-			value.maxValue = Math.max(...amounts);
+			value['minValue'] = Math.min(...amounts);
+			value['maxValue'] = Math.max(...amounts);
 		}
 		return { '@type': 'MonetaryAmount', currency: 'USD', value };
 	}
@@ -512,10 +533,10 @@ export function buildJobPostingSchema(params: {
 
 	const filingAddr = race.filingOfficeAddress?.trim();
 	if (filingAddr) {
-		postalAddress.streetAddress = filingAddr;
+		postalAddress['streetAddress'] = filingAddr;
 		const zipMatch = filingAddr.match(/\b\d{5}(?:-\d{4})?\b/);
 		if (zipMatch?.[0]) {
-			postalAddress.postalCode = zipMatch[0];
+			postalAddress['postalCode'] = zipMatch[0];
 		}
 	}
 
@@ -539,17 +560,17 @@ export function buildJobPostingSchema(params: {
 
 	const validThrough = race.filingDateEnd?.slice(0, 10) || race.electionDate?.slice(0, 10);
 	if (validThrough) {
-		schema.validThrough = validThrough;
+		schema['validThrough'] = validThrough;
 	}
 
-	schema.employmentType = race.employmentType
+	schema['employmentType'] = race.employmentType
 		? mapPositionEmploymentType(race.employmentType)
 		: 'FULL_TIME';
 
 	if (race.salary) {
 		const baseSalary = parseSalaryString(race.salary);
 		if (baseSalary) {
-			schema.baseSalary = baseSalary;
+			schema['baseSalary'] = baseSalary;
 		}
 	}
 
@@ -671,4 +692,52 @@ export function buildDynamicFAQItems(
 	}
 
 	return items;
+}
+
+/** Formats election frequency years for profile sidebar (e.g. [4] → "4 Years"). */
+export function formatTermLength(
+	frequency: Array<number | string> | undefined | null,
+): string | undefined {
+	if (!frequency?.length) return undefined;
+	const years = Number(frequency[0]);
+	if (!Number.isFinite(years) || years <= 0) return undefined;
+	return years === 1 ? '1 Year' : `${years} Years`;
+}
+
+/** Infers Lucide icon name for elections sidebar links from URL. */
+export function inferSidebarLinkIcon(href: string): string {
+	const lower = href.toLowerCase();
+	if (lower.startsWith('mailto:')) return 'mail';
+	if (lower.includes('linkedin.com')) return 'linkedin';
+	if (lower.includes('facebook.com') || lower.includes('fb.com')) return 'facebook';
+	if (lower.includes('twitter.com') || lower.includes('x.com')) return 'twitter';
+	if (lower.includes('instagram.com')) return 'instagram';
+	return 'globe';
+}
+
+/** Human-readable label for a candidate profile link (first URL is always Website). */
+export function formatSidebarLinkLabel(href: string, index: number): string {
+	if (index === 0) return 'Website';
+	const lower = href.toLowerCase();
+	if (lower.startsWith('mailto:')) return 'Email';
+	if (lower.includes('linkedin.com')) return 'LinkedIn';
+	if (lower.includes('facebook.com') || lower.includes('fb.com')) return 'Facebook';
+	if (lower.includes('twitter.com') || lower.includes('x.com')) return 'Twitter';
+	if (lower.includes('instagram.com')) return 'Instagram';
+	try {
+		const url = new URL(href.startsWith('http') ? href : `https://${href}`);
+		const host = url.hostname.replace(/^www\./, '');
+		return host.charAt(0).toUpperCase() + host.slice(1);
+	} catch {
+		return `Link ${index + 1}`;
+	}
+}
+
+/** Builds elections position page path from a race slug (e.g. ok/foo/local-school-board). */
+export function buildRacePositionHref(raceSlug: string | undefined): string | undefined {
+	if (!raceSlug) return undefined;
+	const parts = raceSlug.split('/').filter(Boolean);
+	const positionSlug = parts.pop();
+	if (!positionSlug || parts.length === 0) return undefined;
+	return `/elections/${parts.join('/')}/position/${positionSlug}`;
 }

--- a/src/lib/electionsHelpers.ts
+++ b/src/lib/electionsHelpers.ts
@@ -784,11 +784,56 @@ export function prependClaimedWebsiteIfNew(
 	];
 }
 
-/** Builds elections position page path from a race slug (e.g. ok/foo/local-school-board). */
-export function buildRacePositionHref(raceSlug: string | undefined): string | undefined {
-	if (!raceSlug) return undefined;
-	const parts = raceSlug.split('/').filter(Boolean);
+export type RaceSlugEntry = { slug?: string; positionLevel?: string };
+
+export type BuildElectionPositionHrefOptions = {
+	citySlugToCountySlug?: Map<string, string>;
+	/** When true, omit CITY 3-part slugs with no county mapping (sitemap behavior). */
+	skipUnmappedCity?: boolean;
+};
+
+/**
+ * Builds elections position page path from a race slug and optional county lookup.
+ * Mirrors buildRaceEntries URL rules in sitemap-entries.ts.
+ */
+export function buildElectionPositionHrefFromRaceSlug(
+	race: RaceSlugEntry,
+	options?: BuildElectionPositionHrefOptions,
+): string | undefined {
+	if (!race.slug) return undefined;
+	const parts = race.slug.split('/').filter(Boolean);
 	const positionSlug = parts.pop();
 	if (!positionSlug || parts.length === 0) return undefined;
-	return `/elections/${parts.join('/')}/position/${positionSlug}`;
+
+	const level = (race.positionLevel ?? '').toUpperCase();
+
+	if (level === 'CITY' || level === 'LOCAL') {
+		const citySlug = parts.join('/');
+		const countySlug = options?.citySlugToCountySlug?.get(citySlug);
+		if (countySlug) {
+			const citySegment = parts.pop();
+			if (!citySegment) return undefined;
+			return `/elections/${countySlug}/${citySegment}/position/${positionSlug}`;
+		}
+		if (level === 'CITY' && parts.length === 2 && options?.skipUnmappedCity) {
+			return undefined;
+		}
+	}
+
+	const prefix = parts.join('/');
+	return `/elections/${prefix}/position/${positionSlug}`;
+}
+
+/** Builds elections position page path from a race slug (e.g. ok/foo/local-school-board). */
+export function buildRacePositionHref(raceSlug: string | undefined): string | undefined {
+	return buildElectionPositionHrefFromRaceSlug({ slug: raceSlug });
+}
+
+/** Builds elections candidates listing path from a race slug entry. */
+export function buildRaceCandidatesHref(
+	race: RaceSlugEntry,
+	options?: BuildElectionPositionHrefOptions,
+): string | undefined {
+	const positionHref = buildElectionPositionHrefFromRaceSlug(race, options);
+	return positionHref ? `${positionHref}/candidates` : undefined;
 }

--- a/src/lib/electionsHelpers.ts
+++ b/src/lib/electionsHelpers.ts
@@ -733,6 +733,57 @@ export function formatSidebarLinkLabel(href: string, index: number): string {
 	}
 }
 
+export type SidebarLink = { label: string; icon: string; href: string };
+
+export type SidebarLinkInput = { label: string; href: string; icon?: string };
+
+/** Normalize URLs for dedup (scheme, www, trailing slash). mailto: compared case-insensitively. */
+export function normalizeLinkHrefForCompare(href: string): string {
+	const trimmed = href.trim();
+	const lower = trimmed.toLowerCase();
+	if (lower.startsWith('mailto:')) {
+		return lower;
+	}
+	try {
+		const url = new URL(trimmed.startsWith('http') ? trimmed : `https://${trimmed}`);
+		const host = url.hostname.replace(/^www\./i, '').toLowerCase();
+		const path = url.pathname.replace(/\/$/, '') || '';
+		return `${host}${path}`;
+	} catch {
+		return lower;
+	}
+}
+
+export function linkHrefAlreadyPresent(
+	links: ReadonlyArray<{ href: string }>,
+	href: string,
+): boolean {
+	const target = normalizeLinkHrefForCompare(href);
+	return links.some((l) => normalizeLinkHrefForCompare(l.href) === target);
+}
+
+/** Prepends claimed campaign website when not already present (by href, not label). */
+export function prependClaimedWebsiteIfNew(
+	links: SidebarLinkInput[],
+	claimedWebsite: string,
+): SidebarLink[] {
+	const normalized = links.map((link) => ({
+		...link,
+		icon: link.icon ?? inferSidebarLinkIcon(link.href),
+	}));
+	if (linkHrefAlreadyPresent(normalized, claimedWebsite)) {
+		return normalized;
+	}
+	return [
+		{
+			label: 'Website',
+			icon: inferSidebarLinkIcon(claimedWebsite),
+			href: claimedWebsite,
+		},
+		...normalized,
+	];
+}
+
 /** Builds elections position page path from a race slug (e.g. ok/foo/local-school-board). */
 export function buildRacePositionHref(raceSlug: string | undefined): string | undefined {
 	if (!raceSlug) return undefined;

--- a/src/lib/schema.test.ts
+++ b/src/lib/schema.test.ts
@@ -167,6 +167,19 @@ describe('buildBreadcrumbSchema', () => {
 		expect(items[1]?.['position']).toBe(2);
 		expect('item' in (items[1] ?? {})).toBe(false);
 	});
+
+	test('omitted href on current crumb omits item field', () => {
+		const schema = asRecord(
+			buildBreadcrumbSchema([
+				{ href: '/candidates', label: 'Candidates' },
+				{ label: 'Jane Doe' },
+			]),
+		);
+		const items = schema['itemListElement'] as Array<Record<string, unknown>>;
+		expect(items[0]?.['item']).toBe('https://goodparty.org/candidates');
+		expect(items[1]?.['name']).toBe('Jane Doe');
+		expect('item' in (items[1] ?? {})).toBe(false);
+	});
 });
 
 describe('buildFAQSchema', () => {

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -1,4 +1,7 @@
 import { getBaseUrl, toAbsoluteUrl, DEFAULT_SHARE_IMAGE } from './url';
+import type { BreadcrumbItem } from '~/ui/BreadcrumbBlock';
+
+export type { BreadcrumbItem };
 
 const ORGANIZATION_ID_FRAGMENT = '#organization';
 const WEBSITE_ID_FRAGMENT = '#website';
@@ -195,8 +198,6 @@ export function buildArticleSchema(params: ArticleSchemaParams): object {
 
 	return schema;
 }
-
-export type BreadcrumbItem = { href: string; label: string };
 
 /**
  * Schema.org BreadcrumbList built from breadcrumb items. Items without an `href`

--- a/src/lib/sitemap-entries.ts
+++ b/src/lib/sitemap-entries.ts
@@ -5,7 +5,10 @@
 
 import type { MetadataRoute } from 'next';
 import { sanityClient } from '~/sanity/sanityClient';
-import { stripCountySuffix as stripCountySuffixFromHelpers } from '~/lib/electionsHelpers';
+import {
+	buildElectionPositionHrefFromRaceSlug,
+	stripCountySuffix as stripCountySuffixFromHelpers,
+} from '~/lib/electionsHelpers';
 
 /** 51 US state/DC codes (50 states + DC) */
 export const US_STATE_CODES = [
@@ -109,33 +112,12 @@ export function buildRaceEntries(
 ): MetadataRoute.Sitemap {
 	const out: MetadataRoute.Sitemap = [];
 	for (const r of races) {
-		if (!r.slug) continue;
-		const parts = r.slug.split('/');
-		const positionSlug = parts.pop();
-		if (!positionSlug) continue;
-
-		const level = (r.positionLevel ?? '').toUpperCase();
-
-		if (level === 'CITY' || level === 'LOCAL') {
-			const citySlug = parts.join('/');
-			const countySlug = citySlugToCountySlug.get(citySlug);
-			if (countySlug) {
-				// 3-part city slug with a known county mapping → expand to 4-level URL
-				const citySegment = parts.pop();
-				if (!citySegment) continue;
-				out.push(
-					toEntry(baseUrl, `/elections/${countySlug}/${citySegment}/position/${positionSlug}`, 0.7, 'weekly'),
-				);
-				continue;
-			}
-			// CITY 3-part slug with no county mapping would produce a bad URL (city treated
-			// as county). Skip it. 4-part slugs (parts.length === 3) already carry the county
-			// and fall through to emit the correct URL from the prefix.
-			if (level === 'CITY' && parts.length === 2) continue;
-		}
-
-		const prefix = parts.join('/');
-		out.push(toEntry(baseUrl, `/elections/${prefix}/position/${positionSlug}`, 0.7, 'weekly'));
+		const path = buildElectionPositionHrefFromRaceSlug(r, {
+			citySlugToCountySlug,
+			skipUnmappedCity: true,
+		});
+		if (!path) continue;
+		out.push(toEntry(baseUrl, path, 0.7, 'weekly'));
 	}
 	return out;
 }

--- a/src/types/elections.ts
+++ b/src/types/elections.ts
@@ -47,14 +47,18 @@ export interface CandidacyItem {
 	about?: string;
 	email?: string;
 	urls?: string[];
+	positionDescription?: string;
+	electionFrequency?: number[];
 	Stances?: Array<{
 		Issue?: { name?: string };
 		stanceStatement?: string;
 	}>;
 	Race?: {
 		brHashId: string;
+		slug?: string;
 		electionDate?: string;
-		[key: string]: unknown;
+		positionDescription?: string;
+		frequency?: number[];
 	};
 }
 

--- a/src/types/elections.ts
+++ b/src/types/elections.ts
@@ -56,6 +56,7 @@ export interface CandidacyItem {
 	Race?: {
 		brHashId: string;
 		slug?: string;
+		positionLevel?: string;
 		electionDate?: string;
 		positionDescription?: string;
 		frequency?: number[];

--- a/src/ui/BlogArticleHero.tsx
+++ b/src/ui/BlogArticleHero.tsx
@@ -6,6 +6,7 @@ import { Media } from './Media';
 import { Tagline } from './Tagline';
 import { Text } from './Text';
 import { Breadcrumbs } from './Breadcrumbs';
+import type { BreadcrumbItem } from './BreadcrumbBlock';
 
 interface BlogArticleHeroProps {
 	title?: string;
@@ -15,7 +16,7 @@ interface BlogArticleHeroProps {
 		href?: string;
 	};
 	image?: SanityImage;
-	breadcrumbs?: { href: string; label: string }[];
+	breadcrumbs?: BreadcrumbItem[];
 }
 
 export const BlogArticleHero = (props: BlogArticleHeroProps) => {

--- a/src/ui/BreadcrumbBlock.stories.tsx
+++ b/src/ui/BreadcrumbBlock.stories.tsx
@@ -85,3 +85,14 @@ export const LongBreadcrumb: Story = {
 		},
 	},
 };
+
+export const CurrentPageWithoutHref: Story = {
+	args: {
+		backgroundColor: 'midnight',
+		breadcrumbs: [
+			{ href: '/', label: 'Home' },
+			{ href: '/candidates', label: 'Candidates' },
+			{ label: 'Jane Doe' },
+		],
+	},
+};

--- a/src/ui/BreadcrumbBlock.tsx
+++ b/src/ui/BreadcrumbBlock.tsx
@@ -1,4 +1,3 @@
-import type { backgroundTypeValues } from './_lib/designTypesStore';
 import { cn, tv } from './_lib/utils';
 import { Breadcrumbs } from './Breadcrumbs';
 import { Container } from './Container';
@@ -20,13 +19,16 @@ const styles = tv({
 });
 
 export type BreadcrumbItem = {
-	href: string;
+	id?: string;
+	href?: string;
 	label: string;
 };
 
+export type BreadcrumbBackgroundColor = 'cream' | 'midnight';
+
 export type BreadcrumbBlockProps = {
 	className?: string;
-	backgroundColor?: (typeof backgroundTypeValues)[number];
+	backgroundColor?: BreadcrumbBackgroundColor;
 	breadcrumbs: BreadcrumbItem[];
 };
 

--- a/src/ui/Breadcrumbs.test.ts
+++ b/src/ui/Breadcrumbs.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from 'bun:test';
+import { getBreadcrumbItemKey, shouldRenderBreadcrumbLink } from './Breadcrumbs';
+
+describe('shouldRenderBreadcrumbLink', () => {
+	const crumbs = [
+		{ href: '/', label: 'Home' },
+		{ href: '/candidates', label: 'Candidates' },
+		{ label: 'Jane Doe' },
+	];
+
+	test('last item without href is not a link', () => {
+		expect(shouldRenderBreadcrumbLink(crumbs[2]!, 2, crumbs.length)).toBe(false);
+	});
+
+	test('middle item without href is not a link', () => {
+		expect(shouldRenderBreadcrumbLink({ label: 'Missing href' }, 1, 3)).toBe(false);
+	});
+
+	test('middle item with href is a link', () => {
+		expect(shouldRenderBreadcrumbLink(crumbs[1]!, 1, crumbs.length)).toBe(true);
+	});
+
+	test('empty string href is treated as non-link', () => {
+		expect(shouldRenderBreadcrumbLink({ href: '', label: 'Current' }, 1, 3)).toBe(false);
+	});
+});
+
+describe('getBreadcrumbItemKey', () => {
+	test('uses stable id when provided', () => {
+		expect(getBreadcrumbItemKey({ id: 'current-page', label: 'Jane Doe' }, 2)).toBe('current-page');
+	});
+
+	test('duplicate labels at different indices produce different keys', () => {
+		const keyA = getBreadcrumbItemKey({ href: '/a', label: 'Home' }, 0);
+		const keyB = getBreadcrumbItemKey({ href: '/b', label: 'Home' }, 1);
+		expect(keyA).not.toBe(keyB);
+	});
+
+	test('omitted href uses current segment in generated key', () => {
+		expect(getBreadcrumbItemKey({ label: 'Jane Doe' }, 2)).toBe('2-current-Jane Doe');
+	});
+});

--- a/src/ui/Breadcrumbs.tsx
+++ b/src/ui/Breadcrumbs.tsx
@@ -1,8 +1,8 @@
 import Link from 'next/link';
 import { Fragment } from 'react';
 
-import type { backgroundTypeValues } from './_lib/designTypesStore';
 import { cn, tv } from './_lib/utils';
+import type { BreadcrumbBackgroundColor, BreadcrumbItem } from './BreadcrumbBlock';
 import { IconResolver } from './IconResolver';
 
 const styles = tv({
@@ -30,9 +30,21 @@ const styles = tv({
 	},
 });
 
+export function shouldRenderBreadcrumbLink(
+	crumb: BreadcrumbItem,
+	index: number,
+	total: number,
+): boolean {
+	return index < total - 1 && Boolean(crumb.href);
+}
+
+export function getBreadcrumbItemKey(crumb: BreadcrumbItem, index: number): string {
+	return crumb.id ?? `${index}-${crumb.href ?? 'current'}-${crumb.label}`;
+}
+
 export const Breadcrumbs = (props: {
-	items?: { href: string; label: string }[];
-	backgroundColor?: (typeof backgroundTypeValues)[number];
+	items?: BreadcrumbItem[];
+	backgroundColor?: BreadcrumbBackgroundColor;
 }) => {
 	const crumbs = props.items ?? [];
 	const backgroundColor = props.backgroundColor ?? 'midnight';
@@ -40,18 +52,23 @@ export const Breadcrumbs = (props: {
 
 	return (
 		<nav className={nav()}>
-			{crumbs.map((crumb, i) => (
-				<Fragment key={crumb.href}>
-					{i > 0 && <IconResolver icon='chevron-right' className={separator()} />}
-					{i === crumbs.length - 1 ? (
-						<span className={current()}>{crumb.label}</span>
-					) : (
-						<Link href={crumb.href} className={cn(link())}>
-							{crumb.label}
-						</Link>
-					)}
-				</Fragment>
-			))}
+			{crumbs.map((crumb, i) => {
+				const isLast = i === crumbs.length - 1;
+				const showLink = shouldRenderBreadcrumbLink(crumb, i, crumbs.length);
+
+				return (
+					<Fragment key={getBreadcrumbItemKey(crumb, i)}>
+						{i > 0 && <IconResolver icon='chevron-right' className={separator()} />}
+						{showLink ? (
+							<Link href={crumb.href!} className={cn(link())}>
+								{crumb.label}
+							</Link>
+						) : (
+							<span className={isLast ? current() : undefined}>{crumb.label}</span>
+						)}
+					</Fragment>
+				);
+			})}
 		</nav>
 	);
 };

--- a/src/ui/ClaimProfileBlock.stories.tsx
+++ b/src/ui/ClaimProfileBlock.stories.tsx
@@ -14,8 +14,8 @@ type Story = StoryObj<typeof meta>;
 const exampleCard = {
 	name: 'Firstname Lastname',
 	partyAffiliation: 'City Council Member',
-	secondaryText: 'District 5',
-	showBadge: true,
+	href: '#',
+	isGoodPartyCandidate: true,
 };
 
 export const Default: Story = {
@@ -72,6 +72,21 @@ export const MinimalContent: Story = {
 		exampleCard: {
 			name: 'Jane Smith',
 			partyAffiliation: 'School Board Trustee',
+			href: '#',
+		},
+	},
+};
+
+export const BannerLayout: Story = {
+	args: {
+		layout: 'banner',
+		backgroundColor: 'cream',
+		headline: 'This profile is unclaimed',
+		body: 'Enhance your profile by signing up.',
+		claimButton: {
+			buttonType: 'internal',
+			href: 'https://app.goodparty.org/sign-up',
+			label: 'Join today',
 		},
 	},
 };

--- a/src/ui/ClaimProfileBlock.tsx
+++ b/src/ui/ClaimProfileBlock.tsx
@@ -12,38 +12,114 @@ const styles = tv({
 		content: 'flex flex-col lg:flex-row gap-8 items-center',
 		textSection: 'flex-1 flex flex-col gap-6',
 		cardSection: 'flex-1 w-full lg:w-auto',
+		bannerBase: 'w-full border-0 rounded-none py-5 md:py-6',
+		bannerContent: 'flex w-full flex-col gap-4 md:flex-row md:items-center md:justify-between md:gap-6',
+		bannerTextSection: 'min-w-0 flex-1 flex flex-col gap-2 md:gap-3',
 	},
 	variants: {
+		layout: {
+			card: {},
+			banner: {
+				base: '',
+			},
+		},
 		backgroundColor: {
 			midnight: {
 				base: 'bg-midnight-900 border-midnight-700',
 				textSection: 'text-white',
+				bannerTextSection: 'text-white',
 			},
 			cream: {
 				base: 'bg-goodparty-cream border-bright-yellow-600',
+				bannerBase: 'bg-goodparty-cream',
 			},
 			'bright-yellow': {
 				base: 'bg-bright-yellow-100 border-bright-yellow-600',
+				bannerBase: 'bg-bright-yellow-100',
 			},
 		},
 	},
+	compoundVariants: [
+		{
+			layout: 'banner',
+			backgroundColor: 'cream',
+			class: {
+				base: 'bg-goodparty-cream border-0',
+			},
+		},
+		{
+			layout: 'banner',
+			backgroundColor: 'midnight',
+			class: {
+				base: 'bg-midnight-900 border-0',
+			},
+		},
+		{
+			layout: 'banner',
+			backgroundColor: 'bright-yellow',
+			class: {
+				base: 'bg-bright-yellow-100 border-0',
+			},
+		},
+	],
 });
 
 export type ClaimProfileBlockProps = {
 	className?: string;
+	layout?: 'card' | 'banner';
 	backgroundColor?: (typeof backgroundTypeValues)[number] | 'bright-yellow';
 	headline?: string;
 	body?: ReactNode;
 	claimButton: ComponentButtonProps;
-	exampleCard: CandidatesCardProps;
+	exampleCard?: CandidatesCardProps;
 };
 
 export function ClaimProfileBlock(props: ClaimProfileBlockProps) {
+	const layout = props.layout ?? 'card';
 	const backgroundColor = props.backgroundColor ?? 'cream';
-	const { base, content, textSection, cardSection } = styles({ backgroundColor });
+	const { base, content, textSection, cardSection, bannerBase, bannerContent, bannerTextSection } = styles({
+		backgroundColor,
+		layout,
+	});
+
+	const claimButtonProps = {
+		...props.claimButton,
+		className: cn(layout === 'banner' ? 'w-fit shrink-0' : 'w-fit p-8', props.claimButton.className),
+		buttonProps: {
+			...props.claimButton.buttonProps,
+			styleSize: props.claimButton.buttonProps?.styleSize ?? 'sm',
+			styleType:
+				props.claimButton.buttonProps?.styleType ??
+				(backgroundColor === 'bright-yellow' ? 'secondary' : 'primary'),
+		},
+	};
+
+	if (layout === 'banner') {
+		return (
+			<article
+				className={cn(bannerBase(), props.className)}
+				data-component='ClaimProfileBlock'
+				data-layout='banner'
+			>
+				<Container size='xl'>
+					<div className={bannerContent()}>
+						<div className={bannerTextSection()}>
+							{props.headline && (
+								<Text as='h2' styleType='subtitle-1'>
+									{props.headline}
+								</Text>
+							)}
+							{props.body && <Text styleType='body-2'>{props.body}</Text>}
+						</div>
+						<ComponentButton {...claimButtonProps} />
+					</div>
+				</Container>
+			</article>
+		);
+	}
 
 	return (
-		<article className={cn(base(), props.className)} data-component='ClaimProfileBlock'>
+		<article className={cn(base(), props.className)} data-component='ClaimProfileBlock' data-layout='card'>
 			<Container size='xl' className='px-0!'>
 				<div className={content()}>
 					<div className={textSection()}>
@@ -53,21 +129,13 @@ export function ClaimProfileBlock(props: ClaimProfileBlockProps) {
 							</Text>
 						)}
 						{props.body && <Text styleType='body-1'>{props.body}</Text>}
-						<ComponentButton
-							{...props.claimButton}
-							className={cn('w-fit p-8', props.claimButton.className)}
-							buttonProps={{
-								...props.claimButton.buttonProps,
-								styleSize: props.claimButton.buttonProps?.styleSize ?? 'sm',
-								styleType:
-									props.claimButton.buttonProps?.styleType ??
-									(backgroundColor === 'bright-yellow' ? 'secondary' : 'primary'),
-							}}
-						/>
+						<ComponentButton {...claimButtonProps} />
 					</div>
-					<div className={cardSection()}>
-						<CandidatesCard {...props.exampleCard} />
-					</div>
+					{props.exampleCard && (
+						<div className={cardSection()}>
+							<CandidatesCard {...props.exampleCard} />
+						</div>
+					)}
 				</div>
 			</Container>
 		</article>

--- a/src/ui/ElectionsSidebar.tsx
+++ b/src/ui/ElectionsSidebar.tsx
@@ -6,17 +6,17 @@ import { Anchor } from './Anchor.tsx';
 
 const styles = tv({
 	slots: {
-		base: 'min-w-[400px] flex flex-col gap-6',
+		base: 'flex w-full min-w-0 flex-col gap-6',
 		card: 'flex flex-col gap-4 p-6 bg-white rounded-xl',
 		linkItem: 'flex items-start gap-3 py-3 border-b border-gray-200 last:border-b-0',
 		linkIcon: 'min-w-5 min-h-5 w-5 h-5 max-w-5 max-h-5 flex-shrink-0',
-		linkText: 'flex-1 flex flex-col gap-1',
+		linkText: 'flex min-w-0 flex-1 flex-col gap-1',
 		linkLabel: 'font-semibold',
-		linkUrlContainer: 'flex items-center gap-2',
-		linkUrl: 'text-blue-600 hover:text-blue-800',
+		linkUrlContainer: 'flex min-w-0 items-start gap-2',
+		linkUrl: 'min-w-0 [overflow-wrap:anywhere] text-blue-600 hover:text-blue-800',
 		infoItem: 'flex flex-col gap-2 py-4 border-b border-gray-200 last:border-b-0',
 		label: '',
-		value: '',
+		value: 'break-words',
 	},
 });
 

--- a/src/ui/GoodPartyOrgPledge.tsx
+++ b/src/ui/GoodPartyOrgPledge.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from 'react';
 
 import { cn, tv } from './_lib/utils.ts';
-import type { backgroundTypeValues, componentColorValues } from './_lib/designTypesStore.ts';
+import type { backgroundTypeValues, componentColorValues, iconColorValues } from './_lib/designTypesStore.ts';
 
 import { Container } from './Container.tsx';
 import { HeaderBlock, type HeaderBlockProps } from './HeaderBlock.tsx';
@@ -44,8 +44,15 @@ export type GoodPartyOrgPledgeProps = {
 	backgroundColor?: (typeof backgroundTypeValues)[number];
 	header?: HeaderBlockProps;
 	pledgeCards?: PledgeCard[];
-	iconBg?: Exclude<(typeof componentColorValues)[number], 'inverse'>;
+	iconBg?: Exclude<(typeof componentColorValues)[number], 'inverse'> | 'mixed';
 };
+
+const PLEDGE_MIXED_ICON_COLORS: Exclude<(typeof iconColorValues)[number], 'mixed' | 'white'>[] = [
+	'blue',
+	'bright-yellow',
+	'lavender',
+	'halo-green',
+];
 
 export function GoodPartyOrgPledge(props: GoodPartyOrgPledgeProps) {
 	const backgroundColor = props.backgroundColor ?? 'cream';
@@ -53,6 +60,17 @@ export function GoodPartyOrgPledge(props: GoodPartyOrgPledgeProps) {
 	const { base, wrapper, grid, card } = styles({ backgroundColor });
 
 	const resolvedStyle = resolveButtonStyleType('min-ghost', backgroundColor);
+
+	const resolveCardIconBg = (
+		card: PledgeCard,
+		index: number,
+	): Exclude<(typeof componentColorValues)[number], 'inverse'> => {
+		if (card.iconBg) return card.iconBg;
+		if (iconBg === 'mixed') {
+			return PLEDGE_MIXED_ICON_COLORS[index % PLEDGE_MIXED_ICON_COLORS.length];
+		}
+		return iconBg;
+	};
 
 	return (
 		<article className={cn(base(), props.className)} data-component='GoodPartyOrgPledge'>
@@ -63,7 +81,9 @@ export function GoodPartyOrgPledge(props: GoodPartyOrgPledgeProps) {
 						{props.pledgeCards?.map((pledgeCard, index) => (
 							<div key={`pledge-${index}`} className={card()}>
 								<div className='flex flex-col gap-4'>
-									{pledgeCard.icon && <CircleIcon icon={pledgeCard.icon} iconBg={pledgeCard.iconBg ?? iconBg} />}
+									{pledgeCard.icon && (
+										<CircleIcon icon={pledgeCard.icon} iconBg={resolveCardIconBg(pledgeCard, index)} />
+									)}
 									{pledgeCard.title && (
 										<Text as='h3' styleType='subtitle-1'>
 											{pledgeCard.title}

--- a/src/ui/ProfileContentBlock.mdx
+++ b/src/ui/ProfileContentBlock.mdx
@@ -30,6 +30,12 @@ Use this component when:
 
 <Canvas of={ProfileContentBlockStories.MultipleCards} />
 
+<Canvas of={ProfileContentBlockStories.SidebarOnly} />
+
+<Canvas of={ProfileContentBlockStories.LongUrls} />
+
+<Canvas of={ProfileContentBlockStories.TabletStacked} />
+
 ## Props
 
 <Controls of={ProfileContentBlockStories.Default} />
@@ -77,17 +83,19 @@ Additional CSS classes to apply to the component.
 ## Layout
 
 The component uses a responsive grid layout:
-- **Mobile**: Single column (sidebar appears above content if present)
-- **Desktop** (`lg:`): Two-column grid with fixed sidebar width
-  - Sidebar: `300px` fixed width
-  - Content: Remaining space (`1fr`)
-  - Gap: `gap-8` between columns
+- **Mobile / tablet (below `lg`)**: Single column inside a centered `max-w-3xl` content well; sidebar and content cards share the same width and left edge
+- **Desktop** (`lg:`): Two-column grid (well constraints removed)
+  - Sidebar: up to `400px` wide (`minmax(280px, 400px)`), sticky while scrolling
+  - Content: remaining width (`minmax(0, 1fr)`) with `min-w-0` so long copy wraps
+  - Gap: `gap-8` below `lg`, `gap-10` at `lg`, `gap-12` at `xl`
+- **Sidebar-only profiles**: Centered `max-w-3xl` well — cards fill the well without a faux second column on wide viewports
 
 ## Sticky Sidebar
 
-When the sidebar is present:
-- Uses `sticky top-4 self-start` positioning
+When the sidebar is present on desktop (`lg:` and two columns):
+- Uses `lg:sticky lg:top-4 self-start` positioning
 - Stays visible while scrolling through content cards
+- Below `lg`, the sidebar is not sticky (avoids content scrolling under the sidebar on tablet/mobile)
 - Provides quick access to contact links, office information, and CTA
 - Displays links with icons (Website, Facebook, Email, etc.)
 - Shows office details (About Office, Term Length, Election Date) with separators

--- a/src/ui/ProfileContentBlock.mdx
+++ b/src/ui/ProfileContentBlock.mdx
@@ -88,14 +88,17 @@ The component uses a responsive grid layout:
   - Sidebar: up to `400px` wide (`minmax(280px, 400px)`), sticky while scrolling
   - Content: remaining width (`minmax(0, 1fr)`) with `min-w-0` so long copy wraps
   - Gap: `gap-8` below `lg`, `gap-10` at `lg`, `gap-12` at `xl`
-- **Sidebar-only profiles**: Centered `max-w-3xl` well — cards fill the well without a faux second column on wide viewports
+- **Sidebar-only profiles**: Centered `max-w-3xl` well — sidebar fills the full well width; no sticky positioning or 400px cap (those apply only when content cards are present)
 
 ## Sticky Sidebar
 
-When the sidebar is present on desktop (`lg:` and two columns):
+When the sidebar is present on desktop (`lg:`) **and** content cards are rendered (two-column layout):
 - Uses `lg:sticky lg:top-4 self-start` positioning
+- Sidebar is capped at `400px` wide within the grid
 - Stays visible while scrolling through content cards
 - Below `lg`, the sidebar is not sticky (avoids content scrolling under the sidebar on tablet/mobile)
+
+When the sidebar is the only content (no content cards), it spans the full `max-w-3xl` well and is not sticky.
 - Provides quick access to contact links, office information, and CTA
 - Displays links with icons (Website, Facebook, Email, etc.)
 - Shows office details (About Office, Term Length, Election Date) with separators

--- a/src/ui/ProfileContentBlock.stories.tsx
+++ b/src/ui/ProfileContentBlock.stories.tsx
@@ -16,27 +16,29 @@ const meta: Meta<typeof ProfileContentBlock> = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
+const defaultSidebar = {
+	links: [
+		{ label: 'Website', icon: 'globe', href: 'https://www.website.com' },
+		{ label: 'Facebook', icon: 'facebook', href: 'https://www.facebook.com/' },
+		{ label: 'Email', icon: 'mail', href: 'mailto:hello@example.com' },
+	],
+	aboutOffice: 'Body text here',
+	termLength: 'Body text here',
+	electionDate: 'Body text here',
+	cta: {
+		buttonType: 'internal' as const,
+		href: '/run',
+		label: 'Run for Office',
+		buttonProps: {
+			styleType: 'secondary' as const,
+		},
+	},
+};
+
 export const Default: Story = {
 	args: {
 		backgroundColor: 'cream',
-		sidebar: {
-			links: [
-				{ label: 'Website', icon: 'globe', href: 'https://www.website.com' },
-				{ label: 'Facebook', icon: 'facebook', href: 'https://www.facebook.com/' },
-				{ label: 'Email', icon: 'mail', href: 'mailto:hello@example.com' },
-			],
-			aboutOffice: 'Body text here',
-			termLength: 'Body text here',
-			electionDate: 'Body text here',
-			cta: {
-				buttonType: 'internal',
-				href: '/run',
-				label: 'Run for Office',
-				buttonProps: {
-					styleType: 'secondary',
-				},
-			},
-		},
+		sidebar: defaultSidebar,
 		title: 'Candidate Name',
 		contentCards: [
 			{
@@ -141,5 +143,72 @@ export const MultipleCards: Story = {
 				content: 'Fourth card content.',
 			},
 		],
+	},
+};
+
+export const SidebarOnly: Story = {
+	args: {
+		backgroundColor: 'cream',
+		sidebar: defaultSidebar,
+		contentCards: [],
+	},
+	parameters: {
+		viewport: { defaultViewport: 'hd' },
+	},
+};
+
+export const LongUrls: Story = {
+	args: {
+		backgroundColor: 'cream',
+		sidebar: {
+			links: [
+				{
+					label: 'LinkedIn',
+					icon: 'linkedin',
+					href: 'https://www.linkedin.com/in/dylan-hays-5263b0218',
+				},
+				{
+					label: 'Website',
+					icon: 'globe',
+					href: 'https://www.ci.northville.mi.us/government/city-council',
+				},
+				{
+					label: 'Campaign',
+					icon: 'globe',
+					href: 'https://www.krenzfornorthville.com/about-the-candidate',
+				},
+			],
+			aboutOffice:
+				'The City Legislature is the legislative branch of City Government. The Legislature is composed of a seven-member Council, elected from six Council districts and one at-large Council member.',
+			termLength: '4 Years',
+			electionDate: 'November 3, 2025',
+			cta: defaultSidebar.cta,
+		},
+		contentCards: [
+			{
+				cardType: 'about-me',
+				heading: 'About Me',
+				content:
+					'I am dedicated to building bike paths connecting neighborhoods to the future River Walk and serving on the Planning Commission.',
+			},
+		],
+	},
+};
+
+export const TabletStacked: Story = {
+	args: LongUrls.args,
+	parameters: {
+		viewport: {
+			defaultViewport: 'surfacePro7',
+			viewports: {
+				surfacePro7: {
+					name: 'Surface Pro 7',
+					styles: {
+						width: '912px',
+						height: '1368px',
+					},
+				},
+			},
+		},
 	},
 };

--- a/src/ui/ProfileContentBlock.tsx
+++ b/src/ui/ProfileContentBlock.tsx
@@ -8,8 +8,10 @@ import { Text } from './Text.tsx';
 const styles = tv({
 	slots: {
 		base: 'py-(--container-padding)',
+		well: 'mx-auto w-full max-w-3xl',
 		grid: 'grid w-full mx-auto max-w-3xl gap-8 lg:mx-0 lg:max-w-none lg:grid-cols-[minmax(280px,400px)_minmax(0,1fr)] lg:gap-10 xl:gap-12 lg:overflow-hidden',
 		sidebar: 'self-start w-full min-w-0 lg:max-w-[400px] lg:sticky lg:top-4',
+		sidebarStandalone: 'w-full min-w-0',
 		content: 'flex min-w-0 w-full flex-col gap-8 rounded-xl bg-white p-6',
 		title: 'border-b border-gray-200 ',
 	},
@@ -36,7 +38,7 @@ export type ProfileContentBlockProps = {
 
 export function ProfileContentBlock(props: ProfileContentBlockProps) {
 	const backgroundColor = props.backgroundColor ?? 'cream';
-	const { base, grid, sidebar, content, title: titleSlot } = styles({ backgroundColor });
+	const { base, well, grid, sidebar, sidebarStandalone, content, title: titleSlot } = styles({ backgroundColor });
 	const hasContentCards = props.contentCards.length > 0;
 
 	return (
@@ -47,12 +49,12 @@ export function ProfileContentBlock(props: ProfileContentBlockProps) {
 						hasContentCards
 							? grid()
 							: props.sidebar
-								? 'mx-auto w-full max-w-3xl'
+								? well()
 								: undefined,
 					)}
 				>
 					{props.sidebar && (
-						<aside className={sidebar()}>
+						<aside className={hasContentCards ? sidebar() : sidebarStandalone()}>
 							<ElectionsSidebar {...props.sidebar} />
 						</aside>
 					)}

--- a/src/ui/ProfileContentBlock.tsx
+++ b/src/ui/ProfileContentBlock.tsx
@@ -8,9 +8,9 @@ import { Text } from './Text.tsx';
 const styles = tv({
 	slots: {
 		base: 'py-(--container-padding)',
-		grid: 'grid lg:grid-cols-[minmax(400px,auto)_1fr] gap-[80px]',
-		sidebar: 'sticky top-4 self-start',
-		content: 'flex flex-col gap-8 bg-white rounded-xl p-6',
+		grid: 'grid w-full mx-auto max-w-3xl gap-8 lg:mx-0 lg:max-w-none lg:grid-cols-[minmax(280px,400px)_minmax(0,1fr)] lg:gap-10 xl:gap-12 lg:overflow-hidden',
+		sidebar: 'self-start w-full min-w-0 lg:max-w-[400px] lg:sticky lg:top-4',
+		content: 'flex min-w-0 w-full flex-col gap-8 rounded-xl bg-white p-6',
 		title: 'border-b border-gray-200 ',
 	},
 	variants: {
@@ -37,26 +37,37 @@ export type ProfileContentBlockProps = {
 export function ProfileContentBlock(props: ProfileContentBlockProps) {
 	const backgroundColor = props.backgroundColor ?? 'cream';
 	const { base, grid, sidebar, content, title: titleSlot } = styles({ backgroundColor });
+	const hasContentCards = props.contentCards.length > 0;
 
 	return (
 		<article className={cn(base(), props.className)} data-component='ProfileContentBlock'>
 			<Container size='xl'>
-				<div className={grid()}>
+				<div
+					className={cn(
+						hasContentCards
+							? grid()
+							: props.sidebar
+								? 'mx-auto w-full max-w-3xl'
+								: undefined,
+					)}
+				>
 					{props.sidebar && (
 						<aside className={sidebar()}>
 							<ElectionsSidebar {...props.sidebar} />
 						</aside>
 					)}
-					<div className={cn(content())}>
-						{props.title && (
-							<Text as="h2" styleType="heading-sm" className={titleSlot()}>
-								{props.title}
-							</Text>
-						)}
-						{props.contentCards.map((card, index) => (
-							<ProfileContentCard key={index} {...card} />
-						))}
-					</div>
+					{hasContentCards && (
+						<div className={cn(content())}>
+							{props.title && (
+								<Text as="h2" styleType="heading-sm" className={titleSlot()}>
+									{props.title}
+								</Text>
+							)}
+							{props.contentCards.map((card, index) => (
+								<ProfileContentCard key={index} {...card} />
+							))}
+						</div>
+					)}
 				</div>
 			</Container>
 		</article>

--- a/src/ui/ProfileContentCard.tsx
+++ b/src/ui/ProfileContentCard.tsx
@@ -7,7 +7,7 @@ const styles = tv({
 	slots: {
 		base: 'flex flex-col gap-6 border-b border-gray-200 last:border-b-0 pb-[16px]',
 		heading: '',
-		content: '',
+		content: 'min-w-0 break-words',
 	},
 });
 
@@ -29,7 +29,7 @@ export function ProfileContentCard(props: ProfileContentCardProps) {
 				</Text>
 			)}
 			{isValidRichText(props.content) && (
-				<div className={content()}>
+				<div className={cn(content(), typeof props.content === 'string' && 'whitespace-pre-line')}>
 					<Text styleType='body-2'>{props.content}</Text>
 				</div>
 			)}

--- a/src/ui/ProfileHero.tsx
+++ b/src/ui/ProfileHero.tsx
@@ -9,13 +9,13 @@ import { Logo } from '~/sanity/utils/Logo.tsx';
 
 const styles = tv({
 	slots: {
-		base: 'relative py-12 md:py-16 lg:py-20 overflow-hidden',
+		base: 'relative py-8 md:py-10 lg:py-12 overflow-hidden',
 		backgroundWrapper: 'absolute top-0 bottom-0 max-md:-left-[var(--container-padding)] max-md:-right-[var(--container-padding)] md:inset-0',
 		topSection: 'absolute top-0 left-0 right-0 h-[60%]',
 		bottomSection: 'absolute bottom-0 left-0 right-0 h-[40%]',
 		container: 'relative z-10 flex flex-col items-start gap-8 md:flex-row md:items-start md:gap-12 lg:gap-40',
 		imageWrapper: 'relative flex-shrink-0 z-20',
-		image: 'rounded-full overflow-hidden w-48 h-48 md:w-56 md:h-56 lg:w-64 lg:h-64 mt-8 md:mt-12 lg:mt-16',
+		image: 'rounded-full overflow-hidden w-48 h-48 md:w-56 md:h-56 lg:w-64 lg:h-64',
 		badge: 'absolute bottom-0 right-0 translate-x-[-2%] translate-y-1/17 z-30',
 		content: 'flex flex-col gap-6 text-left z-10',
 		heading: '',
@@ -58,7 +58,8 @@ export type ProfileHeroProps = {
 
 export function ProfileHero(props: ProfileHeroProps) {
 	const backgroundColor = props.backgroundColor ?? 'midnight';
-	const { base, backgroundWrapper, topSection, bottomSection, container, imageWrapper, image, badge, content, heading, office, attribution, attributionIcon, attributionText } = styles({ backgroundColor });
+	const resolvedBackgroundColor = backgroundColor === 'white' ? 'cream' : backgroundColor;
+	const { base, backgroundWrapper, topSection, bottomSection, container, imageWrapper, image, badge, content, heading, office, attribution, attributionIcon, attributionText } = styles({ backgroundColor: resolvedBackgroundColor });
 
 	return (
 		<section className={cn(base(), props.className)} data-component="ProfileHero">

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -93,6 +93,6 @@
       "env": ["./env.ts"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", "src/components/HeaderNav.tsx"],
+  "include": ["next-env.d.ts", "bun-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", "src/components/HeaderNav.tsx"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
- Aligns the live candidate profile page with the QA template: section order (ProfileHero before ClaimProfileBlock), claim banner layout, breadcrumb overrides, and refined ProfileContentBlock grid/sticky sidebar spacing.
- Improves profile data wiring: sidebar link labels/icons, term length, office description, and a "View office details" CTA derived from the candidate's race.
- Links the "Candidates" breadcrumb (and office CTA) to the position-specific candidates listing via `Race.slug`, with canonical city URLs resolved through shared election path helpers (sitemap-aligned).
- Adds claimed-website handling so empowered candidates' websites are prepended without duplicates (www/trailing-slash normalized).
- Hardens related UI plumbing: ClaimProfileBlock background color resolution, CTA href normalization in `buttonTransformer`, and expanded test coverage across helpers and page sections.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Profile pages now depend on elections API fetches for race URL expansion and navigation targets; changes are localized but affect user-facing links and layout across all candidate profiles.
> 
> **Overview**
> Aligns the **candidate profile** experience with the QA template and wires **election-aware navigation** from live API data.
> 
> The static profile section order is reordered (**ProfileHero** before **Claim Profile**), claim messaging uses a **banner** layout on profiles, and **breadcrumbs** are supplied via `sectionOverrides` (including a **Candidates** crumb that links to the race’s position **candidates** URL when resolvable). **Profile content** gets richer sidebar data (link labels/icons, term length, office copy, **View office details** CTA) and layout tweaks (responsive grid, sticky sidebar only on desktop with cards, long-URL wrapping).
> 
> Shared **election path** helpers (`buildElectionPositionHrefFromRaceSlug`, `resolveRaceElectionHrefs`, county slug resolution) centralize URL rules with the sitemap; the profile page calls `resolveRaceElectionHrefs` at render time. **CTA handling** is hardened via `normalizeRawCtaToButton` / `isUsableHref` and label fallbacks on CTA cards; several page sections adopt the same pattern for static/mock Sanity shapes.
> 
> **Breadcrumbs** now allow crumbs without `href` (current page). **ClaimProfileBlock** gains `card` vs `banner` layouts and legacy CMS color aliases. Adds **`bun-types`** and broad **unit tests** for helpers and sections.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c0f75b25c17af78b643502623d60ba662b02c9f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->