### PR TITLE
Release develop to master

### DIFF
--- a/src/app/candidate/[...slug]/page.tsx
+++ b/src/app/candidate/[...slug]/page.tsx
@@ -16,6 +16,7 @@ import { PageSections } from '~/PageSections';
 import type { SectionOverrides } from '~/PageSections';
 import type { CandidacyItem, FindByRaceIdResponse } from '~/types/elections';
 import type { ProfileData, OfficeData } from '~/PageSections/ProfileContentBlockSection';
+import { SITE_NAME } from '~/lib/url';
 import { PROFILE_PAGE_SECTIONS } from './profilePageSections';
 
 export const revalidate = 3600;
@@ -210,6 +211,8 @@ export async function generateMetadata({
 			resolveProfileAboutText(candidate.about, claimed) ??
 			`View ${candidateName}'s profile for ${positionName}.`,
 		openGraph: {
+			type: 'website',
+			siteName: SITE_NAME,
 			images: profileImageUrl ? [{ url: profileImageUrl }] : undefined,
 		},
 	};

--- a/src/app/elections/[state]/[county]/[city]/[subplace]/position/[positionSlug]/candidates/page.tsx
+++ b/src/app/elections/[state]/[county]/[city]/[subplace]/position/[positionSlug]/candidates/page.tsx
@@ -17,13 +17,6 @@ import {
 } from '~/lib/electionsHelpers';
 import { CandidatesPageContent } from '~/ui/CandidatesPageContent';
 
-function humanizeSegment(segment: string): string {
-	return segment
-		.split('-')
-		.map((w) => w.charAt(0).toUpperCase() + w.slice(1))
-		.join(' ');
-}
-
 export default async function Page({
 	params,
 }: {
@@ -60,10 +53,8 @@ export default async function Page({
 		null;
 	if (!cityPlace) notFound();
 
-	const subplaceLabel =
-		race.Place && race.Place.slug?.toLowerCase().endsWith(`/${subplace.toLowerCase()}`)
-			? race.Place.name
-			: humanizeSegment(subplace);
+	const isRealSubplace =
+		race.Place?.slug?.toLowerCase().endsWith(`/${subplace.toLowerCase()}`) ?? false;
 
 	const stateName = getStateName(stateCode);
 	const cityName = cityPlace.name;
@@ -83,7 +74,7 @@ export default async function Page({
 		{ href: `/elections/${state.toLowerCase()}`, label: stateName },
 		{ href: `/elections/${countySlug}`, label: countyName },
 		{ href: `/elections/${cityPathSlug}`, label: cityName },
-		{ href: '', label: subplaceLabel },
+		...(isRealSubplace ? [{ href: '', label: race.Place!.name }] : []),
 		{ href: '', label: `Candidates for ${officeName}` },
 	];
 
@@ -130,13 +121,12 @@ export async function generateMetadata({
 		race?.Place ??
 		null;
 	const cityName = cityPlace?.name ?? city;
-	const subplaceLabel =
-		race?.Place && race.Place.slug?.toLowerCase().endsWith(`/${subplace.toLowerCase()}`)
-			? race.Place.name
-			: humanizeSegment(subplace);
+	const isRealSubplace =
+		race?.Place?.slug?.toLowerCase().endsWith(`/${subplace.toLowerCase()}`) ?? false;
+	const localityLabel = isRealSubplace ? race!.Place!.name : cityName;
 	const positionName = race?.normalizedPositionName ?? race?.name ?? 'Position';
 	return {
-		title: `Candidates for ${positionName} in ${subplaceLabel}, ${cityName}, ${stateName} | Good Party`,
-		description: `View candidates running for ${positionName} in ${subplaceLabel}, ${cityName}, ${countyDisplayName}, ${stateName}.`,
+		title: `Candidates for ${positionName} in ${localityLabel}, ${cityName}, ${stateName} | Good Party`,
+		description: `View candidates running for ${positionName} in ${localityLabel}, ${cityName}, ${countyDisplayName}, ${stateName}.`,
 	};
 }

--- a/src/app/elections/[state]/[county]/[city]/[subplace]/position/[positionSlug]/candidates/page.tsx
+++ b/src/app/elections/[state]/[county]/[city]/[subplace]/position/[positionSlug]/candidates/page.tsx
@@ -123,10 +123,16 @@ export async function generateMetadata({
 	const cityName = cityPlace?.name ?? city;
 	const isRealSubplace =
 		race?.Place?.slug?.toLowerCase().endsWith(`/${subplace.toLowerCase()}`) ?? false;
-	const localityLabel = isRealSubplace ? race!.Place!.name : cityName;
 	const positionName = race?.normalizedPositionName ?? race?.name ?? 'Position';
+	if (isRealSubplace) {
+		const subplaceName = race!.Place!.name;
+		return {
+			title: `Candidates for ${positionName} in ${subplaceName}, ${cityName}, ${stateName} | Good Party`,
+			description: `View candidates running for ${positionName} in ${subplaceName}, ${cityName}, ${countyDisplayName}, ${stateName}.`,
+		};
+	}
 	return {
-		title: `Candidates for ${positionName} in ${localityLabel}, ${cityName}, ${stateName} | Good Party`,
-		description: `View candidates running for ${positionName} in ${localityLabel}, ${cityName}, ${countyDisplayName}, ${stateName}.`,
+		title: `Candidates for ${positionName} in ${cityName}, ${stateName} | Good Party`,
+		description: `View candidates running for ${positionName} in ${cityName}, ${countyDisplayName}, ${stateName}.`,
 	};
 }

--- a/src/app/elections/[state]/[county]/[city]/[subplace]/position/[positionSlug]/page.tsx
+++ b/src/app/elections/[state]/[county]/[city]/[subplace]/position/[positionSlug]/page.tsx
@@ -129,10 +129,16 @@ export async function generateMetadata({
 	const cityName = cityPlace?.name ?? city;
 	const isRealSubplace =
 		race?.Place?.slug?.toLowerCase().endsWith(`/${subplace.toLowerCase()}`) ?? false;
-	const localityLabel = isRealSubplace ? race!.Place!.name : cityName;
 	const positionName = race?.normalizedPositionName ?? race?.name ?? 'Position';
+	if (isRealSubplace) {
+		const subplaceName = race!.Place!.name;
+		return {
+			title: `${positionName} in ${subplaceName}, ${cityName}, ${stateName} | Good Party`,
+			description: `Election details and candidates for ${positionName} in ${subplaceName}, ${cityName}, ${countyDisplayName}, ${stateName}.`,
+		};
+	}
 	return {
-		title: `${positionName} in ${localityLabel}, ${cityName}, ${stateName} | Good Party`,
-		description: `Election details and candidates for ${positionName} in ${localityLabel}, ${cityName}, ${countyDisplayName}, ${stateName}.`,
+		title: `${positionName} in ${cityName}, ${stateName} | Good Party`,
+		description: `Election details and candidates for ${positionName} in ${cityName}, ${countyDisplayName}, ${stateName}.`,
 	};
 }

--- a/src/app/elections/[state]/[county]/[city]/[subplace]/position/[positionSlug]/page.tsx
+++ b/src/app/elections/[state]/[county]/[city]/[subplace]/position/[positionSlug]/page.tsx
@@ -19,13 +19,6 @@ import { PositionPageContent } from '~/ui/PositionPageContent';
 
 export const revalidate = 3600;
 
-function humanizeSegment(segment: string): string {
-	return segment
-		.split('-')
-		.map((w) => w.charAt(0).toUpperCase() + w.slice(1))
-		.join(' ');
-}
-
 export async function generateStaticParams() {
 	const { subplacePositionParams } = await getCachedElectionRouteParams();
 	return subplacePositionParams;
@@ -70,10 +63,8 @@ export default async function Page({
 		null;
 	if (!cityPlace) notFound();
 
-	const subplaceLabel =
-		race.Place && race.Place.slug?.toLowerCase().endsWith(`/${subplace.toLowerCase()}`)
-			? race.Place.name
-			: humanizeSegment(subplace);
+	const isRealSubplace =
+		race.Place?.slug?.toLowerCase().endsWith(`/${subplace.toLowerCase()}`) ?? false;
 
 	const stateName = getStateName(stateCode);
 	const cityName = cityPlace.name;
@@ -88,7 +79,7 @@ export default async function Page({
 		{ href: `/elections/${state.toLowerCase()}`, label: stateName },
 		{ href: `/elections/${countySlug}`, label: countyPlace.name },
 		{ href: `/elections/${cityPathSlug}`, label: cityName },
-		{ href: '', label: subplaceLabel },
+		...(isRealSubplace ? [{ href: '', label: race.Place!.name }] : []),
 		{ href: '', label: officeName },
 	];
 
@@ -136,13 +127,12 @@ export async function generateMetadata({
 		race?.Place ??
 		null;
 	const cityName = cityPlace?.name ?? city;
-	const subplaceLabel =
-		race?.Place && race.Place.slug?.toLowerCase().endsWith(`/${subplace.toLowerCase()}`)
-			? race.Place.name
-			: humanizeSegment(subplace);
+	const isRealSubplace =
+		race?.Place?.slug?.toLowerCase().endsWith(`/${subplace.toLowerCase()}`) ?? false;
+	const localityLabel = isRealSubplace ? race!.Place!.name : cityName;
 	const positionName = race?.normalizedPositionName ?? race?.name ?? 'Position';
 	return {
-		title: `${positionName} in ${subplaceLabel}, ${cityName}, ${stateName} | Good Party`,
-		description: `Election details and candidates for ${positionName} in ${subplaceLabel}, ${cityName}, ${countyDisplayName}, ${stateName}.`,
+		title: `${positionName} in ${localityLabel}, ${cityName}, ${stateName} | Good Party`,
+		description: `Election details and candidates for ${positionName} in ${localityLabel}, ${cityName}, ${countyDisplayName}, ${stateName}.`,
 	};
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -9,7 +9,7 @@ import '~/ui/_styles/globals.css';
 import { Amplitude } from '~/ui/Amplitude';
 import { ScrollDepthTracker } from '~/ui/ScrollDepthTracker';
 import { PageSchema } from '~/ui/PageSchema';
-import { getBaseUrl } from '~/lib/url';
+import { getBaseUrl, SITE_NAME } from '~/lib/url';
 import { buildOrganizationSchema, buildSchemaGraph, buildWebSiteSchema, resolveSameAs } from '~/lib/schema';
 import { sanityFetch } from '~/sanity/sanityClient';
 import { goodpartyOrg_socialChannelsQuery } from '~/sanity/groq';
@@ -48,7 +48,7 @@ export const metadata: Metadata = {
 		'GoodParty.org empowers independent candidates to run, win and serve. Access campaign tools, voter data, and support to level the playing field without deep pockets.',
 	openGraph: {
 		type: 'website',
-		siteName: 'GoodParty.org',
+		siteName: SITE_NAME,
 	},
 	twitter: {
 		card: 'summary_large_image',

--- a/src/components/StructureMetadata.ts
+++ b/src/components/StructureMetadata.ts
@@ -1,7 +1,7 @@
 import type { Metadata, ResolvedMetadata } from 'next';
 import type { Robots } from 'next/dist/lib/metadata/types/metadata-types';
 import type { Group_seo } from 'sanity.types';
-import { DEFAULT_SHARE_IMAGE, getBaseUrl, toAbsoluteUrl } from '~/lib/url';
+import { DEFAULT_SHARE_IMAGE, getBaseUrl, SITE_NAME, toAbsoluteUrl } from '~/lib/url';
 
 function metaString(value: unknown): string | undefined {
 	if (typeof value === 'string') return value;
@@ -28,6 +28,8 @@ export async function StructureMetaData(parentMetadata: ResolvedMetadata, page?:
 		description: metaDescription,
 		openGraph: {
 			...(parentMetadata.openGraph as Metadata['openGraph']),
+			type: 'website',
+			siteName: SITE_NAME,
 			title: metaTitle,
 			images,
 			url: absoluteUrl,

--- a/src/lib/faqSlugs.test.ts
+++ b/src/lib/faqSlugs.test.ts
@@ -4,6 +4,7 @@ import {
 	findFaqBySlug,
 	getAllFaqSlugs,
 	getFaqHref,
+	getFaqSitemapEntries,
 	slugifyFaqQuestion,
 } from './faqSlugs';
 
@@ -117,5 +118,65 @@ describe('findFaqBySlug', () => {
 
 	it('returns undefined for unknown slug', () => {
 		expect(findFaqBySlug(faqs, 'does-not-exist')).toBeUndefined();
+	});
+});
+
+describe('getFaqSitemapEntries', () => {
+	it('returns one canonical entry for three duplicate questions (ticket scenario)', () => {
+		const faqs = [
+			{ _id: 'faq8942aa', faqOverview: { field_question: 'What is GoodParty.org?' } },
+			{ _id: 'faq40f192', faqOverview: { field_question: 'What is GoodParty.org?' } },
+			{ _id: 'faq999999', faqOverview: { field_question: 'What is GoodParty.org?' } },
+		];
+
+		const entries = getFaqSitemapEntries(faqs);
+
+		expect(entries).toHaveLength(1);
+		expect(entries[0]?.slug).toBe('what-is-goodpartyorg');
+		expect(entries[0]?.faq._id).toBe('faq8942aa');
+	});
+
+	it('excludes suffixed duplicates and keeps distinct questions', () => {
+		const downloadQuestion = 'Do I need to download anything to use GoodParty.org?';
+		const faqs = [
+			{ _id: 'download-canonical', faqOverview: { field_question: downloadQuestion } },
+			{ _id: 'download-cc0853', faqOverview: { field_question: downloadQuestion } },
+			{ _id: 'unique-faq', faqOverview: { field_question: 'How much does it cost?' } },
+		];
+
+		const entries = getFaqSitemapEntries(faqs);
+		const slugs = entries.map(e => e.slug);
+
+		expect(entries).toHaveLength(2);
+		expect(slugs).toContain('do-i-need-to-download-anything-to-use-goodpartyorg');
+		expect(slugs).toContain('how-much-does-it-cost');
+		expect(slugs.some(s => s.includes('-cc0853'))).toBe(false);
+	});
+
+	it('includes distinct questions that share a slug prefix after collision suffixing', () => {
+		const faqs = [
+			{ _id: 'aaa111', faqOverview: { field_question: 'What is GoodParty.org?' } },
+			{ _id: 'bbb222', faqOverview: { field_question: 'What is GoodParty.org?' } },
+			{ _id: 'ccc333', faqOverview: { field_question: 'What is GoodParty.org bbb222' } },
+		];
+
+		const entries = getFaqSitemapEntries(faqs);
+		const slugs = entries.map(e => e.slug);
+
+		expect(entries).toHaveLength(2);
+		expect(slugs).toContain('what-is-goodpartyorg');
+		expect(slugs).toContain('what-is-goodpartyorg-bbb222-ccc333');
+	});
+
+	it('includes one entry per FAQ when question is missing (keyed by _id)', () => {
+		const faqs = [
+			{ _id: 'no-question-a' },
+			{ _id: 'no-question-b' },
+		];
+
+		const entries = getFaqSitemapEntries(faqs);
+
+		expect(entries).toHaveLength(2);
+		expect(entries.map(e => e.slug)).toEqual(['no-question-a', 'no-question-b']);
 	});
 });

--- a/src/lib/faqSlugs.test.ts
+++ b/src/lib/faqSlugs.test.ts
@@ -168,6 +168,18 @@ describe('getFaqSitemapEntries', () => {
 		expect(slugs).toContain('what-is-goodpartyorg-bbb222-ccc333');
 	});
 
+	it('keeps all FAQs whose questions slugify to empty string (falls back to _id)', () => {
+		const faqs = [
+			{ _id: 'symbols-a', faqOverview: { field_question: '!!!' } },
+			{ _id: 'symbols-b', faqOverview: { field_question: '@#$' } },
+		];
+
+		const entries = getFaqSitemapEntries(faqs);
+
+		expect(entries).toHaveLength(2);
+		expect(entries.map(e => e.slug)).toEqual(['symbols-a', 'symbols-b']);
+	});
+
 	it('includes one entry per FAQ when question is missing (keyed by _id)', () => {
 		const faqs = [
 			{ _id: 'no-question-a' },

--- a/src/lib/faqSlugs.ts
+++ b/src/lib/faqSlugs.ts
@@ -6,9 +6,15 @@ export const FAQ_BASE_PATH = `/${FAQ_PAGE_SLUG}`;
 
 export type FaqLike = {
 	_id: string;
+	_updatedAt?: string;
 	faqOverview?: {
 		field_question?: unknown;
 	} | null;
+};
+
+export type FaqSitemapEntry = {
+	slug: string;
+	faq: FaqLike;
 };
 
 export function slugifyFaqQuestion(question: string): string {
@@ -75,4 +81,29 @@ export function findFaqBySlug(faqs: ReadonlyArray<FaqLike>, slug: string): FaqLi
 export function getAllFaqSlugs(faqs: ReadonlyArray<FaqLike>): string[] {
 	const slugMap = buildFaqSlugMap(faqs);
 	return faqs.map(faq => getFaqSlug(faq, slugMap));
+}
+
+function faqDedupeKey(faq: FaqLike): string {
+	const question = readQuestion(faq);
+	return question ? slugifyFaqQuestion(question) : faq._id.replace(/^drafts\./, '');
+}
+
+/** One sitemap entry per unique question (first FAQ wins); excludes collision-suffixed duplicates. */
+export function getFaqSitemapEntries(faqs: ReadonlyArray<FaqLike>): FaqSitemapEntry[] {
+	const slugMap = buildFaqSlugMap(faqs);
+	const seenKeys = new Set<string>();
+	const entries: FaqSitemapEntry[] = [];
+
+	for (const faq of faqs) {
+		const key = faqDedupeKey(faq);
+		if (seenKeys.has(key)) continue;
+		seenKeys.add(key);
+
+		const slug = getFaqSlug(faq, slugMap);
+		if (slug) {
+			entries.push({ slug, faq });
+		}
+	}
+
+	return entries;
 }

--- a/src/lib/faqSlugs.ts
+++ b/src/lib/faqSlugs.ts
@@ -85,7 +85,8 @@ export function getAllFaqSlugs(faqs: ReadonlyArray<FaqLike>): string[] {
 
 function faqDedupeKey(faq: FaqLike): string {
 	const question = readQuestion(faq);
-	return question ? slugifyFaqQuestion(question) : faq._id.replace(/^drafts\./, '');
+	const slug = question ? slugifyFaqQuestion(question) : '';
+	return slug || faq._id.replace(/^drafts\./, '');
 }
 
 /** One sitemap entry per unique question (first FAQ wins); excludes collision-suffixed duplicates. */

--- a/src/lib/siteBaseUrl.ts
+++ b/src/lib/siteBaseUrl.ts
@@ -5,6 +5,8 @@
 
 const PRODUCTION_HOST = 'https://goodparty.org';
 
+export const SITE_NAME = 'GoodParty.org';
+
 function sanitizeSiteUrl(value: string | undefined): string | undefined {
 	if (value == null || typeof value !== 'string') return undefined;
 	const cleaned = value.replace(/[\s\r\n]+/g, '').replace(/\/$/, '');

--- a/src/lib/sitemap-entries.ts
+++ b/src/lib/sitemap-entries.ts
@@ -11,7 +11,7 @@ import {
 	resolveElectionPositionFromRaceSlug,
 	stripCountySuffix as stripCountySuffixFromHelpers,
 } from '~/lib/electionsHelpers';
-import { FAQ_BASE_PATH, getAllFaqSlugs } from '~/lib/faqSlugs';
+import { FAQ_BASE_PATH, getFaqSitemapEntries } from '~/lib/faqSlugs';
 import { allFaqsQuery } from '~/sanity/groq';
 
 /** 51 US state/DC codes (50 states + DC) */
@@ -473,14 +473,10 @@ export async function fetchMainSitemapEntries(baseUrl: string): Promise<Metadata
 		}
 	}
 
-	const faqSlugs = getAllFaqSlugs(faqs);
-	for (let i = 0; i < faqs.length; i++) {
-		const slug = faqSlugs[i];
-		if (slug) {
-			entries.push(
-				toEntry(baseUrl, `${FAQ_BASE_PATH}/${slug}`, 0.6, 'monthly', faqs[i]?._updatedAt?.slice(0, 10)),
-			);
-		}
+	for (const { slug, faq } of getFaqSitemapEntries(faqs)) {
+		entries.push(
+			toEntry(baseUrl, `${FAQ_BASE_PATH}/${slug}`, 0.6, 'monthly', faq._updatedAt?.slice(0, 10)),
+		);
 	}
 
 	return dedupeByUrl(entries);

--- a/src/lib/url.ts
+++ b/src/lib/url.ts
@@ -1,7 +1,7 @@
 import { dataset, projectId } from '~/lib/env';
 import { getBaseUrl } from './siteBaseUrl';
 
-export { getBaseUrl } from './siteBaseUrl';
+export { getBaseUrl, SITE_NAME } from './siteBaseUrl';
 
 /** Default share image for Open Graph, Twitter, and schema when no page-specific image is set */
 export const DEFAULT_SHARE_IMAGE = 'https://assets.goodparty.org/gp-share-2025.png';

--- a/src/ui/Nav/MobileNav/index.tsx
+++ b/src/ui/Nav/MobileNav/index.tsx
@@ -32,20 +32,26 @@ export function MobileNav(props: NavProps) {
 						className='min-w-[2.4rem] min-h-[2.7rem] w-[2.4rem] h-[2.7rem] max-w-[2.4rem] max-h-[2.7rem]'
 					/>
 				</Anchor>
-				<div className='flex flex-row gap-[1rem] items-center justify-center w-fit'>
+				<div className='flex flex-row gap-[1rem] max-[360px]:gap-1.5 items-center justify-center w-fit min-w-0 shrink'>
 					{/* Sign-up (and other) CTAs: tracking lives in `ComponentButton` via `isSignUpUrl` / `trackSignUpClicked`. */}
 					{props.secondaryCTA && (
 						<ComponentButton
 							{...props.secondaryCTA}
-							buttonProps={{ styleType: 'outline-inverse', styleSize: 'md' }}
-							className={cn(props.secondaryCTA?.className, 'max-[480px]:[&>div]:hidden')}
+							buttonProps={{ styleType: 'outline-inverse', styleSize: 'sm' }}
+							className={cn(
+								props.secondaryCTA?.className,
+								'max-[360px]:!px-2 max-[360px]:!gap-1 max-[360px]:text-xs',
+							)}
 						/>
 					)}
 					{props.primaryCTA && (
 						<ComponentButton
 							{...props.primaryCTA}
-							buttonProps={{ styleType: 'primary', styleSize: 'md' }}
-							className={cn(props.primaryCTA?.className, 'max-[480px]:[&>div]:hidden')}
+							buttonProps={{ styleType: 'primary', styleSize: 'sm' }}
+							className={cn(
+								props.primaryCTA?.className,
+								'max-[360px]:!px-2 max-[360px]:!gap-1 max-[360px]:text-xs',
+							)}
 						/>
 					)}
 

--- a/src/ui/Nav/MobileNav/index.tsx
+++ b/src/ui/Nav/MobileNav/index.tsx
@@ -32,7 +32,7 @@ export function MobileNav(props: NavProps) {
 						className='min-w-[2.4rem] min-h-[2.7rem] w-[2.4rem] h-[2.7rem] max-w-[2.4rem] max-h-[2.7rem]'
 					/>
 				</Anchor>
-				<div className='flex flex-row gap-[1rem] max-[360px]:gap-1.5 items-center justify-center w-fit min-w-0 shrink'>
+				<div className='flex flex-row gap-[1rem] max-[360px]:gap-1.5 items-center shrink-0'>
 					{/* Sign-up (and other) CTAs: tracking lives in `ComponentButton` via `isSignUpUrl` / `trackSignUpClicked`. */}
 					{props.secondaryCTA && (
 						<ComponentButton

--- a/src/ui/Nav/MobileNav/index.tsx
+++ b/src/ui/Nav/MobileNav/index.tsx
@@ -38,14 +38,14 @@ export function MobileNav(props: NavProps) {
 						<ComponentButton
 							{...props.secondaryCTA}
 							buttonProps={{ styleType: 'outline-inverse', styleSize: 'md' }}
-							className={cn(props.secondaryCTA?.className, 'max-[400px]:[&>*:last-child]:hidden')}
+							className={cn(props.secondaryCTA?.className, 'max-[480px]:[&>div]:hidden')}
 						/>
 					)}
 					{props.primaryCTA && (
 						<ComponentButton
 							{...props.primaryCTA}
 							buttonProps={{ styleType: 'primary', styleSize: 'md' }}
-							className={cn(props.primaryCTA?.className, 'max-[400px]:[&>*:last-child]:hidden')}
+							className={cn(props.primaryCTA?.className, 'max-[480px]:[&>div]:hidden')}
 						/>
 					)}
 

--- a/src/ui/_styles/globals.css
+++ b/src/ui/_styles/globals.css
@@ -129,6 +129,7 @@
 		scroll-padding-top: 8rem;
 		padding: 0 !important;
 		scroll-behavior: smooth;
+		overflow-x: hidden;
 		h1[id],
 		h2[id] {
 			scroll-margin-top: 2.5rem;


### PR DESCRIPTION
- Mobile navbar responsiveness and layout fixes (#131)
- OG site name and election page metadata improvements (#132)
- FAQ sitemap duplicate entries fix (#134)
- Joint position breadcrumbs fix (#133)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are mostly metadata, sitemap deduplication, and UI polish; election breadcrumb/title logic only affects display when the URL subplace does not match a real place slug.
> 
> **Overview**
> This release bundles **Open Graph** consistency, **election subplace** labeling, **FAQ sitemap** deduplication, and **mobile header** layout fixes.
> 
> **OG / metadata:** Introduces shared `SITE_NAME` (`GoodParty.org`) from `siteBaseUrl` and wires it through root layout, Sanity `StructureMetaData`, and candidate profile `openGraph` (with `type: 'website'`).
> 
> **Election subplace routes:** Replaces `humanizeSegment(subplace)` with `isRealSubplace` (place slug must end with the URL subplace). When the segment is not a real subplace (e.g. joint-position URLs), breadcrumbs **omit** the fake subplace crumb and titles/descriptions use **city + state** only; real subplaces still show the place name.
> 
> **FAQ sitemap:** Adds `getFaqSitemapEntries` to emit **one URL per unique question** (first FAQ wins), skipping collision-suffixed duplicate Sanity docs; sitemap generation switches from per-FAQ slugs to this helper (with tests).
> 
> **Mobile nav / layout:** Shrinks header CTAs to `sm`, adds tighter spacing/typography under 360px, and sets `overflow-x: hidden` on `html`/`body` to reduce horizontal scroll.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cecf114c8c087c9faa40af9bbc1c06193a72bc1d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->