### PR TITLE
Add getFaqSitemapEntries function and related tests

### DIFF
--- a/src/lib/faqSlugs.test.ts
+++ b/src/lib/faqSlugs.test.ts
@@ -4,6 +4,7 @@ import {
 	findFaqBySlug,
 	getAllFaqSlugs,
 	getFaqHref,
+	getFaqSitemapEntries,
 	slugifyFaqQuestion,
 } from './faqSlugs';
 
@@ -117,5 +118,65 @@ describe('findFaqBySlug', () => {
 
 	it('returns undefined for unknown slug', () => {
 		expect(findFaqBySlug(faqs, 'does-not-exist')).toBeUndefined();
+	});
+});
+
+describe('getFaqSitemapEntries', () => {
+	it('returns one canonical entry for three duplicate questions (ticket scenario)', () => {
+		const faqs = [
+			{ _id: 'faq8942aa', faqOverview: { field_question: 'What is GoodParty.org?' } },
+			{ _id: 'faq40f192', faqOverview: { field_question: 'What is GoodParty.org?' } },
+			{ _id: 'faq999999', faqOverview: { field_question: 'What is GoodParty.org?' } },
+		];
+
+		const entries = getFaqSitemapEntries(faqs);
+
+		expect(entries).toHaveLength(1);
+		expect(entries[0]?.slug).toBe('what-is-goodpartyorg');
+		expect(entries[0]?.faq._id).toBe('faq8942aa');
+	});
+
+	it('excludes suffixed duplicates and keeps distinct questions', () => {
+		const downloadQuestion = 'Do I need to download anything to use GoodParty.org?';
+		const faqs = [
+			{ _id: 'download-canonical', faqOverview: { field_question: downloadQuestion } },
+			{ _id: 'download-cc0853', faqOverview: { field_question: downloadQuestion } },
+			{ _id: 'unique-faq', faqOverview: { field_question: 'How much does it cost?' } },
+		];
+
+		const entries = getFaqSitemapEntries(faqs);
+		const slugs = entries.map(e => e.slug);
+
+		expect(entries).toHaveLength(2);
+		expect(slugs).toContain('do-i-need-to-download-anything-to-use-goodpartyorg');
+		expect(slugs).toContain('how-much-does-it-cost');
+		expect(slugs.some(s => s.includes('-cc0853'))).toBe(false);
+	});
+
+	it('includes distinct questions that share a slug prefix after collision suffixing', () => {
+		const faqs = [
+			{ _id: 'aaa111', faqOverview: { field_question: 'What is GoodParty.org?' } },
+			{ _id: 'bbb222', faqOverview: { field_question: 'What is GoodParty.org?' } },
+			{ _id: 'ccc333', faqOverview: { field_question: 'What is GoodParty.org bbb222' } },
+		];
+
+		const entries = getFaqSitemapEntries(faqs);
+		const slugs = entries.map(e => e.slug);
+
+		expect(entries).toHaveLength(2);
+		expect(slugs).toContain('what-is-goodpartyorg');
+		expect(slugs).toContain('what-is-goodpartyorg-bbb222-ccc333');
+	});
+
+	it('includes one entry per FAQ when question is missing (keyed by _id)', () => {
+		const faqs = [
+			{ _id: 'no-question-a' },
+			{ _id: 'no-question-b' },
+		];
+
+		const entries = getFaqSitemapEntries(faqs);
+
+		expect(entries).toHaveLength(2);
+		expect(entries.map(e => e.slug)).toEqual(['no-question-a', 'no-question-b']);
 	});
 });

--- a/src/lib/faqSlugs.test.ts
+++ b/src/lib/faqSlugs.test.ts
@@ -168,6 +168,18 @@ describe('getFaqSitemapEntries', () => {
 		expect(slugs).toContain('what-is-goodpartyorg-bbb222-ccc333');
 	});
 
+	it('keeps all FAQs whose questions slugify to empty string (falls back to _id)', () => {
+		const faqs = [
+			{ _id: 'symbols-a', faqOverview: { field_question: '!!!' } },
+			{ _id: 'symbols-b', faqOverview: { field_question: '@#$' } },
+		];
+
+		const entries = getFaqSitemapEntries(faqs);
+
+		expect(entries).toHaveLength(2);
+		expect(entries.map(e => e.slug)).toEqual(['symbols-a', 'symbols-b']);
+	});
+
 	it('includes one entry per FAQ when question is missing (keyed by _id)', () => {
 		const faqs = [
 			{ _id: 'no-question-a' },

--- a/src/lib/faqSlugs.ts
+++ b/src/lib/faqSlugs.ts
@@ -6,9 +6,15 @@ export const FAQ_BASE_PATH = `/${FAQ_PAGE_SLUG}`;
 
 export type FaqLike = {
 	_id: string;
+	_updatedAt?: string;
 	faqOverview?: {
 		field_question?: unknown;
 	} | null;
+};
+
+export type FaqSitemapEntry = {
+	slug: string;
+	faq: FaqLike;
 };
 
 export function slugifyFaqQuestion(question: string): string {
@@ -75,4 +81,29 @@ export function findFaqBySlug(faqs: ReadonlyArray<FaqLike>, slug: string): FaqLi
 export function getAllFaqSlugs(faqs: ReadonlyArray<FaqLike>): string[] {
 	const slugMap = buildFaqSlugMap(faqs);
 	return faqs.map(faq => getFaqSlug(faq, slugMap));
+}
+
+function faqDedupeKey(faq: FaqLike): string {
+	const question = readQuestion(faq);
+	return question ? slugifyFaqQuestion(question) : faq._id.replace(/^drafts\./, '');
+}
+
+/** One sitemap entry per unique question (first FAQ wins); excludes collision-suffixed duplicates. */
+export function getFaqSitemapEntries(faqs: ReadonlyArray<FaqLike>): FaqSitemapEntry[] {
+	const slugMap = buildFaqSlugMap(faqs);
+	const seenKeys = new Set<string>();
+	const entries: FaqSitemapEntry[] = [];
+
+	for (const faq of faqs) {
+		const key = faqDedupeKey(faq);
+		if (seenKeys.has(key)) continue;
+		seenKeys.add(key);
+
+		const slug = getFaqSlug(faq, slugMap);
+		if (slug) {
+			entries.push({ slug, faq });
+		}
+	}
+
+	return entries;
 }

--- a/src/lib/faqSlugs.ts
+++ b/src/lib/faqSlugs.ts
@@ -85,7 +85,8 @@ export function getAllFaqSlugs(faqs: ReadonlyArray<FaqLike>): string[] {
 
 function faqDedupeKey(faq: FaqLike): string {
 	const question = readQuestion(faq);
-	return question ? slugifyFaqQuestion(question) : faq._id.replace(/^drafts\./, '');
+	const slug = question ? slugifyFaqQuestion(question) : '';
+	return slug || faq._id.replace(/^drafts\./, '');
 }
 
 /** One sitemap entry per unique question (first FAQ wins); excludes collision-suffixed duplicates. */

--- a/src/lib/sitemap-entries.ts
+++ b/src/lib/sitemap-entries.ts
@@ -11,7 +11,7 @@ import {
 	resolveElectionPositionFromRaceSlug,
 	stripCountySuffix as stripCountySuffixFromHelpers,
 } from '~/lib/electionsHelpers';
-import { FAQ_BASE_PATH, getAllFaqSlugs } from '~/lib/faqSlugs';
+import { FAQ_BASE_PATH, getFaqSitemapEntries } from '~/lib/faqSlugs';
 import { allFaqsQuery } from '~/sanity/groq';
 
 /** 51 US state/DC codes (50 states + DC) */
@@ -473,14 +473,10 @@ export async function fetchMainSitemapEntries(baseUrl: string): Promise<Metadata
 		}
 	}
 
-	const faqSlugs = getAllFaqSlugs(faqs);
-	for (let i = 0; i < faqs.length; i++) {
-		const slug = faqSlugs[i];
-		if (slug) {
-			entries.push(
-				toEntry(baseUrl, `${FAQ_BASE_PATH}/${slug}`, 0.6, 'monthly', faqs[i]?._updatedAt?.slice(0, 10)),
-			);
-		}
+	for (const { slug, faq } of getFaqSitemapEntries(faqs)) {
+		entries.push(
+			toEntry(baseUrl, `${FAQ_BASE_PATH}/${slug}`, 0.6, 'monthly', faq._updatedAt?.slice(0, 10)),
+		);
 	}
 
 	return dedupeByUrl(entries);


### PR DESCRIPTION
- Introduced getFaqSitemapEntries function to generate unique sitemap entries for FAQs, ensuring deduplication of questions and handling of collision suffixes.
- Updated faqSlugs.ts to include new FaqSitemapEntry type and logic for deduplication.
- Added comprehensive tests for getFaqSitemapEntries in faqSlugs.test.ts to validate functionality across various scenarios.
- Modified sitemap-entries.ts to utilize getFaqSitemapEntries for improved sitemap generation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> SEO/sitemap-only change with no auth or data mutation; duplicate FAQ pages may still exist outside the sitemap.
> 
> **Overview**
> **FAQ sitemap URLs are deduplicated** so duplicate Sanity FAQ documents with the same question no longer produce multiple sitemap entries for suffixed collision slugs.
> 
> Adds `getFaqSitemapEntries`, which keeps **one canonical URL per unique question** (first FAQ in list order) while still emitting separate entries when questions are genuinely different—including cases where collision suffixing creates distinct slugs. FAQs without a question still get one entry keyed by `_id`.
> 
> `fetchMainSitemapEntries` switches from iterating every FAQ via `getAllFaqSlugs` to this helper, and wires `lastModified` from each chosen FAQ’s `_updatedAt` (optional on `FaqLike`). Tests cover duplicate-question tickets, suffixed duplicates, distinct slug-prefix cases, and missing questions.
> 
> **Note:** FAQ page static generation still uses `getAllFaqSlugs`, so alternate suffixed routes can remain buildable; only the sitemap listing changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9eb40caf9179a7447b4cc42bac442e8d0e9a28ff. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->