### PR TITLE
Fix og:site_name Open Graph tag

### DIFF
--- a/src/app/candidate/[...slug]/page.tsx
+++ b/src/app/candidate/[...slug]/page.tsx
@@ -16,6 +16,7 @@ import { PageSections } from '~/PageSections';
 import type { SectionOverrides } from '~/PageSections';
 import type { CandidacyItem, FindByRaceIdResponse } from '~/types/elections';
 import type { ProfileData, OfficeData } from '~/PageSections/ProfileContentBlockSection';
+import { SITE_NAME } from '~/lib/url';
 import { PROFILE_PAGE_SECTIONS } from './profilePageSections';
 
 export const revalidate = 3600;
@@ -210,6 +211,8 @@ export async function generateMetadata({
 			resolveProfileAboutText(candidate.about, claimed) ??
 			`View ${candidateName}'s profile for ${positionName}.`,
 		openGraph: {
+			type: 'website',
+			siteName: SITE_NAME,
 			images: profileImageUrl ? [{ url: profileImageUrl }] : undefined,
 		},
 	};

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -9,7 +9,7 @@ import '~/ui/_styles/globals.css';
 import { Amplitude } from '~/ui/Amplitude';
 import { ScrollDepthTracker } from '~/ui/ScrollDepthTracker';
 import { PageSchema } from '~/ui/PageSchema';
-import { getBaseUrl } from '~/lib/url';
+import { getBaseUrl, SITE_NAME } from '~/lib/url';
 import { buildOrganizationSchema, buildSchemaGraph, buildWebSiteSchema, resolveSameAs } from '~/lib/schema';
 import { sanityFetch } from '~/sanity/sanityClient';
 import { goodpartyOrg_socialChannelsQuery } from '~/sanity/groq';
@@ -48,7 +48,7 @@ export const metadata: Metadata = {
 		'GoodParty.org empowers independent candidates to run, win and serve. Access campaign tools, voter data, and support to level the playing field without deep pockets.',
 	openGraph: {
 		type: 'website',
-		siteName: 'GoodParty.org',
+		siteName: SITE_NAME,
 	},
 	twitter: {
 		card: 'summary_large_image',

--- a/src/components/StructureMetadata.ts
+++ b/src/components/StructureMetadata.ts
@@ -1,7 +1,7 @@
 import type { Metadata, ResolvedMetadata } from 'next';
 import type { Robots } from 'next/dist/lib/metadata/types/metadata-types';
 import type { Group_seo } from 'sanity.types';
-import { DEFAULT_SHARE_IMAGE, getBaseUrl, toAbsoluteUrl } from '~/lib/url';
+import { DEFAULT_SHARE_IMAGE, getBaseUrl, SITE_NAME, toAbsoluteUrl } from '~/lib/url';
 
 function metaString(value: unknown): string | undefined {
 	if (typeof value === 'string') return value;
@@ -28,6 +28,8 @@ export async function StructureMetaData(parentMetadata: ResolvedMetadata, page?:
 		description: metaDescription,
 		openGraph: {
 			...(parentMetadata.openGraph as Metadata['openGraph']),
+			type: 'website',
+			siteName: SITE_NAME,
 			title: metaTitle,
 			images,
 			url: absoluteUrl,

--- a/src/lib/siteBaseUrl.ts
+++ b/src/lib/siteBaseUrl.ts
@@ -5,6 +5,8 @@
 
 const PRODUCTION_HOST = 'https://goodparty.org';
 
+export const SITE_NAME = 'GoodParty.org';
+
 function sanitizeSiteUrl(value: string | undefined): string | undefined {
 	if (value == null || typeof value !== 'string') return undefined;
 	const cleaned = value.replace(/[\s\r\n]+/g, '').replace(/\/$/, '');

--- a/src/lib/url.ts
+++ b/src/lib/url.ts
@@ -1,7 +1,7 @@
 import { dataset, projectId } from '~/lib/env';
 import { getBaseUrl } from './siteBaseUrl';
 
-export { getBaseUrl } from './siteBaseUrl';
+export { getBaseUrl, SITE_NAME } from './siteBaseUrl';
 
 /** Default share image for Open Graph, Twitter, and schema when no page-specific image is set */
 export const DEFAULT_SHARE_IMAGE = 'https://assets.goodparty.org/gp-share-2025.png';


### PR DESCRIPTION
- Add a shared `SITE_NAME` constant (`GoodParty.org`) for Open Graph metadata
- Explicitly set `og:site_name` in `StructureMetadata` so all Sanity-driven pages emit the correct site prefix
- Set `siteName` on candidate profile pages that override `openGraph` with only images
- Use the constant in the root layout for consistency

## Why

When `og:site_name` is missing, link unfurlers (ClickUp, Slack, etc.) derive the label from the hostname and display "Goodparty" instead of "GoodParty.org". The root layout already set the correct value, but child `generateMetadata` overrides did not reliably inherit it — notably on `/contact` and `/elections`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only change with no auth, data, or runtime behavior impact.
> 
> **Overview**
> Introduces a shared **`SITE_NAME`** constant (`GoodParty.org`) in `siteBaseUrl.ts` (re-exported from `~/lib/url`) and wires it into Open Graph metadata everywhere the site name matters.
> 
> **Root layout** now uses the constant instead of an inline string. **`StructureMetaData`** explicitly sets `openGraph.type` and `openGraph.siteName` for Sanity-driven pages (landing, policy, blog, etc.), so overrides no longer drop `og:site_name`. **Candidate profile** `generateMetadata` does the same when it only customizes OG images—fixing unfurlers that showed “Goodparty” from the hostname instead of **GoodParty.org**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f5c40839429c491526a9f845763ac47f9d8e4a3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->