### PR TITLE
Add rounded corners to HeroBlock hero images

### DIFF
--- a/src/ui/HeroBlock.tsx
+++ b/src/ui/HeroBlock.tsx
@@ -165,7 +165,7 @@ export function HeroBlock(props: HeroBlockProps) {
 							{props.embedCode ? (
 								<EmbedHtml html={props.embedCode} />
 							) : (
-								<Media aspectRatio='5:4' image={props.image} objectFit={props.showFullImage ? 'contain' : 'cover'} priority={props.priority} />
+								<Media aspectRatio='5:4' className='rounded-lg' image={props.image} objectFit={props.showFullImage ? 'contain' : 'cover'} priority={props.priority} />
 							)}
 						</div>
 					)}

--- a/src/ui/HeroBlock.tsx
+++ b/src/ui/HeroBlock.tsx
@@ -148,9 +148,12 @@ export type HeroBlockProps = {
 	textSize?: ResolvedTextSize;
 };
 
+const ROUNDED_MEDIA_LAYOUTS = ['media-left', 'media-right'] as const satisfies readonly HeroBlockProps['layout'][];
+
 export function HeroBlock(props: HeroBlockProps) {
 	const backgroundColor = props.backgroundColor ?? 'cream';
 	const layout = props.layout ?? 'no-media';
+	const roundMedia = ROUNDED_MEDIA_LAYOUTS.includes(layout as (typeof ROUNDED_MEDIA_LAYOUTS)[number]);
 	const textSize = props.textSize ?? resolveTextSize('Medium');
 
 	const { base, wrapper, container, media, content, overline, buttons, text } = styles({ backgroundColor, layout });
@@ -165,7 +168,7 @@ export function HeroBlock(props: HeroBlockProps) {
 							{props.embedCode ? (
 								<EmbedHtml html={props.embedCode} />
 							) : (
-								<Media aspectRatio='5:4' className='rounded-lg' image={props.image} objectFit={props.showFullImage ? 'contain' : 'cover'} priority={props.priority} />
+								<Media aspectRatio='5:4' className={roundMedia ? 'rounded-lg' : undefined} image={props.image} objectFit={props.showFullImage ? 'contain' : 'cover'} priority={props.priority} />
 							)}
 						</div>
 					)}


### PR DESCRIPTION
- Add `rounded-lg` to the shared `Media` wrapper in `HeroBlock` so hero images render with consistent rounded corners
- Fixes the sharp-cornered hero image on `/about` to match the rounded treatment on `/team`
- Applies to all `HeroBlock` media layouts site-wide that include an image

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Tailwind class on hero Media; cosmetic only with no auth, data, or API impact.
> 
> **Overview**
> Adds **`rounded-lg`** on the shared **`Media`** instance in **`HeroBlock`** when a hero image is shown (not embed HTML), so hero imagery gets consistent rounded corners across layouts that include media.
> 
> This is a presentational tweak only—no routing, data, or form behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3141c8861b1ab2264c9a2c16a8c56219f418fc3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->