### PR TITLE
Fix Mobile Navbar

### DIFF
--- a/src/ui/Nav/MobileNav/index.tsx
+++ b/src/ui/Nav/MobileNav/index.tsx
@@ -32,20 +32,26 @@ export function MobileNav(props: NavProps) {
 						className='min-w-[2.4rem] min-h-[2.7rem] w-[2.4rem] h-[2.7rem] max-w-[2.4rem] max-h-[2.7rem]'
 					/>
 				</Anchor>
-				<div className='flex flex-row gap-[1rem] items-center justify-center w-fit'>
+				<div className='flex flex-row gap-[1rem] max-[360px]:gap-1.5 items-center justify-center w-fit min-w-0 shrink'>
 					{/* Sign-up (and other) CTAs: tracking lives in `ComponentButton` via `isSignUpUrl` / `trackSignUpClicked`. */}
 					{props.secondaryCTA && (
 						<ComponentButton
 							{...props.secondaryCTA}
-							buttonProps={{ styleType: 'outline-inverse', styleSize: 'md' }}
-							className={cn(props.secondaryCTA?.className, 'max-[480px]:[&>div]:hidden')}
+							buttonProps={{ styleType: 'outline-inverse', styleSize: 'sm' }}
+							className={cn(
+								props.secondaryCTA?.className,
+								'max-[360px]:!px-2 max-[360px]:!gap-1 max-[360px]:text-xs',
+							)}
 						/>
 					)}
 					{props.primaryCTA && (
 						<ComponentButton
 							{...props.primaryCTA}
-							buttonProps={{ styleType: 'primary', styleSize: 'md' }}
-							className={cn(props.primaryCTA?.className, 'max-[480px]:[&>div]:hidden')}
+							buttonProps={{ styleType: 'primary', styleSize: 'sm' }}
+							className={cn(
+								props.primaryCTA?.className,
+								'max-[360px]:!px-2 max-[360px]:!gap-1 max-[360px]:text-xs',
+							)}
 						/>
 					)}
 

--- a/src/ui/Nav/MobileNav/index.tsx
+++ b/src/ui/Nav/MobileNav/index.tsx
@@ -32,7 +32,7 @@ export function MobileNav(props: NavProps) {
 						className='min-w-[2.4rem] min-h-[2.7rem] w-[2.4rem] h-[2.7rem] max-w-[2.4rem] max-h-[2.7rem]'
 					/>
 				</Anchor>
-				<div className='flex flex-row gap-[1rem] max-[360px]:gap-1.5 items-center justify-center w-fit min-w-0 shrink'>
+				<div className='flex flex-row gap-[1rem] max-[360px]:gap-1.5 items-center shrink-0'>
 					{/* Sign-up (and other) CTAs: tracking lives in `ComponentButton` via `isSignUpUrl` / `trackSignUpClicked`. */}
 					{props.secondaryCTA && (
 						<ComponentButton

--- a/src/ui/Nav/MobileNav/index.tsx
+++ b/src/ui/Nav/MobileNav/index.tsx
@@ -38,14 +38,14 @@ export function MobileNav(props: NavProps) {
 						<ComponentButton
 							{...props.secondaryCTA}
 							buttonProps={{ styleType: 'outline-inverse', styleSize: 'md' }}
-							className={cn(props.secondaryCTA?.className, 'max-[400px]:[&>*:last-child]:hidden')}
+							className={cn(props.secondaryCTA?.className, 'max-[480px]:[&>div]:hidden')}
 						/>
 					)}
 					{props.primaryCTA && (
 						<ComponentButton
 							{...props.primaryCTA}
 							buttonProps={{ styleType: 'primary', styleSize: 'md' }}
-							className={cn(props.primaryCTA?.className, 'max-[400px]:[&>*:last-child]:hidden')}
+							className={cn(props.primaryCTA?.className, 'max-[480px]:[&>div]:hidden')}
 						/>
 					)}
 

--- a/src/ui/_styles/globals.css
+++ b/src/ui/_styles/globals.css
@@ -129,6 +129,7 @@
 		scroll-padding-top: 8rem;
 		padding: 0 !important;
 		scroll-behavior: smooth;
+		overflow-x: hidden;
 		h1[id],
 		h2[id] {
 			scroll-margin-top: 2.5rem;


### PR DESCRIPTION
Fixes mobile navbar layout on narrow viewports so CTA buttons and the menu icon fit without overflow or unpredictable wrapping.

- **Smaller CTA buttons on mobile** — Switches primary and secondary nav CTAs from `md` to `sm`, with tighter padding, gap, and `text-xs` at viewports ≤360px.
- **Keeps button labels visible** — Replaces the previous `max-[400px]` rule that hid button label text with responsive sizing instead of truncating content.
- **Fixes conflicting flex sizing** — Removes `w-fit`, `min-w-0`, and `shrink` from the button container (which fought each other) and uses `shrink-0` so the action group keeps a stable natural width.
- **Prevents horizontal page scroll** — Adds `overflow-x: hidden` on the root scroll container in `globals.css` as a safeguard when the navbar is tight on very small screens.

## Screenshots

<img width="739" height="939" alt="image" src="https://github.com/user-attachments/assets/59504625-c29a-413d-9982-8e4cec4f0b82" />

<img width="763" height="1219" alt="image" src="https://github.com/user-attachments/assets/7470ec73-a0d7-4202-aeca-7b4445e2a2e9" />

<img width="753" height="1150" alt="image" src="https://github.com/user-attachments/assets/566c75ff-0186-4c0f-9e2d-5e8680fe8678" />

<img width="783" height="1264" alt="image" src="https://github.com/user-attachments/assets/6198bca3-01d2-4f77-a134-2b9e719b7e2d" />

## Test plan

- [X] Open the site on a mobile viewport (or DevTools device mode) at widths **360px**, **375px**, and **320px**
- [X] Confirm both primary and secondary CTA labels remain visible (no hidden text/icons-only state)
- [X] Confirm the hamburger menu button stays aligned and nothing overflows the navbar
- [X] Confirm no horizontal scrollbar appears on the page at narrow widths
- [X] Verify CTA click tracking still works (sign-up URLs via `ComponentButton` / `trackSignUpClicked`)
- [X] Smoke test desktop nav (`lg+`) to ensure no regressions

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Presentation-only nav and global overflow styling with no auth, data, or routing changes.
> 
> **Overview**
> Tightens the **mobile header** so primary/secondary CTAs and the menu control fit on narrow screens without clipping or horizontal scroll.
> 
> In `MobileNav`, both CTAs switch from **`md` to `sm`** sizing, and the old **`max-[400px]` rule that hid the last child inside each button** is replaced with **`max-[360px]`** padding, gap, and **`text-xs`** overrides so labels stay visible but smaller. The CTA cluster uses **`shrink-0`** and a slightly reduced gap below 360px.
> 
> Globally, **`overflow-x: hidden`** is added on `html`/`body` to suppress sideways overflow that could show up with the fixed mobile nav layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5dfca1c7e16cfcea2838b3a864768ffae5297fc. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->