### PR TITLE
Add permanent redirect for city slugs

### DIFF
--- a/src/app/elections/[state]/[county]/page.tsx
+++ b/src/app/elections/[state]/[county]/page.tsx
@@ -1,11 +1,13 @@
 import type { Metadata } from 'next';
-import { notFound, redirect } from 'next/navigation';
+import { notFound, permanentRedirect, redirect } from 'next/navigation';
 import {
 	COUNTY_MTFCC,
 	getCountyChildPlaces,
 	getPlacesByState,
 	getPlaceBySlug,
+	isCityOrTownMtfcc,
 	isDistrictMtfcc,
+	resolveCountySlugForPlace,
 	TOWN_MTFCC,
 } from '~/lib/electionsApi';
 import { isValidStateCode } from '~/constants/usStateCodes';
@@ -84,6 +86,17 @@ export default async function Page({
 		: await getCountyChildPlaces({ state: stateCode, countySlug: fullSlug });
 
 	if (!countyPlace && !isDistrict) {
+		if (placeData && isCityOrTownMtfcc(placeData.mtfcc) && placeData.countyName) {
+			const canonicalCountySlug = await resolveCountySlugForPlace(stateCode, placeData.countyName);
+			if (canonicalCountySlug) {
+				const citySegment =
+					placeData.slug?.split('/').pop()?.toLowerCase() ?? county.toLowerCase();
+				const canonicalCitySlug = `${canonicalCountySlug}/${citySegment}`;
+				if (canonicalCitySlug.toLowerCase() !== fullSlug) {
+					permanentRedirect(`/elections/${canonicalCitySlug}`);
+				}
+			}
+		}
 		if (placeData?.mtfcc && placeData.mtfcc !== COUNTY_MTFCC) {
 			redirect(`/elections/${state.toLowerCase()}`);
 		}


### PR DESCRIPTION

- Introduced permanentRedirect for city slugs to ensure correct URL structure.
- Enhanced county place validation logic to handle city or town MTFCC types.
- Added resolveCountySlugForPlace function to determine canonical county slugs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Routing-only change in the not-found path for non-county URLs; uses existing API helpers and does not alter successful county or district page rendering.
> 
> **Overview**
> When a request hits the **two-segment** elections route (`/elections/[state]/[county]`) with a slug that is a **city or town** rather than a county, the page now **301-redirects** to the canonical URL instead of falling through to state redirect or 404.
> 
> Before the county-not-found branch, it checks `placeData` for city/town MTFCC and `countyName`, uses **`resolveCountySlugForPlace`** to map the county name to the official county slug, rebuilds the path as `{canonicalCountySlug}/{citySegment}`, and calls **`permanentRedirect`** when that path differs from the requested `fullSlug`. Existing behavior for non-county non-city places (redirect to state index) and `notFound()` is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12e7efe52adb1339d7711dac1f0c9b40e56c8f14. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->