### PR TITLE
feat: add FAQ detail pages with link-style landing list

### DIFF
--- a/src/PageSections/FAQBlockSection.tsx
+++ b/src/PageSections/FAQBlockSection.tsx
@@ -1,5 +1,7 @@
 import { stegaClean } from 'next-sanity';
 import { transformButtons } from '~/lib/buttonTransformer';
+import { FAQ_PAGE_SLUG } from '~/lib/faqSlugs';
+import { getCachedFaqSlugMap } from '~/lib/getCachedFaqSlugMap';
 import type { Sections } from '~/PageSections';
 import { resolveFAQItems } from '~/ui/_lib/resolveFAQItems';
 import { resolveFAQItemsAsText } from '~/lib/resolveFAQItemsAsText';
@@ -8,13 +10,21 @@ import { RichData } from '~/ui/RichData';
 import { PageSchema } from '~/ui/PageSchema';
 import { buildFAQSchema } from '~/lib/schema';
 
-export function FAQBlockSection(section: Extract<Sections, { _type: 'component_faqBlock' }>) {
+type FAQBlockSectionProps = Extract<Sections, { _type: 'component_faqBlock' }> & {
+	pageSlug?: string;
+};
+
+export async function FAQBlockSection(section: FAQBlockSectionProps) {
 	const sourceFaqs = (section.faQsContentCollection?.['faQs'] ?? null) as Parameters<typeof resolveFAQItemsAsText>[0];
-	const faqSchema = buildFAQSchema(resolveFAQItemsAsText(sourceFaqs));
+	const isFaqLandingPage = section.pageSlug === FAQ_PAGE_SLUG;
+	const slugMap = isFaqLandingPage ? await getCachedFaqSlugMap() : undefined;
+	const faqSchema = isFaqLandingPage ? null : buildFAQSchema(resolveFAQItemsAsText(sourceFaqs));
+
 	return (
 		<section id={stegaClean(section.componentSettings?.field_anchorId)} data-section='FAQ Block'>
 			<PageSchema schema={faqSchema ?? undefined} />
 			<FAQBlock
+				variant={isFaqLandingPage ? 'links' : 'accordion'}
 				header={{
 					label: section.summaryInfo?.field_label,
 					title: section.summaryInfo?.field_title,
@@ -22,7 +32,10 @@ export function FAQBlockSection(section: Extract<Sections, { _type: 'component_f
 					caption: section.summaryInfo?.field_caption,
 					buttons: transformButtons(section.summaryInfo?.list_buttons),
 				}}
-				items={resolveFAQItems(section.faQsContentCollection?.['faQs'])}
+				items={resolveFAQItems(section.faQsContentCollection?.['faQs'], {
+					linksOnly: isFaqLandingPage,
+					slugMap,
+				})}
 			/>
 		</section>
 	);

--- a/src/PageSections/FAQBlockSection.tsx
+++ b/src/PageSections/FAQBlockSection.tsx
@@ -1,7 +1,6 @@
 import { stegaClean } from 'next-sanity';
 import { transformButtons } from '~/lib/buttonTransformer';
 import { FAQ_PAGE_SLUG } from '~/lib/faqSlugs';
-import { getCachedFaqSlugMap } from '~/lib/getCachedFaqSlugMap';
 import type { Sections } from '~/PageSections';
 import { resolveFAQItems } from '~/ui/_lib/resolveFAQItems';
 import { resolveFAQItemsAsText } from '~/lib/resolveFAQItemsAsText';
@@ -12,12 +11,13 @@ import { buildFAQSchema } from '~/lib/schema';
 
 type FAQBlockSectionProps = Extract<Sections, { _type: 'component_faqBlock' }> & {
 	pageSlug?: string;
+	faqSlugMap?: ReadonlyMap<string, string>;
 };
 
-export async function FAQBlockSection(section: FAQBlockSectionProps) {
+export function FAQBlockSection(section: FAQBlockSectionProps) {
 	const sourceFaqs = (section.faQsContentCollection?.['faQs'] ?? null) as Parameters<typeof resolveFAQItemsAsText>[0];
 	const isFaqLandingPage = section.pageSlug === FAQ_PAGE_SLUG;
-	const slugMap = isFaqLandingPage ? await getCachedFaqSlugMap() : undefined;
+	const slugMap = isFaqLandingPage ? section.faqSlugMap : undefined;
 	const faqSchema = isFaqLandingPage ? null : buildFAQSchema(resolveFAQItemsAsText(sourceFaqs));
 
 	return (

--- a/src/PageSections/index.tsx
+++ b/src/PageSections/index.tsx
@@ -80,6 +80,7 @@ export type SectionOverrides = {
 type Props = {
 	pageSections?: Sections[] | null;
 	sectionOverrides?: SectionOverrides;
+	pageSlug?: string;
 };
 
 export function PageSections(props: Props) {
@@ -190,7 +191,7 @@ export function PageSections(props: Props) {
 					case 'component_faqBlock':
 						return (
 							<ComponentErrorBoundary key={section._key} componentName='FAQ Block'>
-								<FAQBlockSection {...section} />
+								<FAQBlockSection {...section} pageSlug={props.pageSlug} />
 							</ComponentErrorBoundary>
 						);
 					case 'component_featuredBlogBlock':

--- a/src/PageSections/index.tsx
+++ b/src/PageSections/index.tsx
@@ -81,6 +81,7 @@ type Props = {
 	pageSections?: Sections[] | null;
 	sectionOverrides?: SectionOverrides;
 	pageSlug?: string;
+	faqSlugMap?: ReadonlyMap<string, string>;
 };
 
 export function PageSections(props: Props) {
@@ -191,7 +192,7 @@ export function PageSections(props: Props) {
 					case 'component_faqBlock':
 						return (
 							<ComponentErrorBoundary key={section._key} componentName='FAQ Block'>
-								<FAQBlockSection {...section} pageSlug={props.pageSlug} />
+								<FAQBlockSection {...section} pageSlug={props.pageSlug} faqSlugMap={props.faqSlugMap} />
 							</ComponentErrorBoundary>
 						);
 					case 'component_featuredBlogBlock':

--- a/src/app/[slug]/page.tsx
+++ b/src/app/[slug]/page.tsx
@@ -11,6 +11,7 @@ import type { Params } from '~/lib/types';
 import { RichTextContentSections } from '~/RichTextContentSections';
 import { PageSections } from '~/PageSections';
 import { ExperimentResolver } from '~/experiments/ExperimentResolver';
+import { getFaqSlugMapForPage } from '~/lib/getCachedFaqSlugMap';
 import { HeaderBlock } from '~/ui/HeaderBlock';
 import { Container } from '~/ui/Container';
 import { PageSchema } from '~/ui/PageSchema';
@@ -49,6 +50,7 @@ export default async function Page(props: any) {
 
 	if (page._type === SANITY_DOC_TYPE.LANDING_PAGE) {
 		const controlSections = page.pageSections?.list_pageSections;
+		const faqSlugMap = await getFaqSlugMapForPage(slug);
 		const landingName = page.detailPageOverviewNoHero?.field_pageName
 			? stegaClean(page.detailPageOverviewNoHero.field_pageName)
 			: slug;
@@ -60,8 +62,8 @@ export default async function Page(props: any) {
 		return (
 			<>
 				<PageSchema schema={landingSchema} />
-				<Suspense fallback={<PageSections pageSections={controlSections} pageSlug={slug} />}>
-					<ExperimentResolver pageId={page._id} controlSections={controlSections} pageSlug={slug} />
+				<Suspense fallback={<PageSections pageSections={controlSections} pageSlug={slug} faqSlugMap={faqSlugMap} />}>
+					<ExperimentResolver pageId={page._id} controlSections={controlSections} pageSlug={slug} faqSlugMap={faqSlugMap} />
 				</Suspense>
 			</>
 		);

--- a/src/app/[slug]/page.tsx
+++ b/src/app/[slug]/page.tsx
@@ -60,8 +60,8 @@ export default async function Page(props: any) {
 		return (
 			<>
 				<PageSchema schema={landingSchema} />
-				<Suspense fallback={<PageSections pageSections={controlSections} />}>
-					<ExperimentResolver pageId={page._id} controlSections={controlSections} />
+				<Suspense fallback={<PageSections pageSections={controlSections} pageSlug={slug} />}>
+					<ExperimentResolver pageId={page._id} controlSections={controlSections} pageSlug={slug} />
 				</Suspense>
 			</>
 		);

--- a/src/app/frequently-asked-questions/[faqSlug]/page.tsx
+++ b/src/app/frequently-asked-questions/[faqSlug]/page.tsx
@@ -2,8 +2,7 @@ import type { Metadata, ResolvingMetadata } from 'next';
 import { notFound } from 'next/navigation';
 import { stegaClean } from 'next-sanity';
 import { allFaqsQuery } from '~/sanity/groq';
-import { sanityFetch } from '~/sanity/sanityClient';
-import { client } from '~/lib/client';
+import { sanityClient, sanityFetch } from '~/sanity/sanityClient';
 import { StructureMetaData } from '~/components/StructureMetadata';
 import type { Params } from '~/lib/types';
 import { FAQ_BASE_PATH, FAQ_PAGE_LABEL, findFaqBySlug, getAllFaqSlugs, getFaqHref, buildFaqSlugMap } from '~/lib/faqSlugs';
@@ -18,8 +17,8 @@ import { ArrowShortIcon } from '~/ui/icons/ArrowShortIcon';
 import { cn } from '~/ui/_lib/utils';
 
 export async function generateStaticParams() {
-	const faqs = await client.fetch<Array<{ _id: string; faqOverview?: { field_question?: string } }>>(allFaqsQuery);
-	return getAllFaqSlugs(faqs).map(faqSlug => ({ faqSlug }));
+	const faqs = await sanityClient.fetch(allFaqsQuery, {}, { perspective: 'published', next: { tags: ['faq'] } });
+	return getAllFaqSlugs(faqs ?? []).map(faqSlug => ({ faqSlug }));
 }
 
 export default async function Page(props: Params) {

--- a/src/app/frequently-asked-questions/[faqSlug]/page.tsx
+++ b/src/app/frequently-asked-questions/[faqSlug]/page.tsx
@@ -1,0 +1,112 @@
+import type { Metadata, ResolvingMetadata } from 'next';
+import { notFound } from 'next/navigation';
+import { stegaClean } from 'next-sanity';
+import { allFaqsQuery } from '~/sanity/groq';
+import { sanityFetch } from '~/sanity/sanityClient';
+import { client } from '~/lib/client';
+import { StructureMetaData } from '~/components/StructureMetadata';
+import type { Params } from '~/lib/types';
+import { FAQ_BASE_PATH, FAQ_PAGE_LABEL, findFaqBySlug, getAllFaqSlugs, getFaqHref, buildFaqSlugMap } from '~/lib/faqSlugs';
+import { resolveFAQItemsAsText } from '~/lib/resolveFAQItemsAsText';
+import { buildFAQSchema } from '~/lib/schema';
+import { Anchor } from '~/ui/Anchor';
+import { RichData } from '~/ui/RichData';
+import { Container } from '~/ui/Container';
+import { Text } from '~/ui/Text';
+import { PageSchema } from '~/ui/PageSchema';
+import { ArrowShortIcon } from '~/ui/icons/ArrowShortIcon';
+import { cn } from '~/ui/_lib/utils';
+
+export async function generateStaticParams() {
+	const faqs = await client.fetch<Array<{ _id: string; faqOverview?: { field_question?: string } }>>(allFaqsQuery);
+	return getAllFaqSlugs(faqs).map(faqSlug => ({ faqSlug }));
+}
+
+export default async function Page(props: Params) {
+	const faqSlug = (await props.params)['faqSlug'];
+
+	if (!faqSlug) {
+		notFound();
+	}
+
+	const faqs = await sanityFetch({
+		query: allFaqsQuery,
+		tags: ['faq'],
+	});
+
+	const faq = findFaqBySlug(faqs ?? [], faqSlug);
+	if (!faq) {
+		notFound();
+	}
+
+	const faqTextItems = resolveFAQItemsAsText([faq]);
+	const faqSchema = buildFAQSchema(faqTextItems);
+	const question = faq.faqOverview?.field_question ? stegaClean(faq.faqOverview.field_question) : undefined;
+
+	return (
+		<>
+			<PageSchema schema={faqSchema ?? undefined} />
+			<div className='bg-goodparty-cream'>
+				<Container size='xl' className='pt-4 pb-(--container-padding) flex flex-col gap-6'>
+					<Anchor
+						href={FAQ_BASE_PATH}
+						className='group inline-flex items-center gap-2 text-sm text-neutral-500 hover:text-black transition-colors w-fit'
+					>
+						<ArrowShortIcon
+							size={24}
+							className='rotate-180 flex-shrink-0'
+							innerClassName='group-hover:animate-slide-in-right'
+						/>
+						{FAQ_PAGE_LABEL}
+					</Anchor>
+					{question && (
+						<Text as='h1' styleType='heading-xl'>
+							{question}
+						</Text>
+					)}
+					<Text
+						as='div'
+						styleType='body-1'
+						className={cn(
+							'flex flex-col gap-6 max-w-[43.75rem]',
+							`[&_ul:not([class])]:pl-8 [&_ul:not([class])]:list-disc [&_ul:not([class])_ul]:mt-2 [&_ul:not([class])_li]:mb-[0.5em] [&_ol:not([class])]:list-none [&_ol:not([class])]:[counter-reset:section] [&_ol:not([class])_ol]:mt-2 [&_ol:not([class])_li]:pl-8 [&_ol:not([class])_li]:mb-[0.5em] [&_ol:not([class])_li]:[counter-increment:section] [&_ol:not([class])_li]:before:[content:counters(section,'.')] [&_ol:not([class])_li]:before:mr-3 [&_ol:not([class])_li]:before:font-medium`,
+						)}
+					>
+						<RichData value={faq.faqOverview?.block_answer} />
+					</Text>
+				</Container>
+			</div>
+		</>
+	);
+}
+
+export async function generateMetadata(props: Params, parent: ResolvingMetadata): Promise<Metadata> {
+	const faqSlug = (await props.params)['faqSlug'];
+	const parentMetadata = await parent;
+
+	const faqs = await sanityFetch({
+		query: allFaqsQuery,
+		tags: ['faq'],
+	});
+	const faq = findFaqBySlug(faqs ?? [], faqSlug);
+	if (!faq) {
+		return StructureMetaData(parentMetadata, null);
+	}
+
+	const slugMap = buildFaqSlugMap(faqs ?? []);
+	const pageUrl = getFaqHref(faq, slugMap);
+	const question = faq.faqOverview?.field_question
+		? stegaClean(faq.faqOverview.field_question)
+		: undefined;
+	const answerText = resolveFAQItemsAsText([faq])[0]?.copy;
+	const description = answerText && answerText.length > 160 ? `${answerText.slice(0, 157)}...` : answerText;
+
+	return StructureMetaData(parentMetadata, {
+		name: question,
+		seo: {
+			field_metaTitle: question,
+			field_metaDescription: description,
+		},
+		url: pageUrl,
+	});
+}

--- a/src/experiments/ExperimentResolver.tsx
+++ b/src/experiments/ExperimentResolver.tsx
@@ -2,17 +2,20 @@ import type { Sections } from '~/PageSections';
 import { PageSections, type SectionOverrides } from '~/PageSections';
 import { ExperimentExposureTracker } from '~/experiments/ExperimentExposureTracker';
 import { resolvePageExperiments } from '~/experiments/resolvePageExperiments';
+import { getFaqSlugMapForPage } from '~/lib/getCachedFaqSlugMap';
 
 export async function ExperimentResolver(props: {
 	pageId: string;
 	controlSections?: Sections[] | null;
 	sectionOverrides?: SectionOverrides;
 	pageSlug?: string;
+	faqSlugMap?: ReadonlyMap<string, string>;
 }) {
 	const result = await resolvePageExperiments({
 		pageId: props.pageId,
 		controlSections: props.controlSections,
 	});
+	const faqSlugMap = props.faqSlugMap ?? (await getFaqSlugMapForPage(props.pageSlug));
 
 	return (
 		<>
@@ -23,6 +26,7 @@ export async function ExperimentResolver(props: {
 				pageSections={result.pageSections}
 				sectionOverrides={props.sectionOverrides}
 				pageSlug={props.pageSlug}
+				faqSlugMap={faqSlugMap}
 			/>
 		</>
 	);

--- a/src/experiments/ExperimentResolver.tsx
+++ b/src/experiments/ExperimentResolver.tsx
@@ -7,6 +7,7 @@ export async function ExperimentResolver(props: {
 	pageId: string;
 	controlSections?: Sections[] | null;
 	sectionOverrides?: SectionOverrides;
+	pageSlug?: string;
 }) {
 	const result = await resolvePageExperiments({
 		pageId: props.pageId,
@@ -18,7 +19,11 @@ export async function ExperimentResolver(props: {
 			{result.exposures.map((exp) => (
 				<ExperimentExposureTracker key={exp.flagKey} flagKey={exp.flagKey} variant={exp.variant} />
 			))}
-			<PageSections pageSections={result.pageSections} sectionOverrides={props.sectionOverrides} />
+			<PageSections
+				pageSections={result.pageSections}
+				sectionOverrides={props.sectionOverrides}
+				pageSlug={props.pageSlug}
+			/>
 		</>
 	);
 }

--- a/src/lib/faqSlugs.test.ts
+++ b/src/lib/faqSlugs.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import {
+	buildFaqSlugMap,
+	findFaqBySlug,
+	getAllFaqSlugs,
+	getFaqHref,
+	slugifyFaqQuestion,
+} from './faqSlugs';
+
+describe('slugifyFaqQuestion', () => {
+	it('normalizes question text into a URL slug', () => {
+		expect(slugifyFaqQuestion('What is GoodParty.org?')).toBe('what-is-goodpartyorg');
+		expect(slugifyFaqQuestion('How do I run for city council?')).toBe('how-do-i-run-for-city-council');
+	});
+
+	it('trims and collapses whitespace', () => {
+		expect(slugifyFaqQuestion('  City   Council  ')).toBe('city-council');
+	});
+});
+
+describe('buildFaqSlugMap', () => {
+	it('resolves hrefs after Map is serialized and reconstructed (unstable_cache round-trip)', () => {
+		const faqs = [
+			{ _id: 'abc123', faqOverview: { field_question: 'What is GoodParty.org?' } },
+		];
+		const serialized = Object.fromEntries(buildFaqSlugMap(faqs));
+		const restoredMap = new Map(Object.entries(serialized));
+
+		expect(getFaqHref(faqs[0]!, restoredMap)).toBe('/frequently-asked-questions/what-is-goodpartyorg');
+	});
+
+	it('assigns unique slugs and resolves collisions with id suffix', () => {
+		const faqs = [
+			{ _id: 'abc123', faqOverview: { field_question: 'What is GoodParty.org?' } },
+			{ _id: 'def456', faqOverview: { field_question: 'What is GoodParty.org?' } },
+		];
+
+		const slugMap = buildFaqSlugMap(faqs);
+		const slugs = getAllFaqSlugs(faqs);
+
+		expect(slugs).toHaveLength(2);
+		expect(new Set(slugs).size).toBe(2);
+		expect(slugs[0]).toBe('what-is-goodpartyorg');
+		expect(slugs[1]).toBe('what-is-goodpartyorg-def456');
+		expect(getFaqHref(faqs[0]!, slugMap)).toBe('/frequently-asked-questions/what-is-goodpartyorg');
+	});
+});
+
+describe('findFaqBySlug', () => {
+	const faqs = [
+		{ _id: 'abc123', faqOverview: { field_question: 'What is the pledge?' } },
+		{ _id: 'def456', faqOverview: { field_question: 'How much does it cost?' } },
+	];
+
+	it('finds FAQ by computed slug', () => {
+		const found = findFaqBySlug(faqs, 'what-is-the-pledge');
+		expect(found?._id).toBe('abc123');
+	});
+
+	it('finds FAQ by raw _id fallback', () => {
+		const found = findFaqBySlug(faqs, 'def456');
+		expect(found?._id).toBe('def456');
+	});
+
+	it('returns undefined for unknown slug', () => {
+		expect(findFaqBySlug(faqs, 'does-not-exist')).toBeUndefined();
+	});
+});

--- a/src/lib/faqSlugs.test.ts
+++ b/src/lib/faqSlugs.test.ts
@@ -44,6 +44,59 @@ describe('buildFaqSlugMap', () => {
 		expect(slugs[1]).toBe('what-is-goodpartyorg-def456');
 		expect(getFaqHref(faqs[0]!, slugMap)).toBe('/frequently-asked-questions/what-is-goodpartyorg');
 	});
+
+	it('assigns unique slugs for three duplicate questions', () => {
+		const faqs = [
+			{ _id: 'abc123', faqOverview: { field_question: 'What is GoodParty.org?' } },
+			{ _id: 'def456', faqOverview: { field_question: 'What is GoodParty.org?' } },
+			{ _id: 'ghi789', faqOverview: { field_question: 'What is GoodParty.org?' } },
+		];
+
+		const slugs = getAllFaqSlugs(faqs);
+
+		expect(slugs).toHaveLength(3);
+		expect(new Set(slugs).size).toBe(3);
+		expect(slugs[0]).toBe('what-is-goodpartyorg');
+		expect(slugs[1]).toBe('what-is-goodpartyorg-def456');
+		expect(slugs[2]).toBe('what-is-goodpartyorg-ghi789');
+
+		for (let i = 0; i < faqs.length; i++) {
+			expect(findFaqBySlug(faqs, slugs[i]!)?._id).toBe(faqs[i]!._id);
+		}
+	});
+
+	it('resolves suffix collision when another question slugifies to the suffixed form', () => {
+		const faqs = [
+			{ _id: 'aaa111', faqOverview: { field_question: 'What is GoodParty.org?' } },
+			{ _id: 'bbb222', faqOverview: { field_question: 'What is GoodParty.org?' } },
+			{ _id: 'ccc333', faqOverview: { field_question: 'What is GoodParty.org bbb222' } },
+		];
+
+		const slugs = getAllFaqSlugs(faqs);
+
+		expect(slugs).toHaveLength(3);
+		expect(new Set(slugs).size).toBe(3);
+		expect(slugs[0]).toBe('what-is-goodpartyorg');
+		expect(slugs[1]).toBe('what-is-goodpartyorg-bbb222');
+		expect(slugs[2]).toBe('what-is-goodpartyorg-bbb222-ccc333');
+
+		for (let i = 0; i < faqs.length; i++) {
+			expect(findFaqBySlug(faqs, slugs[i]!)?._id).toBe(faqs[i]!._id);
+		}
+	});
+
+	it('assigns base slug to the first FAQ in array order', () => {
+		const faqsForward = [
+			{ _id: 'abc123', faqOverview: { field_question: 'What is GoodParty.org?' } },
+			{ _id: 'def456', faqOverview: { field_question: 'What is GoodParty.org?' } },
+		];
+		const faqsReversed = [...faqsForward].reverse();
+
+		expect(getAllFaqSlugs(faqsForward)[0]).toBe('what-is-goodpartyorg');
+		expect(getAllFaqSlugs(faqsReversed)[0]).toBe('what-is-goodpartyorg');
+		expect(getAllFaqSlugs(faqsForward)[1]).toBe('what-is-goodpartyorg-def456');
+		expect(getAllFaqSlugs(faqsReversed)[1]).toBe('what-is-goodpartyorg-abc123');
+	});
 });
 
 describe('findFaqBySlug', () => {

--- a/src/lib/faqSlugs.ts
+++ b/src/lib/faqSlugs.ts
@@ -1,0 +1,78 @@
+import { stegaClean } from 'next-sanity';
+
+export const FAQ_PAGE_SLUG = 'frequently-asked-questions';
+export const FAQ_PAGE_LABEL = 'Frequently Asked Questions';
+export const FAQ_BASE_PATH = `/${FAQ_PAGE_SLUG}`;
+
+export type FaqLike = {
+	_id: string;
+	faqOverview?: {
+		field_question?: unknown;
+	} | null;
+};
+
+export function slugifyFaqQuestion(question: string): string {
+	return question
+		.toLowerCase()
+		.replace(/[^a-z0-9\s-]/g, '')
+		.replace(/\s+/g, '-')
+		.replace(/-+/g, '-')
+		.replace(/^-|-$/g, '');
+}
+
+function readQuestion(faq: FaqLike): string {
+	const raw = faq.faqOverview?.field_question;
+	if (typeof raw !== 'string') return '';
+	const cleaned = stegaClean(raw);
+	return typeof cleaned === 'string' ? cleaned.trim() : '';
+}
+
+function shortIdSuffix(id: string): string {
+	const normalized = id.replace(/^drafts\./, '');
+	return normalized.slice(-6).toLowerCase();
+}
+
+export function buildFaqSlugMap(faqs: ReadonlyArray<FaqLike>): Map<string, string> {
+	const slugToId = new Map<string, string>();
+	const idToSlug = new Map<string, string>();
+
+	for (const faq of faqs) {
+		const question = readQuestion(faq);
+		const baseSlug = question ? slugifyFaqQuestion(question) : '';
+		let slug = baseSlug || faq._id.replace(/^drafts\./, '');
+
+		if (slugToId.has(slug) && slugToId.get(slug) !== faq._id) {
+			slug = `${slug}-${shortIdSuffix(faq._id)}`;
+		}
+
+		slugToId.set(slug, faq._id);
+		idToSlug.set(faq._id, slug);
+	}
+
+	return idToSlug;
+}
+
+export function getFaqSlug(faq: FaqLike, slugMap: ReadonlyMap<string, string>): string {
+	return slugMap.get(faq._id) ?? faq._id.replace(/^drafts\./, '');
+}
+
+export function getFaqHref(faq: FaqLike, slugMap: ReadonlyMap<string, string>): string {
+	return `${FAQ_BASE_PATH}/${getFaqSlug(faq, slugMap)}`;
+}
+
+export function findFaqBySlug(faqs: ReadonlyArray<FaqLike>, slug: string): FaqLike | undefined {
+	const direct = faqs.find(faq => faq._id === slug || faq._id === `drafts.${slug}`);
+	if (direct) return direct;
+
+	const slugMap = buildFaqSlugMap(faqs);
+	for (const faq of faqs) {
+		if (getFaqSlug(faq, slugMap) === slug) return faq;
+	}
+
+	return undefined;
+}
+
+export function getAllFaqSlugs(faqs: ReadonlyArray<FaqLike>): string[] {
+	const slugMap = buildFaqSlugMap(faqs);
+	return faqs.map(faq => getFaqSlug(faq, slugMap));
+}

--- a/src/lib/faqSlugs.ts
+++ b/src/lib/faqSlugs.ts
@@ -41,7 +41,7 @@ export function buildFaqSlugMap(faqs: ReadonlyArray<FaqLike>): Map<string, strin
 		const baseSlug = question ? slugifyFaqQuestion(question) : '';
 		let slug = baseSlug || faq._id.replace(/^drafts\./, '');
 
-		if (slugToId.has(slug) && slugToId.get(slug) !== faq._id) {
+		while (slugToId.has(slug) && slugToId.get(slug) !== faq._id) {
 			slug = `${slug}-${shortIdSuffix(faq._id)}`;
 		}
 

--- a/src/lib/getCachedFaqSlugMap.ts
+++ b/src/lib/getCachedFaqSlugMap.ts
@@ -1,6 +1,6 @@
 import { unstable_cache } from 'next/cache';
 import { defaultRevalidate } from '~/lib/env';
-import { buildFaqSlugMap } from '~/lib/faqSlugs';
+import { FAQ_PAGE_SLUG, buildFaqSlugMap } from '~/lib/faqSlugs';
 import { allFaqsQuery } from '~/sanity/groq';
 import { sanityClient } from '~/sanity/sanityClient';
 
@@ -16,4 +16,9 @@ const getCachedFaqs = unstable_cache(
 export async function getCachedFaqSlugMap(): Promise<Map<string, string>> {
 	const faqs = await getCachedFaqs();
 	return buildFaqSlugMap(faqs);
+}
+
+export async function getFaqSlugMapForPage(pageSlug?: string): Promise<Map<string, string> | undefined> {
+	if (pageSlug !== FAQ_PAGE_SLUG) return undefined;
+	return getCachedFaqSlugMap();
 }

--- a/src/lib/getCachedFaqSlugMap.ts
+++ b/src/lib/getCachedFaqSlugMap.ts
@@ -1,12 +1,12 @@
 import { unstable_cache } from 'next/cache';
 import { defaultRevalidate } from '~/lib/env';
-import { buildFaqSlugMap, type FaqLike } from '~/lib/faqSlugs';
+import { buildFaqSlugMap } from '~/lib/faqSlugs';
 import { allFaqsQuery } from '~/sanity/groq';
 import { sanityClient } from '~/sanity/sanityClient';
 
 const getCachedFaqs = unstable_cache(
 	async () => {
-		const faqs = await sanityClient.fetch<FaqLike[]>(allFaqsQuery);
+		const faqs = await sanityClient.fetch(allFaqsQuery, {}, { perspective: 'published', next: { tags: ['faq'] } });
 		return faqs ?? [];
 	},
 	['all-faqs-cache-sanity'],

--- a/src/lib/getCachedFaqSlugMap.ts
+++ b/src/lib/getCachedFaqSlugMap.ts
@@ -1,0 +1,19 @@
+import { unstable_cache } from 'next/cache';
+import { defaultRevalidate } from '~/lib/env';
+import { buildFaqSlugMap, type FaqLike } from '~/lib/faqSlugs';
+import { allFaqsQuery } from '~/sanity/groq';
+import { sanityClient } from '~/sanity/sanityClient';
+
+const getCachedFaqs = unstable_cache(
+	async () => {
+		const faqs = await sanityClient.fetch<FaqLike[]>(allFaqsQuery);
+		return faqs ?? [];
+	},
+	['all-faqs-cache-sanity'],
+	{ revalidate: defaultRevalidate, tags: ['faq'] },
+);
+
+export async function getCachedFaqSlugMap(): Promise<Map<string, string>> {
+	const faqs = await getCachedFaqs();
+	return buildFaqSlugMap(faqs);
+}

--- a/src/lib/sitemap-entries.ts
+++ b/src/lib/sitemap-entries.ts
@@ -9,6 +9,7 @@ import {
 	buildElectionPositionHrefFromRaceSlug,
 	stripCountySuffix as stripCountySuffixFromHelpers,
 } from '~/lib/electionsHelpers';
+import { getAllFaqSlugs } from '~/lib/faqSlugs';
 
 /** 51 US state/DC codes (50 states + DC) */
 export const US_STATE_CODES = [
@@ -391,7 +392,7 @@ async function fetchElectionJson<T>(path: string, params: Record<string, string>
 export async function fetchMainSitemapEntries(baseUrl: string): Promise<MetadataRoute.Sitemap> {
 	const entries: MetadataRoute.Sitemap = [];
 
-	const [singletons, landingAndPolicySlugs, articles, categorySlugs, topicSlugs, glossaryTerms] =
+	const [singletons, landingAndPolicySlugs, articles, categorySlugs, topicSlugs, glossaryTerms, faqs] =
 		await Promise.all([
 			sanityClient.fetch<{
 				home: string | null;
@@ -433,6 +434,11 @@ export async function fetchMainSitemapEntries(baseUrl: string): Promise<Metadata
 				{},
 				{ next: { tags: ['glossary'] } },
 			),
+			sanityClient.fetch<Array<{ _id: string; _updatedAt?: string; faqOverview?: { field_question?: string } }>>(
+				`*[_type == "faq"]{_id,_updatedAt,faqOverview{field_question}}`,
+				{},
+				{ next: { tags: ['faq'] } },
+			),
 		]);
 
 	if (singletons.home) entries.push(toEntry(baseUrl, '/', 1.0, 'monthly'));
@@ -465,6 +471,16 @@ export async function fetchMainSitemapEntries(baseUrl: string): Promise<Metadata
 		if (letter && !seenLetters.has(letter)) {
 			seenLetters.add(letter);
 			entries.push(toEntry(baseUrl, `/political-terms/${letter}`, 0.6, 'monthly'));
+		}
+	}
+
+	const faqSlugs = getAllFaqSlugs(faqs);
+	for (let i = 0; i < faqs.length; i++) {
+		const slug = faqSlugs[i];
+		if (slug) {
+			entries.push(
+				toEntry(baseUrl, `/frequently-asked-questions/${slug}`, 0.6, 'monthly', faqs[i]?._updatedAt?.slice(0, 10)),
+			);
 		}
 	}
 

--- a/src/lib/sitemap-entries.ts
+++ b/src/lib/sitemap-entries.ts
@@ -9,7 +9,8 @@ import {
 	buildElectionPositionHrefFromRaceSlug,
 	stripCountySuffix as stripCountySuffixFromHelpers,
 } from '~/lib/electionsHelpers';
-import { getAllFaqSlugs } from '~/lib/faqSlugs';
+import { FAQ_BASE_PATH, getAllFaqSlugs } from '~/lib/faqSlugs';
+import { allFaqsQuery } from '~/sanity/groq';
 
 /** 51 US state/DC codes (50 states + DC) */
 export const US_STATE_CODES = [
@@ -435,9 +436,9 @@ export async function fetchMainSitemapEntries(baseUrl: string): Promise<Metadata
 				{ next: { tags: ['glossary'] } },
 			),
 			sanityClient.fetch<Array<{ _id: string; _updatedAt?: string; faqOverview?: { field_question?: string } }>>(
-				`*[_type == "faq"]{_id,_updatedAt,faqOverview{field_question}}`,
+				allFaqsQuery,
 				{},
-				{ next: { tags: ['faq'] } },
+				{ perspective: 'published', next: { tags: ['faq'] } },
 			),
 		]);
 
@@ -479,7 +480,7 @@ export async function fetchMainSitemapEntries(baseUrl: string): Promise<Metadata
 		const slug = faqSlugs[i];
 		if (slug) {
 			entries.push(
-				toEntry(baseUrl, `/frequently-asked-questions/${slug}`, 0.6, 'monthly', faqs[i]?._updatedAt?.slice(0, 10)),
+				toEntry(baseUrl, `${FAQ_BASE_PATH}/${slug}`, 0.6, 'monthly', faqs[i]?._updatedAt?.slice(0, 10)),
 			);
 		}
 	}

--- a/src/sanity/groq.ts
+++ b/src/sanity/groq.ts
@@ -302,6 +302,15 @@ export const allArticlesForSearchGroq = `*[_type=="article"] | order(editorialOv
 export const allTermsForSearchGroq = `*[_type=="glossary"] | order(glossaryTermOverview.field_glossaryTerm asc)[]{_id,"title":glossaryTermOverview.field_glossaryTerm,${glossaryTermHrefGroq}}`;
 
 /*language=textmate*/
+export const allFaqsQuery = defineQuery(
+	`*[_type=="faq"] | order(faqOverview.field_question asc){_id,_updatedAt,${faQGroq}}`,
+);
+/*language=textmate*/
+export const faqByIdQuery = defineQuery(
+	`*[_type=="faq"&&_id==$id][0]{_id,_updatedAt,${faQGroq}}`,
+);
+
+/*language=textmate*/
 export const quoteCollectionByIdQuery = defineQuery(
 	`*[_type=="quoteCollections"&&_id==$id][0]{quoteCollectionContent{list_chooseQuotes[]->{_key,quote{field_quote,ref_quoteBy->{_type,personOverview{field_personName,field_jobTitleOrRole,img_profilePicture},organisationOverview{field_organisationName,img_logo}}}}}}`,
 );

--- a/src/ui/FAQBlock.tsx
+++ b/src/ui/FAQBlock.tsx
@@ -13,6 +13,8 @@ import { Container } from './Container.tsx';
 import { IconResolver } from './IconResolver.tsx';
 import { Text } from './Text.tsx';
 import { HeaderBlock, type HeaderBlockProps } from './HeaderBlock.tsx';
+import { Anchor } from './Anchor.tsx';
+import { ArrowShortIcon } from './icons/ArrowShortIcon.tsx';
 
 const styles = tv({
 	slots: {
@@ -20,6 +22,7 @@ const styles = tv({
 		container: 'flex flex-col gap-12',
 		content: 'flex flex-col gap-6',
 		trigger: 'group flex items-center justify-between gap-6 text-left w-full p-6',
+		link: 'group flex items-center justify-between gap-6 text-left w-full p-6 bg-white rounded-lg hover:border-lavender-600 transition-colors',
 		copy: 'p-6 pt-0 text-dark [&>*+*]:mt-4 [&>:empty]:hidden [&_br]:block [&_br]:mt-3',
 	},
 	variants: {
@@ -49,8 +52,9 @@ const styles = tv({
 
 export type FAQBlockItemProps = {
 	id?: string;
-	copy: ReactNode;
+	copy?: ReactNode;
 	title: string;
+	href?: string;
 };
 
 export type FAQBlockProps = {
@@ -65,54 +69,79 @@ export type FAQBlockProps = {
 	caption?: string;
 	header?: HeaderBlockProps;
 	layout?: 'blog' | 'page';
+	variant?: 'accordion' | 'links';
 };
 
 export function FAQBlock(props: FAQBlockProps) {
 	const backgroundColor = props.backgroundColor ?? 'cream';
 	const layout = props.layout ?? 'page';
+	const variant = props.variant ?? 'accordion';
 
-	const { base, container, trigger, copy } = styles({ backgroundColor, layout });
+	const { base, container, trigger, link, copy } = styles({ backgroundColor, layout });
 
 	return (
 		<article className={cn(base(), props.className)} data-component='FAQBlock'>
 			<Container className={container({ hasHeader: !!props.header })} size={layout === 'blog' ? 'unset' : 'xl'}>
 				{props.header && <HeaderBlock {...props.header} backgroundColor={props.backgroundColor} layout='left' />}
-				<Root className={`flex flex-col gap-6`} type='multiple'>
-					{props.items?.map((item, index) => {
-						return (
-							<Item
-								key={`accordion-item-${item.id}-${index}`}
-								value={`accordion-item-${item.id}-${index}`}
-								className={`bg-white rounded-lg data-[state="open"]:bg-background- data-[state="open"]:bg-text-`}
-							>
-								<Header className={`animate-accordion-open`}>
-									<Trigger className={trigger()}>
+				{variant === 'links' ? (
+					<ul className='flex flex-col gap-6'>
+						{props.items?.map((item, index) => (
+							<li key={`faq-link-${item.id}-${index}`}>
+								{item.href ? (
+									<Anchor href={item.href} className={link()}>
 										<Text styleType='subtitle-1'>{item.title}</Text>
-										<div className={`grid transition-transform duration-normal ease-smooth group-data-[state=open]:-scale-y-100`}>
-											<IconResolver
-												icon={'plus'}
-												className={`col-start-1 col-end-1 row-start-1 row-end-1 transition-opacity duration-fast ease-smooth group-data-[state=open]:opacity-0`}
-											/>
-											<IconResolver
-												icon={'minus'}
-												className={`col-start-1 col-end-1 row-start-1 row-end-1 opacity-0 transition-opacity duration-fast ease-smooth group-data-[state=open]:opacity-100`}
-											/>
-										</div>
-									</Trigger>
-								</Header>
-								<Content
-									className={`overflow-hidden data-[state=open]:animate-accordion-open data-[state=closed]:animate-accordion-closed `}
+										<ArrowShortIcon
+											size={32}
+											className='text-neutral-900 flex-shrink-0'
+											innerClassName='group-hover:animate-slide-in-right'
+										/>
+									</Anchor>
+								) : (
+									<div className={link()}>
+										<Text styleType='subtitle-1'>{item.title}</Text>
+									</div>
+								)}
+							</li>
+						))}
+					</ul>
+				) : (
+					<Root className={`flex flex-col gap-6`} type='multiple'>
+						{props.items?.map((item, index) => {
+							return (
+								<Item
+									key={`accordion-item-${item.id}-${index}`}
+									value={`accordion-item-${item.id}-${index}`}
+									className={`bg-white rounded-lg data-[state="open"]:bg-background- data-[state="open"]:bg-text-`}
 								>
-									{isValidRichText(item.copy) && (
-										<Text className={copy()} styleType='body-2'>
-											{item.copy}
-										</Text>
-									)}
-								</Content>
-							</Item>
-						);
-					})}
-				</Root>
+									<Header className={`animate-accordion-open`}>
+										<Trigger className={trigger()}>
+											<Text styleType='subtitle-1'>{item.title}</Text>
+											<div className={`grid transition-transform duration-normal ease-smooth group-data-[state=open]:-scale-y-100`}>
+												<IconResolver
+													icon={'plus'}
+													className={`col-start-1 col-end-1 row-start-1 row-end-1 transition-opacity duration-fast ease-smooth group-data-[state=open]:opacity-0`}
+												/>
+												<IconResolver
+													icon={'minus'}
+													className={`col-start-1 col-end-1 row-start-1 row-end-1 opacity-0 transition-opacity duration-fast ease-smooth group-data-[state=open]:opacity-100`}
+												/>
+											</div>
+										</Trigger>
+									</Header>
+									<Content
+										className={`overflow-hidden data-[state=open]:animate-accordion-open data-[state=closed]:animate-accordion-closed `}
+									>
+										{isValidRichText(item.copy) && (
+											<Text className={copy()} styleType='body-2'>
+												{item.copy}
+											</Text>
+										)}
+									</Content>
+								</Item>
+							);
+						})}
+					</Root>
+				)}
 			</Container>
 		</article>
 	);

--- a/src/ui/_lib/resolveFAQItems.tsx
+++ b/src/ui/_lib/resolveFAQItems.tsx
@@ -1,15 +1,28 @@
+import type { FaqLike } from '~/lib/faqSlugs';
+import { getFaqHref } from '~/lib/faqSlugs';
 import type { FAQBlockItemProps } from '../FAQBlock';
 import { RichData } from '../RichData';
 
-export function resolveFAQItems(items?: any) {
+type ResolveFAQItemsOptions = {
+	slugMap?: ReadonlyMap<string, string>;
+	linksOnly?: boolean;
+};
+
+export function resolveFAQItems(items?: any, options?: ResolveFAQItemsOptions) {
 	if (!items) return [];
 
 	const faqItems: FAQBlockItemProps[] = [];
 	items?.forEach((item: any) => {
+		const href =
+			options?.linksOnly && options.slugMap && item._id
+				? getFaqHref(item as FaqLike, options.slugMap)
+				: undefined;
+
 		faqItems.push({
 			id: item._id,
 			title: item.faqOverview?.field_question,
-			copy: <RichData value={item.faqOverview?.block_answer} />,
+			copy: options?.linksOnly ? undefined : <RichData value={item.faqOverview?.block_answer} />,
+			href,
 		});
 	});
 


### PR DESCRIPTION
- Add individual FAQ detail pages at `/frequently-asked-questions/[faqSlug]`, statically generated from Sanity with per-page metadata, FAQ schema, and a back link to the landing page.
- Convert the FAQ landing page (`/frequently-asked-questions`) to a link-style list instead of an accordion, linking each question to its detail page.
- Introduce FAQ slug utilities (`faqSlugs.ts`) to derive URL-safe slugs from question text, handle collisions, and resolve hrefs consistently.
- Cache the FAQ slug map via `getCachedFaqSlugMap` and pass it through landing page rendering (`PageSections`, `ExperimentResolver`) so experiment variants also get correct links.
- Add FAQ entries to the sitemap and new GROQ queries for fetching all FAQs.
- Add unit tests for slug generation, collision handling, and cache round-trip behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New public routes and slug rules affect SEO and inbound links if questions change; landing FAQ UX and structured data behavior change on the hub only.
> 
> **Overview**
> Adds **per-FAQ detail pages** at `/frequently-asked-questions/[faqSlug]` (static params from Sanity, 404 for unknown slugs, metadata, FAQ JSON-LD, back link to the hub).
> 
> On the **FAQ landing page only**, the FAQ block switches from accordion to a **link list** pointing at those detail URLs; other pages keep accordion + block-level FAQ schema (landing omits aggregate FAQ schema on the hub).
> 
> New **`faqSlugs`** helpers derive URL slugs from question text (with collision suffixes), plus **`getCachedFaqSlugMap`** (`unstable_cache`, `faq` tag) wired through **`[slug]/page`**, **`ExperimentResolver`**, and **`PageSections`** so experiment variants get the same links. **`allFaqsQuery`** / sitemap entries register each detail URL; **`FAQBlock`** gains a `links` variant and **`resolveFAQItems`** optional `href`s.
> 
> Unit tests cover slugify, collisions, lookup, and cache Map round-trip.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2bb61f74d37018482046fdcc6034e4efd43d428. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->