### PR TITLE
fix: eliminate CTA Block load flash on blog and marketing pages

### DIFF
--- a/src/ui/CTABlock.tsx
+++ b/src/ui/CTABlock.tsx
@@ -7,7 +7,6 @@ import type { backgroundTypeValues, normalCondensedValues } from './_lib/designT
 
 import { ComponentButton, type ComponentButtonProps } from './Inputs/Button.tsx';
 import { Container } from './Container.tsx';
-import { FadeIn } from './FadeIn.tsx';
 import { Text } from './Text.tsx';
 import { Newsletter } from './Form/Newsletter.tsx';
 import { Logo } from '~/sanity/utils/Logo.tsx';
@@ -97,8 +96,7 @@ export function CTABlock(props: CTABlockProps) {
 		<article className={cn(base(), props.className)} data-component='CTABlock'>
 			<Container size={layout === 'blog' ? 'unset' : 'xl'}>
 				<div className='group relative'>
-					<FadeIn>
-						<div className={content()}>
+					<div className={content()}>
 						{props.showLogo && (
 							<div className="mb-10">
 								<Logo width={80} height={80} className="object-contain" />
@@ -140,8 +138,7 @@ export function CTABlock(props: CTABlockProps) {
 							</Text>
 						)}
 						{props.form?.provider === 'Hubspot' && props.form.formId && <Newsletter formId={props.form.formId} />}
-						</div>
-					</FadeIn>
+					</div>
 					<div className={card()}>
 						{size === 'normal' && (
 							<svg


### PR DESCRIPTION
- Remove the `FadeIn` wrapper from `CTABlock` so CTA title, copy, and buttons render at the same time as the rest of the page instead of ~1s later.
- Fixes the reported “empty colored box then text pops in” behavior on blog articles, `/run-for-office`, `/sms-tools`, and other pages using `component_ctaBlock` or embedded `ctaSection`.

## Root cause

`FadeIn` starts content at `opacity: 0` until `useInView` fires and a ~0.8s transition runs. The decorative card background is outside `FadeIn`, so users see the box before the text.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-component presentation change with no auth, data, or API impact; other blocks still use FadeIn unchanged.
> 
> **Overview**
> Removes the **`FadeIn`** wrapper around **`CTABlock`** content (headline, body, buttons, newsletter) so that copy renders immediately with the rest of the page instead of after scroll-triggered opacity animation.
> 
> The decorative **card** background was already outside **`FadeIn`**, which caused the reported empty colored box before text appeared on blog posts and marketing pages using **`component_ctaBlock`** or embedded CTA sections.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c812a398e9aeebfbc2acb4938201ab6641248a23. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->