### PR TITLE
Fix: joint position breadcrumbs

### DIFF
--- a/src/app/elections/[state]/[county]/[city]/[subplace]/position/[positionSlug]/candidates/page.tsx
+++ b/src/app/elections/[state]/[county]/[city]/[subplace]/position/[positionSlug]/candidates/page.tsx
@@ -17,13 +17,6 @@ import {
 } from '~/lib/electionsHelpers';
 import { CandidatesPageContent } from '~/ui/CandidatesPageContent';
 
-function humanizeSegment(segment: string): string {
-	return segment
-		.split('-')
-		.map((w) => w.charAt(0).toUpperCase() + w.slice(1))
-		.join(' ');
-}
-
 export default async function Page({
 	params,
 }: {
@@ -60,10 +53,8 @@ export default async function Page({
 		null;
 	if (!cityPlace) notFound();
 
-	const subplaceLabel =
-		race.Place && race.Place.slug?.toLowerCase().endsWith(`/${subplace.toLowerCase()}`)
-			? race.Place.name
-			: humanizeSegment(subplace);
+	const isRealSubplace =
+		race.Place?.slug?.toLowerCase().endsWith(`/${subplace.toLowerCase()}`) ?? false;
 
 	const stateName = getStateName(stateCode);
 	const cityName = cityPlace.name;
@@ -83,7 +74,7 @@ export default async function Page({
 		{ href: `/elections/${state.toLowerCase()}`, label: stateName },
 		{ href: `/elections/${countySlug}`, label: countyName },
 		{ href: `/elections/${cityPathSlug}`, label: cityName },
-		{ href: '', label: subplaceLabel },
+		...(isRealSubplace ? [{ href: '', label: race.Place!.name }] : []),
 		{ href: '', label: `Candidates for ${officeName}` },
 	];
 
@@ -130,13 +121,12 @@ export async function generateMetadata({
 		race?.Place ??
 		null;
 	const cityName = cityPlace?.name ?? city;
-	const subplaceLabel =
-		race?.Place && race.Place.slug?.toLowerCase().endsWith(`/${subplace.toLowerCase()}`)
-			? race.Place.name
-			: humanizeSegment(subplace);
+	const isRealSubplace =
+		race?.Place?.slug?.toLowerCase().endsWith(`/${subplace.toLowerCase()}`) ?? false;
+	const localityLabel = isRealSubplace ? race!.Place!.name : cityName;
 	const positionName = race?.normalizedPositionName ?? race?.name ?? 'Position';
 	return {
-		title: `Candidates for ${positionName} in ${subplaceLabel}, ${cityName}, ${stateName} | Good Party`,
-		description: `View candidates running for ${positionName} in ${subplaceLabel}, ${cityName}, ${countyDisplayName}, ${stateName}.`,
+		title: `Candidates for ${positionName} in ${localityLabel}, ${cityName}, ${stateName} | Good Party`,
+		description: `View candidates running for ${positionName} in ${localityLabel}, ${cityName}, ${countyDisplayName}, ${stateName}.`,
 	};
 }

--- a/src/app/elections/[state]/[county]/[city]/[subplace]/position/[positionSlug]/candidates/page.tsx
+++ b/src/app/elections/[state]/[county]/[city]/[subplace]/position/[positionSlug]/candidates/page.tsx
@@ -123,10 +123,16 @@ export async function generateMetadata({
 	const cityName = cityPlace?.name ?? city;
 	const isRealSubplace =
 		race?.Place?.slug?.toLowerCase().endsWith(`/${subplace.toLowerCase()}`) ?? false;
-	const localityLabel = isRealSubplace ? race!.Place!.name : cityName;
 	const positionName = race?.normalizedPositionName ?? race?.name ?? 'Position';
+	if (isRealSubplace) {
+		const subplaceName = race!.Place!.name;
+		return {
+			title: `Candidates for ${positionName} in ${subplaceName}, ${cityName}, ${stateName} | Good Party`,
+			description: `View candidates running for ${positionName} in ${subplaceName}, ${cityName}, ${countyDisplayName}, ${stateName}.`,
+		};
+	}
 	return {
-		title: `Candidates for ${positionName} in ${localityLabel}, ${cityName}, ${stateName} | Good Party`,
-		description: `View candidates running for ${positionName} in ${localityLabel}, ${cityName}, ${countyDisplayName}, ${stateName}.`,
+		title: `Candidates for ${positionName} in ${cityName}, ${stateName} | Good Party`,
+		description: `View candidates running for ${positionName} in ${cityName}, ${countyDisplayName}, ${stateName}.`,
 	};
 }

--- a/src/app/elections/[state]/[county]/[city]/[subplace]/position/[positionSlug]/page.tsx
+++ b/src/app/elections/[state]/[county]/[city]/[subplace]/position/[positionSlug]/page.tsx
@@ -129,10 +129,16 @@ export async function generateMetadata({
 	const cityName = cityPlace?.name ?? city;
 	const isRealSubplace =
 		race?.Place?.slug?.toLowerCase().endsWith(`/${subplace.toLowerCase()}`) ?? false;
-	const localityLabel = isRealSubplace ? race!.Place!.name : cityName;
 	const positionName = race?.normalizedPositionName ?? race?.name ?? 'Position';
+	if (isRealSubplace) {
+		const subplaceName = race!.Place!.name;
+		return {
+			title: `${positionName} in ${subplaceName}, ${cityName}, ${stateName} | Good Party`,
+			description: `Election details and candidates for ${positionName} in ${subplaceName}, ${cityName}, ${countyDisplayName}, ${stateName}.`,
+		};
+	}
 	return {
-		title: `${positionName} in ${localityLabel}, ${cityName}, ${stateName} | Good Party`,
-		description: `Election details and candidates for ${positionName} in ${localityLabel}, ${cityName}, ${countyDisplayName}, ${stateName}.`,
+		title: `${positionName} in ${cityName}, ${stateName} | Good Party`,
+		description: `Election details and candidates for ${positionName} in ${cityName}, ${countyDisplayName}, ${stateName}.`,
 	};
 }

--- a/src/app/elections/[state]/[county]/[city]/[subplace]/position/[positionSlug]/page.tsx
+++ b/src/app/elections/[state]/[county]/[city]/[subplace]/position/[positionSlug]/page.tsx
@@ -19,13 +19,6 @@ import { PositionPageContent } from '~/ui/PositionPageContent';
 
 export const revalidate = 3600;
 
-function humanizeSegment(segment: string): string {
-	return segment
-		.split('-')
-		.map((w) => w.charAt(0).toUpperCase() + w.slice(1))
-		.join(' ');
-}
-
 export async function generateStaticParams() {
 	const { subplacePositionParams } = await getCachedElectionRouteParams();
 	return subplacePositionParams;
@@ -70,10 +63,8 @@ export default async function Page({
 		null;
 	if (!cityPlace) notFound();
 
-	const subplaceLabel =
-		race.Place && race.Place.slug?.toLowerCase().endsWith(`/${subplace.toLowerCase()}`)
-			? race.Place.name
-			: humanizeSegment(subplace);
+	const isRealSubplace =
+		race.Place?.slug?.toLowerCase().endsWith(`/${subplace.toLowerCase()}`) ?? false;
 
 	const stateName = getStateName(stateCode);
 	const cityName = cityPlace.name;
@@ -88,7 +79,7 @@ export default async function Page({
 		{ href: `/elections/${state.toLowerCase()}`, label: stateName },
 		{ href: `/elections/${countySlug}`, label: countyPlace.name },
 		{ href: `/elections/${cityPathSlug}`, label: cityName },
-		{ href: '', label: subplaceLabel },
+		...(isRealSubplace ? [{ href: '', label: race.Place!.name }] : []),
 		{ href: '', label: officeName },
 	];
 
@@ -136,13 +127,12 @@ export async function generateMetadata({
 		race?.Place ??
 		null;
 	const cityName = cityPlace?.name ?? city;
-	const subplaceLabel =
-		race?.Place && race.Place.slug?.toLowerCase().endsWith(`/${subplace.toLowerCase()}`)
-			? race.Place.name
-			: humanizeSegment(subplace);
+	const isRealSubplace =
+		race?.Place?.slug?.toLowerCase().endsWith(`/${subplace.toLowerCase()}`) ?? false;
+	const localityLabel = isRealSubplace ? race!.Place!.name : cityName;
 	const positionName = race?.normalizedPositionName ?? race?.name ?? 'Position';
 	return {
-		title: `${positionName} in ${subplaceLabel}, ${cityName}, ${stateName} | Good Party`,
-		description: `Election details and candidates for ${positionName} in ${subplaceLabel}, ${cityName}, ${countyDisplayName}, ${stateName}.`,
+		title: `${positionName} in ${localityLabel}, ${cityName}, ${stateName} | Good Party`,
+		description: `Election details and candidates for ${positionName} in ${localityLabel}, ${cityName}, ${countyDisplayName}, ${stateName}.`,
 	};
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Presentation-only changes to breadcrumbs and metadata on subplace election routes; URLs and data fetching are unchanged.
> 
> **Overview**
> **Joint / subplace election pages** no longer invent a breadcrumb step from the URL when `race.Place` is not actually that subplace.
> 
> Both the position and candidates routes under `[subplace]` replace `humanizeSegment(subplace)` with an **`isRealSubplace`** check (`race.Place.slug` ends with `/${subplace}`). The subplace breadcrumb is **only** added when that check passes; otherwise navigation goes Elections → state → county → city → office/candidates.
> 
> **Page metadata** follows the same rule: titles and descriptions include the subplace name only for real subplaces; joint-position URLs get copy scoped to **city + state** (and county in the description) without a misleading subplace label.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2276e95f9aa1687be786ea42de43aeba62f548e5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->