### PR TITLE
Enhance candidate profile and elections API integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,10 +19,11 @@ SANITY_STUDIO_API_TOKEN=
 SANITY_REVALIDATE_SECRET=
 
 # Elections API - candidate and race data for profile/election pages
+# Dev: https://election-api-dev.goodparty.org
+# Production: https://election-api.goodparty.org (default)
+# GP API base for claimed campaign lookup is derived automatically
+# (election-api -> gp-api). Override with GP_API_BASE_URL if needed.
 ELECTIONS_API_BASE_URL=
-
-# GoodParty API - claimed campaign lookup for candidate profiles (GET /v1/public-campaigns)
-GP_API_BASE_URL=
 
 # Ashby job board - required for /work-with-us careers page
 # Find your board name from https://jobs.ashbyhq.com/{JOB_BOARD_NAME}

--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,12 @@ SANITY_STUDIO_API_TOKEN=
 # Paste in Vercel without trailing newlines or webhook signature checks will fail.
 SANITY_REVALIDATE_SECRET=
 
+# Elections API - candidate and race data for profile/election pages
+ELECTIONS_API_BASE_URL=
+
+# GoodParty API - claimed campaign lookup for candidate profiles (GET /v1/public-campaigns)
+GP_API_BASE_URL=
+
 # Ashby job board - required for /work-with-us careers page
 # Find your board name from https://jobs.ashbyhq.com/{JOB_BOARD_NAME}
 ASHBY_JOB_BOARD_NAME=

--- a/src/app/candidate/[...slug]/page.tsx
+++ b/src/app/candidate/[...slug]/page.tsx
@@ -7,6 +7,10 @@ import {
 	formatTermLength,
 	inferSidebarLinkIcon,
 	prependClaimedWebsiteIfNew,
+	resolveClaimedCustomIssueText,
+	resolveClaimedTextField,
+	resolveProfileAboutText,
+	resolveProfileImageUrl,
 } from '~/lib/electionsHelpers';
 import { PageSections } from '~/PageSections';
 import type { SectionOverrides } from '~/PageSections';
@@ -30,8 +34,8 @@ function buildSectionOverrides(
 	const isClaimed = !!claimed;
 
 	const profileData: ProfileData = {
-		aboutMe: candidate.about ?? undefined,
-		whyRunning: claimed?.details?.pastExperience,
+		aboutMe: resolveProfileAboutText(candidate.about, claimed),
+		whyRunning: resolveClaimedTextField(claimed?.details?.pastExperience),
 		topIssues: buildTopIssues(candidate, claimed),
 	};
 
@@ -84,7 +88,7 @@ function buildSectionOverrides(
 		component_profileHero: {
 			candidateName,
 			office,
-			profileImageUrl: candidate.image ?? undefined,
+			profileImageUrl: resolveProfileImageUrl(candidate.image),
 			isEmpowered: isClaimed,
 		},
 		component_profileContentBlock: {
@@ -120,7 +124,7 @@ function buildTopIssues(
 
 	if (claimed?.details?.customIssues?.length) {
 		for (const ci of claimed.details.customIssues) {
-			parts.push(`${ci.title}\n\n${ci.description}`);
+			parts.push(resolveClaimedCustomIssueText(ci));
 		}
 	}
 
@@ -190,12 +194,15 @@ export async function generateMetadata({
 
 	const candidateName = [candidate.firstName, candidate.lastName].filter(Boolean).join(' ') || 'Candidate';
 	const positionName = candidate.positionName ?? 'Office';
+	const profileImageUrl = resolveProfileImageUrl(candidate.image);
 
 	return {
 		title: `${candidateName} for ${positionName} | Good Party`,
-		description: candidate.about ?? `View ${candidateName}'s profile for ${positionName}.`,
+		description:
+			resolveProfileAboutText(candidate.about, null) ??
+			`View ${candidateName}'s profile for ${positionName}.`,
 		openGraph: {
-			images: candidate.image ? [{ url: candidate.image }] : undefined,
+			images: profileImageUrl ? [{ url: profileImageUrl }] : undefined,
 		},
 	};
 }

--- a/src/app/candidate/[...slug]/page.tsx
+++ b/src/app/candidate/[...slug]/page.tsx
@@ -131,6 +131,21 @@ function buildTopIssues(
 	return parts.length ? parts.join('\n\n') : undefined;
 }
 
+async function loadClaimedCampaignForCandidate(
+	candidate: CandidacyItem,
+): Promise<FindByRaceIdResponse | null> {
+	const raceId = candidate.Race?.brHashId;
+	if (!raceId || !candidate.firstName || !candidate.lastName) {
+		return null;
+	}
+
+	return findCampaignByRace({
+		raceId,
+		firstName: candidate.firstName,
+		lastName: candidate.lastName,
+	});
+}
+
 export default async function Page({
 	params,
 }: {
@@ -147,15 +162,7 @@ export default async function Page({
 		notFound();
 	}
 
-	let claimed: FindByRaceIdResponse | null = null;
-	const raceId = candidate.Race?.brHashId;
-	if (raceId && candidate.firstName && candidate.lastName) {
-		claimed = await findCampaignByRace({
-			raceId,
-			firstName: candidate.firstName,
-			lastName: candidate.lastName,
-		});
-	}
+	const claimed = await loadClaimedCampaignForCandidate(candidate);
 
 	const sectionOverrides = buildSectionOverrides(
 		candidate,
@@ -185,13 +192,14 @@ export async function generateMetadata({
 	const candidate = await getCandidateBySlug({
 		slug,
 		includeStances: false,
-		includeRace: false,
+		includeRace: true,
 	});
 
 	if (!candidate) {
 		return { title: 'Candidate Not Found | Good Party' };
 	}
 
+	const claimed = await loadClaimedCampaignForCandidate(candidate);
 	const candidateName = [candidate.firstName, candidate.lastName].filter(Boolean).join(' ') || 'Candidate';
 	const positionName = candidate.positionName ?? 'Office';
 	const profileImageUrl = resolveProfileImageUrl(candidate.image);
@@ -199,7 +207,7 @@ export async function generateMetadata({
 	return {
 		title: `${candidateName} for ${positionName} | Good Party`,
 		description:
-			resolveProfileAboutText(candidate.about, null) ??
+			resolveProfileAboutText(candidate.about, claimed) ??
 			`View ${candidateName}'s profile for ${positionName}.`,
 		openGraph: {
 			images: profileImageUrl ? [{ url: profileImageUrl }] : undefined,

--- a/src/app/elections/[state]/[county]/[city]/page.tsx
+++ b/src/app/elections/[state]/[county]/[city]/page.tsx
@@ -5,6 +5,7 @@ import {
 	getCountyChildPlaces,
 	getPlacesByState,
 	getPlaceBySlug,
+	isCityOrTownMtfcc,
 } from '~/lib/electionsApi';
 import { isValidStateCode } from '~/constants/usStateCodes';
 import {
@@ -18,7 +19,6 @@ import { quoteCollectionByIdQuery } from '~/sanity/groq';
 import {
 	getStateName,
 	hasSuspiciousFactsMatch,
-	isCityOrTownMtfcc,
 	placeToFactsCards,
 	resolveLocalityName,
 } from '~/lib/electionsHelpers';

--- a/src/lib/electionsApi.ts
+++ b/src/lib/electionsApi.ts
@@ -14,11 +14,17 @@ import {
 	buildElectionPositionHrefFromRaceSlug,
 	buildRaceCandidatesHref,
 	canonicalizeCountyEquivalentName,
+	normalizeCandidateLookupName,
 	stripCountySuffix,
 } from '~/lib/electionsHelpers';
 
-const BASE_URL =
+const ELECTIONS_API_BASE_URL =
 	process.env['ELECTIONS_API_BASE_URL'] ?? 'https://election-api.goodparty.org';
+
+const GP_API_BASE_URL =
+	process.env['GP_API_BASE_URL'] ??
+	process.env['NEXT_PUBLIC_API_BASE'] ??
+	'https://gp-api.goodparty.org';
 
 const CACHE_OPTIONS = { next: { revalidate: 3600 } } satisfies RequestInit;
 
@@ -101,7 +107,7 @@ export async function getRacesByYear(params: {
 	const searchParams = new URLSearchParams({ zipcode: params.zipcode });
 	if (params.level) searchParams.set('level', params.level);
 	if (params.electionDate) searchParams.set('electionDate', params.electionDate);
-	const url = `${BASE_URL}/v1/elections/races-by-year?${searchParams}`;
+	const url = `${ELECTIONS_API_BASE_URL}/v1/elections/races-by-year?${searchParams}`;
 	const data = await fetchJson<RaceNode[]>(url);
 	return data ?? [];
 }
@@ -116,7 +122,7 @@ export async function getDistrictTypes(params: {
 		electionYear: params.electionYear.toString(),
 		excludeInvalid: (params.excludeInvalid ?? true).toString(),
 	});
-	const url = `${BASE_URL}/v1/districts/types?${searchParams}`;
+	const url = `${ELECTIONS_API_BASE_URL}/v1/districts/types?${searchParams}`;
 	const data = await fetchJson<DistrictTypeItem[]>(url, CACHE_OPTIONS);
 	return data ?? [];
 }
@@ -135,13 +141,13 @@ export async function getDistrictNames(params: {
 	if (params.excludeInvalid !== undefined) {
 		searchParams.set('excludeInvalid', params.excludeInvalid.toString());
 	}
-	const url = `${BASE_URL}/v1/districts/names?${searchParams}`;
+	const url = `${ELECTIONS_API_BASE_URL}/v1/districts/names?${searchParams}`;
 	const data = await fetchJson<DistrictNameItem[]>(url, CACHE_OPTIONS);
 	return data ?? [];
 }
 
 export async function getPositionById(id: string): Promise<PositionDetail | null> {
-	const url = `${BASE_URL}/v1/positions/${encodeURIComponent(id)}`;
+	const url = `${ELECTIONS_API_BASE_URL}/v1/positions/${encodeURIComponent(id)}`;
 	return fetchJson<PositionDetail>(url, CACHE_OPTIONS);
 }
 
@@ -153,7 +159,7 @@ export async function getRaceBySlug(
 		raceSlug,
 		includePlace: includePlace.toString(),
 	});
-	const url = `${BASE_URL}/v1/races?${searchParams}`;
+	const url = `${ELECTIONS_API_BASE_URL}/v1/races?${searchParams}`;
 	const data = await fetchJson<RaceDetail[]>(url, CACHE_OPTIONS);
 	return Array.isArray(data) && data.length > 0 ? (data[0] ?? null) : null;
 }
@@ -168,7 +174,7 @@ export async function getCandidacies(params: {
 	if (params.positionId) searchParams.set('positionId', params.positionId);
 	if (params.raceSlug) searchParams.set('raceSlug', params.raceSlug);
 	if (searchParams.toString() === '') return [];
-	const url = `${BASE_URL}/v1/candidacies?${searchParams}`;
+	const url = `${ELECTIONS_API_BASE_URL}/v1/candidacies?${searchParams}`;
 	const data = await fetchJson<CandidacyItem[]>(url);
 	return Array.isArray(data) ? data : [];
 }
@@ -183,7 +189,7 @@ export async function getCandidateBySlug(params: {
 		includeStances: (params.includeStances ?? true).toString(),
 		includeRace: (params.includeRace ?? true).toString(),
 	});
-	const url = `${BASE_URL}/v1/candidacies?${searchParams}`;
+	const url = `${ELECTIONS_API_BASE_URL}/v1/candidacies?${searchParams}`;
 	const data = await fetchJson<CandidacyItem[]>(url, CACHE_OPTIONS);
 	return Array.isArray(data) && data.length > 0 ? (data[0] ?? null) : null;
 }
@@ -196,7 +202,7 @@ export async function fetchCandidacySlugs(stateCode: string): Promise<string[]> 
 		state: stateCode.toUpperCase(),
 		columns: 'slug',
 	});
-	const url = `${BASE_URL}/v1/candidacies?${searchParams}`;
+	const url = `${ELECTIONS_API_BASE_URL}/v1/candidacies?${searchParams}`;
 	const data = await fetchJson<Array<{ slug?: string }>>(url, CACHE_OPTIONS);
 	if (!Array.isArray(data)) return [];
 	return data.map((c) => c.slug).filter((s): s is string => typeof s === 'string' && s.length > 0);
@@ -207,17 +213,23 @@ export async function findCampaignByRace(params: {
 	firstName: string;
 	lastName: string;
 }): Promise<FindByRaceIdResponse | null> {
+	const firstName = normalizeCandidateLookupName(params.firstName);
+	const lastName = normalizeCandidateLookupName(params.lastName);
+	if (!firstName || !lastName) {
+		return null;
+	}
+
 	const searchParams = new URLSearchParams({
 		raceId: params.raceId,
-		firstName: params.firstName,
-		lastName: params.lastName,
+		firstName,
+		lastName,
 	});
-	const url = `${BASE_URL}/v1/public-campaigns?${searchParams}`;
+	const url = `${GP_API_BASE_URL.replace(/\/$/, '')}/v1/public-campaigns?${searchParams}`;
 	return fetchJson<FindByRaceIdResponse>(url);
 }
 
 export async function getMostElections(count = 3): Promise<FeaturedCity[]> {
-	const url = `${BASE_URL}/v1/places/most-elections?count=${count}`;
+	const url = `${ELECTIONS_API_BASE_URL}/v1/places/most-elections?count=${count}`;
 	const data = await fetchJson<FeaturedCity[]>(url, CACHE_OPTIONS);
 	return Array.isArray(data) ? data : [];
 }
@@ -230,7 +242,7 @@ export async function getPlacesByState(params: {
 		state: params.state.toUpperCase(),
 	});
 	if (params.mtfcc) searchParams.set('mtfcc', params.mtfcc);
-	const url = `${BASE_URL}/v1/places?${searchParams}`;
+	const url = `${ELECTIONS_API_BASE_URL}/v1/places?${searchParams}`;
 	const data = await fetchJson<PlaceItem[]>(url, CACHE_OPTIONS);
 	return Array.isArray(data) ? data : [];
 }
@@ -313,7 +325,7 @@ export async function getPlaceBySlug(params: {
 	});
 	if (params.placeColumns) searchParams.set('placeColumns', params.placeColumns);
 	if (params.raceColumns) searchParams.set('raceColumns', params.raceColumns);
-	const url = `${BASE_URL}/v1/places?${searchParams}`;
+	const url = `${ELECTIONS_API_BASE_URL}/v1/places?${searchParams}`;
 	const data = await fetchJson<PlaceWithFacts[]>(url, CACHE_OPTIONS);
 	return Array.isArray(data) && data.length > 0 ? (data[0] ?? null) : null;
 }

--- a/src/lib/electionsApi.ts
+++ b/src/lib/electionsApi.ts
@@ -24,7 +24,7 @@ const ELECTIONS_API_BASE_URL =
 const GP_API_BASE_URL =
 	process.env['GP_API_BASE_URL'] ??
 	process.env['NEXT_PUBLIC_API_BASE'] ??
-	'https://gp-api.goodparty.org';
+	ELECTIONS_API_BASE_URL.replace('election-api', 'gp-api');
 
 const CACHE_OPTIONS = { next: { revalidate: 3600 } } satisfies RequestInit;
 

--- a/src/lib/electionsHelpers.test.ts
+++ b/src/lib/electionsHelpers.test.ts
@@ -14,6 +14,7 @@ import {
 	formatSidebarLinkLabel,
 	formatTermLength,
 	linkHrefAlreadyPresent,
+	normalizeCandidateLookupName,
 	normalizeLinkHrefForCompare,
 	prependClaimedWebsiteIfNew,
 	getCountySuffixLabel,
@@ -21,13 +22,16 @@ import {
 	getYearFromDateString,
 	hasSuspiciousFactsMatch,
 	inferSidebarLinkIcon,
-	isCityOrTownMtfcc,
 	placeToFactsCards,
+	resolveClaimedCustomIssueText,
+	resolveClaimedTextField,
 	resolveLocalityName,
+	resolveProfileAboutText,
+	resolveProfileImageUrl,
 	slugifyPositionName,
 	stripCountySuffix,
 } from './electionsHelpers';
-import { CITY_MTFCC, COUNTY_MTFCC, TOWN_MTFCC } from './electionsApi';
+import { CITY_MTFCC, COUNTY_MTFCC, TOWN_MTFCC, isCityOrTownMtfcc } from './electionsApi';
 import type { PlaceItem, PlaceWithFacts, RaceDetail } from '~/types/elections';
 
 function placeItem(id: string, name: string, slug: string, state: string): PlaceItem {
@@ -999,5 +1003,57 @@ describe('buildFAQSchema', () => {
 	test('uses FAQPage as root @type', () => {
 		const schema = buildFAQSchema([{ title: 'Q?', copy: 'A.' }]) as Record<string, unknown>;
 		expect(schema['@type']).toBe('FAQPage');
+	});
+});
+
+describe('claimed profile helpers', () => {
+	test('normalizeCandidateLookupName trims and collapses whitespace', () => {
+		expect(normalizeCandidateLookupName('  Monica  ')).toBe('Monica');
+		expect(normalizeCandidateLookupName('Mary   Jane')).toBe('Mary Jane');
+	});
+
+	test('resolveClaimedTextField handles string and object values', () => {
+		expect(resolveClaimedTextField('  Hello  ')).toBe('Hello');
+		expect(resolveClaimedTextField({ intro: 'Line one', detail: 'Line two' })).toBe(
+			'Line one\n\nLine two',
+		);
+		expect(resolveClaimedTextField('   ')).toBeUndefined();
+	});
+
+	test('resolveClaimedCustomIssueText prefers description then position', () => {
+		expect(
+			resolveClaimedCustomIssueText({ title: 'Education', description: 'Fund schools' }),
+		).toBe('Education\n\nFund schools');
+		expect(resolveClaimedCustomIssueText({ title: 'Education', position: 'Fund schools' })).toBe(
+			'Education\n\nFund schools',
+		);
+	});
+
+	test('resolveProfileAboutText prefers elections API about over claimed occupation', () => {
+		expect(
+			resolveProfileAboutText('Election bio', {
+				id: 1,
+				slug: 'monica-alponte',
+				details: { occupation: 'Teacher' },
+				updatedAt: '',
+				website: null,
+				campaignPositions: [],
+			}),
+		).toBe('Election bio');
+		expect(
+			resolveProfileAboutText(undefined, {
+				id: 1,
+				slug: 'monica-alponte',
+				details: { occupation: 'Teacher' },
+				updatedAt: '',
+				website: null,
+				campaignPositions: [],
+			}),
+		).toBe('Teacher');
+	});
+
+	test('resolveProfileImageUrl trims and rejects empty values', () => {
+		expect(resolveProfileImageUrl(' https://example.com/a.jpg ')).toBe('https://example.com/a.jpg');
+		expect(resolveProfileImageUrl('   ')).toBeUndefined();
 	});
 });

--- a/src/lib/electionsHelpers.ts
+++ b/src/lib/electionsHelpers.ts
@@ -1,8 +1,6 @@
 import { US_STATES } from '~/constants/usStates';
-import type { CandidacyItem, PlaceItem, PlaceWithFacts, RaceDetail } from '~/types/elections';
+import type { CandidacyItem, FindByRaceIdResponse, PlaceItem, PlaceWithFacts, RaceDetail } from '~/types/elections';
 import type { FactsCardProps } from '~/ui/FactsCard';
-
-export { isCityOrTownMtfcc } from '~/lib/electionsApi';
 
 const COUNTY_EQUIV_SUFFIX_RE =
 	/\s+(County|Parish|City and Borough|City and County|Borough|Census Area|Municipality)$/i;
@@ -120,6 +118,58 @@ export function mapCandidacyToCard(
 			? `/candidate/${candidacy.slug}`
 			: `/profile?slug=${encodeURIComponent([candidacy.firstName, candidacy.lastName].filter(Boolean).join('-').toLowerCase())}&raceId=${encodeURIComponent(candidacy.raceId ?? '')}`,
 	};
+}
+
+/** Trims candidate names before public-campaigns lookup. */
+export function normalizeCandidateLookupName(name: string): string {
+	return name.trim().replace(/\s+/g, ' ');
+}
+
+/** Coerces claimed campaign text fields that may be stored as JSON objects. */
+export function resolveClaimedTextField(
+	value: string | Record<string, string> | null | undefined,
+): string | undefined {
+	if (typeof value === 'string') {
+		const trimmed = value.trim();
+		return trimmed.length > 0 ? trimmed : undefined;
+	}
+	if (value && typeof value === 'object') {
+		const parts = Object.values(value)
+			.map((part) => part.trim())
+			.filter(Boolean);
+		return parts.length > 0 ? parts.join('\n\n') : undefined;
+	}
+	return undefined;
+}
+
+type ClaimedCustomIssue = {
+	title: string;
+	description?: string;
+	position?: string;
+};
+
+/** Maps gp-api custom issue shape (title/position) to display text. */
+export function resolveClaimedCustomIssueText(issue: ClaimedCustomIssue): string {
+	const description = issue.description ?? issue.position ?? '';
+	return description ? `${issue.title}\n\n${description}` : issue.title;
+}
+
+/** Prefers elections API bio, then claimed occupation when unclaimed about is empty. */
+export function resolveProfileAboutText(
+	candidateAbout: string | null | undefined,
+	claimed: FindByRaceIdResponse | null,
+): string | undefined {
+	const about = candidateAbout?.trim();
+	if (about) return about;
+	return resolveClaimedTextField(claimed?.details?.occupation);
+}
+
+/** Prefers elections API image; public-campaigns does not expose profile photos. */
+export function resolveProfileImageUrl(
+	candidateImage: string | null | undefined,
+): string | undefined {
+	const image = candidateImage?.trim();
+	return image && image.length > 0 ? image : undefined;
 }
 
 const DATE_ONLY_REGEX = /^\d{4}-\d{2}-\d{2}$/;

--- a/src/types/elections.ts
+++ b/src/types/elections.ts
@@ -115,10 +115,11 @@ export interface FindByRaceIdResponse {
 		occupation?: string;
 		funFact?: string;
 		party?: string;
-		pastExperience?: string;
+		pastExperience?: string | Record<string, string>;
 		website?: string;
+		pledged?: boolean;
 		runningAgainst?: Array<{ name: string; party: string; description: string }>;
-		customIssues?: Array<{ title: string; description: string }>;
+		customIssues?: Array<{ title: string; description?: string; position?: string }>;
 	} | null;
 	updatedAt: string;
 	website: {

--- a/src/ui/ProfileHero.mdx
+++ b/src/ui/ProfileHero.mdx
@@ -9,18 +9,20 @@ import * as ProfileHeroStories from './ProfileHero.stories';
 
 ## Overview
 
-The ProfileHero component displays a candidate's profile header with their name, office title, profile image (with optional GoodParty badge overlay), and "Empowered by GoodParty.org" attribution. It's designed for candidate profile pages.
+The ProfileHero component displays a candidate's profile header with their name, office title, profile image, and optional GoodParty branding. When `isEmpowered` is true, it shows the logo badge on the avatar and the "Empowered by GoodParty.org" attribution.
 
 ## Usage
 
 Use this component when:
 - Displaying the hero section on candidate profile pages
-- Showing candidate information with GoodParty branding
+- Showing candidate information with GoodParty branding for claimed product users
 - Providing visual identification of GoodParty-empowered candidates
 
 ## Variants
 
 <Canvas of={ProfileHeroStories.DefaultStory} />
+
+<Canvas of={ProfileHeroStories.Unclaimed} />
 
 <Canvas of={ProfileHeroStories.CreamBackground} />
 
@@ -46,9 +48,23 @@ The office or position the candidate is running for or holds.
 
 #### `profileImage` (optional)
 
-The candidate's profile image. Can be a SanityImage object.
+The candidate's profile image as a Sanity image object. Used on CMS-driven pages.
 
 **Type:** `SanityImage`
+
+#### `profileImageUrl` (optional)
+
+The candidate's profile image as a hosted URL. Used on dynamic candidate profile pages from the Elections API.
+
+**Type:** `string`
+
+#### `isEmpowered` (optional)
+
+When true, shows the GoodParty logo badge on the avatar and the "Empowered by GoodParty.org" attribution. Set from claimed campaign lookup on candidate profile pages.
+
+**Type:** `boolean`
+
+**Default:** `false`
 
 #### `backgroundColor` (optional)
 
@@ -73,30 +89,26 @@ The component uses a responsive flex layout:
 
 ## Avatar and Badge
 
-When `profileImage` is provided:
-- Image is displayed in a circular container with a red ring border (`ring-4 ring-red-500`)
-- GoodParty logo badge is positioned absolutely at bottom-right of avatar
-- Badge size is responsive: `w-16 h-12` on mobile, `w-20 md:h-15` on tablet, `w-24 lg:h-18` on desktop
+When a profile image is provided (`profileImageUrl` or `profileImage`):
+- Image is displayed in a circular container
+- The GoodParty logo badge overlays the avatar only when `isEmpowered` is true
 - Avatar size is responsive: `w-48 h-48` on mobile, `w-56 md:h-56` on tablet, `w-64 lg:h-64` on desktop
 
 ## Attribution
 
-The component always displays "Empowered by GoodParty.org" text with a heart icon:
-- Positioned below the office title
-- Includes an SVG heart icon
-- Text color adapts to background variant (white on midnight, dark on cream)
+When `isEmpowered` is true, the component displays "Empowered by GoodParty.org" with the GoodParty logo below the office title. Text color adapts to the background variant (white on midnight, dark on cream).
 
 ## Image Fallback
 
-If `profileImage` is not provided, the avatar section is not rendered. Only the text content (name, office, attribution) is displayed.
+If no profile image is provided, a generic person icon placeholder is rendered inside the circular avatar container.
 
 ## Accessibility
 
 - Uses semantic `<section>` element
-- Main heading uses `heading-lg` style type
+- Main heading uses `heading-lg` or `heading-md` style type depending on name length
 - Office title uses `subtitle-1` style type
 - Attribution text uses `body-2` style type
-- Image includes proper alt text handling via ResponsiveImage component
+- Image includes alt text derived from the candidate name
 
 ## Design Reference
 
@@ -105,5 +117,5 @@ If `profileImage` is not provided, the avatar section is not rendered. Only the 
 ## Related Components
 
 - `ProfileContentBlock` - Content section that follows ProfileHero
-- `ResponsiveImage` - Image component used for profile images
-- `Logo` - GoodParty logo component used for badge
+- `ResponsiveImage` - Image component used for Sanity profile images
+- `Logo` - GoodParty logo component used for badge and attribution

--- a/src/ui/ProfileHero.stories.tsx
+++ b/src/ui/ProfileHero.stories.tsx
@@ -58,6 +58,16 @@ export const LongName: Story = {
 	},
 };
 
+export const Unclaimed: Story = {
+	args: {
+		...Default.args,
+		isEmpowered: false,
+	},
+	parameters: {
+		...Default.parameters,
+	},
+};
+
 export const Mobile: Story = {
 	args: {
 		...Default.args,

--- a/src/ui/ProfileHero.tsx
+++ b/src/ui/ProfileHero.tsx
@@ -96,7 +96,9 @@ export function ProfileHero(props: ProfileHeroProps) {
 								</div>
 							)}
 						</div>
-						<Logo width={80} height={65} className={badge()} />
+						{props.isEmpowered && (
+							<Logo width={80} height={65} className={badge()} />
+						)}
 					</div>
 					<div className={content()}>
 						<div>
@@ -108,12 +110,12 @@ export function ProfileHero(props: ProfileHeroProps) {
 							</Text>
 						</div>
 						{props.isEmpowered && (
-						<div className={attribution()}>
-							<Logo className={attributionIcon()} />
-							<Text as="span" styleType="body-2" className={attributionText()}>
-								Empowered by GoodParty.org
-							</Text>
-						</div>
+							<div className={attribution()}>
+								<Logo className={attributionIcon()} />
+								<Text as="span" styleType="body-2" className={attributionText()}>
+									Empowered by GoodParty.org
+								</Text>
+							</div>
 						)}
 					</div>
 				</div>


### PR DESCRIPTION
- Added new environment variables for Elections API and GoodParty API in .env.example.
- Refactored candidate profile handling in page.tsx to utilize new helper functions for resolving claimed text fields and profile images.
- Updated elections API functions to use the new base URLs for fetching race and candidacy data.
- Improved helper functions for normalizing candidate names and resolving claimed campaign details.
- Enhanced ProfileHero component to conditionally display GoodParty branding based on empowerment status.
- Added tests for new helper functions to ensure correct behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Claimed-campaign lookup now depends on correct GP API base URL and name normalization; wrong env config could break empowerment state and profile copy, but changes are localized to elections/candidate surfaces with tests for helpers.
> 
> **Overview**
> Wires **Elections API** and **GP API** separately: election data uses configurable `ELECTIONS_API_BASE_URL`, while **claimed campaign** lookup moves to `GP_API_BASE_URL` (auto-derived from election-api → gp-api unless overridden).
> 
> **Candidate profiles** merge Elections API candidacies with gp-api `public-campaigns` via shared `loadClaimedCampaignForCandidate`, using new resolvers for bios (elections `about` then claimed occupation), images, `pastExperience` (string or JSON object), and custom issues (`description` or `position`). **Metadata** now loads claimed data and race info for richer descriptions and Open Graph images.
> 
> **ProfileHero** only shows GoodParty avatar badge and “Empowered by GoodParty.org” when `isEmpowered` (claimed campaign present). Docs/stories add an unclaimed variant.
> 
> Minor: `isCityOrTownMtfcc` is imported from `electionsApi` on the city elections page; types and unit tests cover the new helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2cf79f33e7ed7cca2b530fb3af77d5503ec0140d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->