### PR TITLE
Refactor candidate image handling and enhance candidacy mapping

### DIFF
--- a/src/app/candidate/[...slug]/page.tsx
+++ b/src/app/candidate/[...slug]/page.tsx
@@ -89,7 +89,7 @@ function buildSectionOverrides(
 		component_profileHero: {
 			candidateName,
 			office,
-			profileImageUrl: resolveProfileImageUrl(candidate.image),
+			profileImageUrl: resolveProfileImageUrl(candidate.image, claimed),
 			isEmpowered: isClaimed,
 		},
 		component_profileContentBlock: {
@@ -203,7 +203,7 @@ export async function generateMetadata({
 	const claimed = await loadClaimedCampaignForCandidate(candidate);
 	const candidateName = [candidate.firstName, candidate.lastName].filter(Boolean).join(' ') || 'Candidate';
 	const positionName = candidate.positionName ?? 'Office';
-	const profileImageUrl = resolveProfileImageUrl(candidate.image);
+	const profileImageUrl = resolveProfileImageUrl(candidate.image, claimed);
 
 	return {
 		title: `${candidateName} for ${positionName} | Good Party`,

--- a/src/app/elections/[state]/[county]/[city]/[subplace]/position/[positionSlug]/candidates/page.tsx
+++ b/src/app/elections/[state]/[county]/[city]/[subplace]/position/[positionSlug]/candidates/page.tsx
@@ -6,13 +6,13 @@ import {
 	getCityPlacesByCounty,
 	getPlacesByState,
 	getSubplaceRaceBySlug,
+	mapCandidaciesToCards,
 } from '~/lib/electionsApi';
 import { isValidStateCode } from '~/constants/usStateCodes';
 import {
 	formatElectionDateFromApi,
 	formatFilingPeriodFromRace,
 	getStateName,
-	mapCandidacyToCard,
 	resolveLocalityName,
 } from '~/lib/electionsHelpers';
 import { CandidatesPageContent } from '~/ui/CandidatesPageContent';
@@ -71,9 +71,9 @@ export default async function Page({
 	const electionDate = formatElectionDateFromApi(race.electionDate);
 	const filingDate = formatFilingPeriodFromRace(race.filingDateStart, race.filingDateEnd);
 
-	const candidacies = await getCandidacies({ raceSlug: race.slug });
+	const candidacies = await getCandidacies({ raceSlug: race.slug, includeRace: true });
 
-	const candidates = candidacies.map((c, i) => mapCandidacyToCard(c, i));
+	const candidates = await mapCandidaciesToCards(candidacies);
 
 	const positionHref = `/elections/${pathBeforePosition}/position/${positionSlug}`;
 	const locationHref = `/elections/${cityPathSlug}`;

--- a/src/app/elections/[state]/[county]/[city]/position/[positionSlug]/candidates/page.tsx
+++ b/src/app/elections/[state]/[county]/[city]/position/[positionSlug]/candidates/page.tsx
@@ -8,6 +8,7 @@ import {
 	getRaceBySlug,
 	isCityOrTownMtfcc,
 	isDistrictMtfcc,
+	mapCandidaciesToCards,
 	resolveCountySlugForPlace,
 } from '~/lib/electionsApi';
 import { isValidStateCode } from '~/constants/usStateCodes';
@@ -16,7 +17,6 @@ import {
 	formatElectionDateFromApi,
 	formatFilingPeriodFromRace,
 	getStateName,
-	mapCandidacyToCard,
 	resolveLocalityName,
 } from '~/lib/electionsHelpers';
 import { CandidatesPageContent } from '~/ui/CandidatesPageContent';
@@ -94,9 +94,9 @@ export default async function Page({
 	const electionDate = formatElectionDateFromApi(race.electionDate);
 	const filingDate = formatFilingPeriodFromRace(race.filingDateStart, race.filingDateEnd);
 
-	const candidacies = await getCandidacies({ raceSlug });
+	const candidacies = await getCandidacies({ raceSlug, includeRace: true });
 
-	const candidates = candidacies.map((c, i) => mapCandidacyToCard(c, i));
+	const candidates = await mapCandidaciesToCards(candidacies);
 
 	const positionHref = `/elections/${fullSlug}/position/${positionSlug}`;
 	const locationHref = `/elections/${fullSlug}`;

--- a/src/app/elections/[state]/[county]/position/[positionSlug]/candidates/page.tsx
+++ b/src/app/elections/[state]/[county]/position/[positionSlug]/candidates/page.tsx
@@ -1,13 +1,12 @@
 import type { Metadata } from 'next';
 import { notFound, redirect } from 'next/navigation';
-import { COUNTY_MTFCC, getCandidacies, getPlacesByState, getRaceBySlug } from '~/lib/electionsApi';
+import { COUNTY_MTFCC, getCandidacies, getPlacesByState, getRaceBySlug, mapCandidaciesToCards } from '~/lib/electionsApi';
 import { isValidStateCode } from '~/constants/usStateCodes';
 import {
 	buildRaceSlug,
 	formatElectionDateFromApi,
 	formatFilingPeriodFromRace,
 	getStateName,
-	mapCandidacyToCard,
 	redirectCityRaceToFourLevelUrl,
 	resolveLocalityName,
 } from '~/lib/electionsHelpers';
@@ -52,9 +51,9 @@ export default async function Page({
 	const electionDate = formatElectionDateFromApi(race.electionDate);
 	const filingDate = formatFilingPeriodFromRace(race.filingDateStart, race.filingDateEnd);
 
-	const candidacies = await getCandidacies({ raceSlug });
+	const candidacies = await getCandidacies({ raceSlug, includeRace: true });
 
-	const candidates = candidacies.map((c, i) => mapCandidacyToCard(c, i));
+	const candidates = await mapCandidaciesToCards(candidacies);
 
 	const positionHref = `/elections/${countySlug}/position/${positionSlug}`;
 	const locationHref = `/elections/${countySlug}`;

--- a/src/app/elections/[state]/position/[positionSlug]/candidates/page.tsx
+++ b/src/app/elections/[state]/position/[positionSlug]/candidates/page.tsx
@@ -1,13 +1,12 @@
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
-import { getCandidacies, getRaceBySlug } from '~/lib/electionsApi';
+import { getCandidacies, getRaceBySlug, mapCandidaciesToCards } from '~/lib/electionsApi';
 import { isValidStateCode } from '~/constants/usStateCodes';
 import {
 	buildRaceSlug,
 	formatElectionDateFromApi,
 	formatFilingPeriodFromRace,
 	getStateName,
-	mapCandidacyToCard,
 } from '~/lib/electionsHelpers';
 import { CandidatesPageContent } from '~/ui/CandidatesPageContent';
 
@@ -26,7 +25,7 @@ export default async function Page({
 	const raceSlug = buildRaceSlug(stateCode, positionSlug);
 	const [race, candidacies] = await Promise.all([
 		getRaceBySlug(raceSlug),
-		getCandidacies({ raceSlug }),
+		getCandidacies({ raceSlug, includeRace: true }),
 	]);
 
 	if (!race) {
@@ -38,7 +37,7 @@ export default async function Page({
 	const electionDate = formatElectionDateFromApi(race.electionDate);
 	const filingDate = formatFilingPeriodFromRace(race.filingDateStart, race.filingDateEnd);
 
-	const candidates = candidacies.map((c, i) => mapCandidacyToCard(c, i));
+	const candidates = await mapCandidaciesToCards(candidacies);
 
 	const statePath = stateCode.toLowerCase();
 	const positionHref = `/elections/${statePath}/position/${positionSlug}`;

--- a/src/lib/electionsApi.test.ts
+++ b/src/lib/electionsApi.test.ts
@@ -3,6 +3,7 @@ import type { PlaceItem } from '~/types/elections';
 import {
 	getCountyChildPlaces,
 	isStateIndexDistrictPlace,
+	mapCandidaciesToCards,
 	resolveCountySlugForPlace,
 	resolveRaceElectionHrefs,
 } from './electionsApi';
@@ -460,5 +461,72 @@ describe('isStateIndexDistrictPlace', () => {
 				mtfcc: 'G5420',
 			}),
 		).toBe(true);
+	});
+});
+
+describe('mapCandidaciesToCards', () => {
+	test('fetches claimed campaigns only for candidacies missing elections images', async () => {
+		const requestedUrls: string[] = [];
+		globalThis.fetch = (async (input: RequestInfo | URL) => {
+			const url = String(input);
+			requestedUrls.push(url);
+			if (url.includes('/v1/public-campaigns?')) {
+				if (url.includes('firstName=Heather-Marie') && url.includes('raceId=race-b')) {
+					return new Response(
+						JSON.stringify({
+							id: 1,
+							slug: 'heather-marie-wilson',
+							updatedAt: '',
+							website: {
+								id: 1,
+								vanityPath: 'heather-marie-wilson',
+								status: 'published',
+								content: {
+									main: { image: 'https://example.com/heather.jpg' },
+								},
+								domain: null,
+							},
+							details: null,
+							campaignPositions: [],
+						}),
+						{ status: 200, headers: { 'content-type': 'application/json' } },
+					);
+				}
+				return new Response('null', { status: 200, headers: { 'content-type': 'application/json' } });
+			}
+			return new Response(JSON.stringify([]), { status: 200 });
+		}) as typeof fetch;
+
+		const cards = await mapCandidaciesToCards([
+			{
+				id: 'with-image',
+				firstName: 'Alex',
+				lastName: 'One',
+				image: 'https://example.com/alex.jpg',
+				Race: { brHashId: 'race-a' },
+			},
+			{
+				id: 'needs-claimed',
+				firstName: 'Heather-Marie',
+				lastName: 'Wilson',
+				image: null,
+				Race: { brHashId: 'race-b' },
+			},
+			{
+				id: 'missing-race',
+				firstName: 'No',
+				lastName: 'Race',
+				image: null,
+			},
+		]);
+
+		expect(cards[0]?.avatar).toBe('https://example.com/alex.jpg');
+		expect(cards[1]?.avatar).toBe('https://example.com/heather.jpg');
+		expect(cards[2]?.avatar).toBeUndefined();
+
+		const campaignRequests = requestedUrls.filter(url => url.includes('/v1/public-campaigns?'));
+		expect(campaignRequests).toHaveLength(1);
+		expect(campaignRequests[0]).toContain('raceId=race-b');
+		expect(campaignRequests[0]).toContain('firstName=Heather-Marie');
 	});
 });

--- a/src/lib/electionsApi.ts
+++ b/src/lib/electionsApi.ts
@@ -27,7 +27,7 @@ const ELECTIONS_API_BASE_URL =
 const GP_API_BASE_URL =
 	process.env['GP_API_BASE_URL'] ??
 	process.env['NEXT_PUBLIC_API_BASE'] ??
-	ELECTIONS_API_BASE_URL.replace('election-api', 'gp-api');
+	'https://gp-api.goodparty.org';
 
 const CACHE_OPTIONS = { next: { revalidate: 3600 } } satisfies RequestInit;
 

--- a/src/lib/electionsApi.ts
+++ b/src/lib/electionsApi.ts
@@ -15,7 +15,9 @@ import {
 	buildRaceCandidatesHref,
 	buildSubplaceRaceSlug,
 	canonicalizeCountyEquivalentName,
+	mapCandidacyToCard,
 	normalizeCandidateLookupName,
+	resolveProfileImageUrl,
 	stripCountySuffix,
 } from '~/lib/electionsHelpers';
 
@@ -195,11 +197,13 @@ export async function getCandidacies(params: {
 	raceId?: string;
 	positionId?: string;
 	raceSlug?: string;
+	includeRace?: boolean;
 }): Promise<CandidacyItem[]> {
 	const searchParams = new URLSearchParams();
 	if (params.raceId) searchParams.set('raceId', params.raceId);
 	if (params.positionId) searchParams.set('positionId', params.positionId);
 	if (params.raceSlug) searchParams.set('raceSlug', params.raceSlug);
+	if (params.includeRace) searchParams.set('includeRace', 'true');
 	if (searchParams.toString() === '') return [];
 	const url = `${ELECTIONS_API_BASE_URL}/v1/candidacies?${searchParams}`;
 	const data = await fetchJson<CandidacyItem[]>(url);
@@ -253,6 +257,39 @@ export async function findCampaignByRace(params: {
 	});
 	const url = `${GP_API_BASE_URL.replace(/\/$/, '')}/v1/public-campaigns?${searchParams}`;
 	return fetchJson<FindByRaceIdResponse>(url);
+}
+
+export async function mapCandidaciesToCards(
+	candidacies: CandidacyItem[],
+): Promise<ReturnType<typeof mapCandidacyToCard>[]> {
+	const needsClaimed = candidacies
+		.map((candidacy, index) => ({ candidacy, index }))
+		.filter(
+			({ candidacy }) =>
+				!resolveProfileImageUrl(candidacy.image) &&
+				candidacy.firstName &&
+				candidacy.lastName &&
+				candidacy.Race?.brHashId,
+		);
+
+	const claimedResults = await Promise.all(
+		needsClaimed.map(({ candidacy }) =>
+			findCampaignByRace({
+				raceId: candidacy.Race!.brHashId,
+				firstName: candidacy.firstName!,
+				lastName: candidacy.lastName!,
+			}),
+		),
+	);
+
+	const claimedByIndex = new Map<number, FindByRaceIdResponse | null>();
+	needsClaimed.forEach(({ index }, resultIndex) => {
+		claimedByIndex.set(index, claimedResults[resultIndex] ?? null);
+	});
+
+	return candidacies.map((candidacy, index) =>
+		mapCandidacyToCard(candidacy, index, claimedByIndex.get(index) ?? null),
+	);
 }
 
 export async function getMostElections(count = 3): Promise<FeaturedCity[]> {

--- a/src/lib/electionsHelpers.test.ts
+++ b/src/lib/electionsHelpers.test.ts
@@ -29,6 +29,7 @@ import {
 	resolveClaimedCustomIssueText,
 	resolveClaimedTextField,
 	resolveLocalityName,
+	mapCandidacyToCard,
 	resolveProfileAboutText,
 	resolveProfileImageUrl,
 	slugifyPositionName,
@@ -1149,6 +1150,109 @@ describe('claimed profile helpers', () => {
 	test('resolveProfileImageUrl trims and rejects empty values', () => {
 		expect(resolveProfileImageUrl(' https://example.com/a.jpg ')).toBe('https://example.com/a.jpg');
 		expect(resolveProfileImageUrl('   ')).toBeUndefined();
+	});
+
+	test('resolveProfileImageUrl prefers elections API image over claimed campaign image', () => {
+		expect(
+			resolveProfileImageUrl('https://example.com/elections.jpg', {
+				id: 1,
+				slug: 'candidate',
+				updatedAt: '',
+				website: {
+					id: 1,
+					vanityPath: 'candidate',
+					status: 'published',
+					content: {
+						main: { image: 'https://example.com/claimed.jpg' },
+					},
+					domain: null,
+				},
+				details: null,
+				campaignPositions: [],
+			}),
+		).toBe('https://example.com/elections.jpg');
+	});
+
+	test('resolveProfileImageUrl falls back to claimed main.image then logo', () => {
+		const claimedWithMain = {
+			id: 1,
+			slug: 'candidate',
+			updatedAt: '',
+			website: {
+				id: 1,
+				vanityPath: 'candidate',
+				status: 'published',
+				content: {
+					main: { image: 'https://example.com/main.jpg' },
+					logo: 'https://example.com/logo.jpg',
+				},
+				domain: null,
+			},
+			details: null,
+			campaignPositions: [],
+		};
+
+		expect(resolveProfileImageUrl(null, claimedWithMain)).toBe('https://example.com/main.jpg');
+
+		const claimedWithLogoOnly = {
+			...claimedWithMain,
+			website: {
+				...claimedWithMain.website,
+				content: { logo: 'https://example.com/logo.jpg' },
+			},
+		};
+
+		expect(resolveProfileImageUrl(undefined, claimedWithLogoOnly)).toBe('https://example.com/logo.jpg');
+	});
+
+	test('resolveProfileImageUrl ignores malformed claimed website content', () => {
+		expect(
+			resolveProfileImageUrl(null, {
+				id: 1,
+				slug: 'candidate',
+				updatedAt: '',
+				website: {
+					id: 1,
+					vanityPath: 'candidate',
+					status: 'published',
+					content: { main: 'not-an-object', logo: 123 },
+					domain: null,
+				},
+				details: null,
+				campaignPositions: [],
+			}),
+		).toBeUndefined();
+	});
+
+	test('mapCandidacyToCard uses claimed campaign image when elections image is missing', () => {
+		const card = mapCandidacyToCard(
+			{
+				id: 'c-1',
+				firstName: 'Heather-Marie',
+				lastName: 'Wilson',
+				party: 'Independent',
+				slug: 'heather-marie-wilson/washington-state-senate-district-43',
+			},
+			0,
+			{
+				id: 1,
+				slug: 'heather-marie-wilson',
+				updatedAt: '',
+				website: {
+					id: 1,
+					vanityPath: 'heather-marie-wilson',
+					status: 'published',
+					content: {
+						main: { image: 'data:image/jpeg;base64,abc' },
+					},
+					domain: null,
+				},
+				details: null,
+				campaignPositions: [],
+			},
+		);
+
+		expect(card.avatar).toBe('data:image/jpeg;base64,abc');
 	});
 });
 

--- a/src/lib/electionsHelpers.ts
+++ b/src/lib/electionsHelpers.ts
@@ -110,13 +110,14 @@ export function getCountySuffixLabel(name: string): string {
 export function mapCandidacyToCard(
 	candidacy: CandidacyItem,
 	index: number,
+	claimed?: FindByRaceIdResponse | null,
 ): { _key: string; name: string; partyAffiliation: string; avatar?: string; href: string } {
 	const name = [candidacy.firstName, candidacy.lastName].filter(Boolean).join(' ') || 'Candidate';
 	return {
 		_key: candidacy.id ?? `c-${index}`,
 		name,
 		partyAffiliation: candidacy.party ?? 'Unknown',
-		avatar: candidacy.image ?? undefined,
+		avatar: resolveProfileImageUrl(candidacy.image, claimed),
 		href: candidacy.slug
 			? `/candidate/${candidacy.slug}`
 			: `/profile?slug=${encodeURIComponent([candidacy.firstName, candidacy.lastName].filter(Boolean).join('-').toLowerCase())}&raceId=${encodeURIComponent(candidacy.raceId ?? '')}`,
@@ -167,12 +168,38 @@ export function resolveProfileAboutText(
 	return resolveClaimedTextField(claimed?.details?.occupation);
 }
 
-/** Prefers elections API image; public-campaigns does not expose profile photos. */
+function resolveClaimedWebsiteImageUrl(
+	value: unknown,
+): string | undefined {
+	if (typeof value !== 'string') return undefined;
+	const trimmed = value.trim();
+	return trimmed.length > 0 ? trimmed : undefined;
+}
+
+/** Reads profile image from claimed campaign website builder content. */
+function resolveClaimedProfileImageUrl(
+	claimed: FindByRaceIdResponse | null,
+): string | undefined {
+	const content = claimed?.website?.content;
+	if (!content || typeof content !== 'object') return undefined;
+
+	const main = content['main'];
+	if (main && typeof main === 'object') {
+		const mainImage = resolveClaimedWebsiteImageUrl((main as { image?: unknown }).image);
+		if (mainImage) return mainImage;
+	}
+
+	return resolveClaimedWebsiteImageUrl(content['logo']);
+}
+
+/** Prefers elections API image, then claimed campaign website image. */
 export function resolveProfileImageUrl(
 	candidateImage: string | null | undefined,
+	claimed?: FindByRaceIdResponse | null,
 ): string | undefined {
 	const image = candidateImage?.trim();
-	return image && image.length > 0 ? image : undefined;
+	if (image && image.length > 0) return image;
+	return resolveClaimedProfileImageUrl(claimed ?? null);
 }
 
 const DATE_ONLY_REGEX = /^\d{4}-\d{2}-\d{2}$/;

--- a/src/types/elections.ts
+++ b/src/types/elections.ts
@@ -46,6 +46,7 @@ export interface CandidacyItem {
 	placeName?: string;
 	about?: string;
 	email?: string;
+	gpCandidateId?: string | null;
 	urls?: string[];
 	positionDescription?: string;
 	electionFrequency?: number[];


### PR DESCRIPTION
- Updated `resolveProfileImageUrl` to prefer images from claimed campaigns when elections API images are missing.
- Introduced `mapCandidaciesToCards` function to streamline the mapping of candidacies to card components, ensuring claimed campaign images are utilized where applicable.
- Adjusted candidate pages to include the new mapping logic, improving the display of candidate images across various election pages.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Listing pages add parallel gp-api calls for candidates without elections images, which can affect latency and load; claimed website image URLs are rendered without new validation beyond type checks.
> 
> **Overview**
> **Candidate photos** now use elections API images when present, otherwise fall back to claimed campaign website content (`main.image`, then `logo`). Candidate profile hero and Open Graph metadata pass the loaded claimed campaign into `resolveProfileImageUrl`.
> 
> **Election candidates listings** no longer map candidacies synchronously with elections `image` only. They request candidacies with `includeRace: true` and use **`mapCandidaciesToCards`**, which calls `findCampaignByRace` only for rows missing a resolved elections image and with race/name data, then builds cards via `mapCandidacyToCard`.
> 
> Tests cover image precedence, malformed claimed content, selective public-campaign fetches, and card avatars.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 472b8a4763b3d526d2666b9bb79527262e807d36. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->