### PR TITLE
Enhance candidate profile image resolution and metadata generation

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -71,6 +71,7 @@ const nextConfig = {
 			{ hostname: 'cdn.sanity.io' },
 			{ hostname: 'election-api.goodparty.org' },
 			{ hostname: 'election-api-dev.goodparty.org' },
+			{ hostname: 'assets.goodparty.org' },
 		],
 	},
 	experimental: {

--- a/src/app/candidate/[...slug]/page.tsx
+++ b/src/app/candidate/[...slug]/page.tsx
@@ -16,7 +16,7 @@ import { PageSections } from '~/PageSections';
 import type { SectionOverrides } from '~/PageSections';
 import type { CandidacyItem, FindByRaceIdResponse } from '~/types/elections';
 import type { ProfileData, OfficeData } from '~/PageSections/ProfileContentBlockSection';
-import { SITE_NAME } from '~/lib/url';
+import { DEFAULT_SHARE_IMAGE, SITE_NAME } from '~/lib/url';
 import { PROFILE_PAGE_SECTIONS } from './profilePageSections';
 
 export const revalidate = 3600;
@@ -89,7 +89,7 @@ function buildSectionOverrides(
 		component_profileHero: {
 			candidateName,
 			office,
-			profileImageUrl: resolveProfileImageUrl(candidate.image),
+			profileImageUrl: resolveProfileImageUrl(candidate.image, claimed),
 			isEmpowered: isClaimed,
 		},
 		component_profileContentBlock: {
@@ -203,7 +203,11 @@ export async function generateMetadata({
 	const claimed = await loadClaimedCampaignForCandidate(candidate);
 	const candidateName = [candidate.firstName, candidate.lastName].filter(Boolean).join(' ') || 'Candidate';
 	const positionName = candidate.positionName ?? 'Office';
-	const profileImageUrl = resolveProfileImageUrl(candidate.image);
+	const profileImageUrl = resolveProfileImageUrl(candidate.image, claimed);
+	const ogImageUrl =
+		profileImageUrl?.startsWith('http') ?
+			profileImageUrl
+		:	DEFAULT_SHARE_IMAGE;
 
 	return {
 		title: `${candidateName} for ${positionName} | Good Party`,
@@ -213,7 +217,7 @@ export async function generateMetadata({
 		openGraph: {
 			type: 'website',
 			siteName: SITE_NAME,
-			images: profileImageUrl ? [{ url: profileImageUrl }] : undefined,
+			images: [{ url: ogImageUrl }],
 		},
 	};
 }

--- a/src/lib/electionsHelpers.test.ts
+++ b/src/lib/electionsHelpers.test.ts
@@ -1150,6 +1150,80 @@ describe('claimed profile helpers', () => {
 		expect(resolveProfileImageUrl(' https://example.com/a.jpg ')).toBe('https://example.com/a.jpg');
 		expect(resolveProfileImageUrl('   ')).toBeUndefined();
 	});
+
+	test('resolveProfileImageUrl prefers elections API image over claimed campaign image', () => {
+		expect(
+			resolveProfileImageUrl('https://example.com/elections.jpg', {
+				id: 1,
+				slug: 'candidate',
+				updatedAt: '',
+				website: {
+					id: 1,
+					vanityPath: 'candidate',
+					status: 'published',
+					content: {
+						main: { image: 'https://example.com/claimed.jpg' },
+					},
+					domain: null,
+				},
+				details: null,
+				campaignPositions: [],
+			}),
+		).toBe('https://example.com/elections.jpg');
+	});
+
+	test('resolveProfileImageUrl falls back to claimed main.image then logo', () => {
+		const claimedWithMain = {
+			id: 1,
+			slug: 'candidate',
+			updatedAt: '',
+			website: {
+				id: 1,
+				vanityPath: 'candidate',
+				status: 'published',
+				content: {
+					main: { image: 'https://example.com/main.jpg' },
+					logo: 'https://example.com/logo.jpg',
+				},
+				domain: null,
+			},
+			details: null,
+			campaignPositions: [],
+		};
+
+		expect(resolveProfileImageUrl(null, claimedWithMain)).toBe('https://example.com/main.jpg');
+
+		const claimedWithLogoOnly = {
+			...claimedWithMain,
+			website: {
+				...claimedWithMain.website,
+				content: { logo: 'https://example.com/logo.jpg' },
+			},
+		};
+
+		expect(resolveProfileImageUrl(undefined, claimedWithLogoOnly)).toBe(
+			'https://example.com/logo.jpg',
+		);
+	});
+
+	test('resolveProfileImageUrl ignores malformed claimed website content', () => {
+		expect(
+			resolveProfileImageUrl(null, {
+				id: 1,
+				slug: 'candidate',
+				updatedAt: '',
+				website: {
+					id: 1,
+					vanityPath: 'candidate',
+					status: 'published',
+					content: { main: 'not-an-object', logo: 123 },
+					domain: null,
+				},
+				details: null,
+				campaignPositions: [],
+			}),
+		).toBeUndefined();
+	});
 });
 
 describe('redirectCityRaceToFourLevelUrl', () => {

--- a/src/lib/electionsHelpers.ts
+++ b/src/lib/electionsHelpers.ts
@@ -167,12 +167,39 @@ export function resolveProfileAboutText(
 	return resolveClaimedTextField(claimed?.details?.occupation);
 }
 
-/** Prefers elections API image; public-campaigns does not expose profile photos. */
+function resolveClaimedWebsiteImageUrl(
+	value: unknown,
+): string | undefined {
+	if (typeof value !== 'string') return undefined;
+	const trimmed = value.trim();
+	return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function resolveClaimedProfileImageUrl(
+	claimed: FindByRaceIdResponse | null,
+): string | undefined {
+	const content = claimed?.website?.content;
+	if (!content || typeof content !== 'object') return undefined;
+
+	const main = content['main'];
+	if (main && typeof main === 'object') {
+		const mainImage = resolveClaimedWebsiteImageUrl(
+			(main as { image?: unknown }).image,
+		);
+		if (mainImage) return mainImage;
+	}
+
+	return resolveClaimedWebsiteImageUrl(content['logo']);
+}
+
+/** Prefers elections API image, then claimed website hero, then logo. */
 export function resolveProfileImageUrl(
 	candidateImage: string | null | undefined,
+	claimed?: FindByRaceIdResponse | null,
 ): string | undefined {
 	const image = candidateImage?.trim();
-	return image && image.length > 0 ? image : undefined;
+	if (image && image.length > 0) return image;
+	return resolveClaimedProfileImageUrl(claimed ?? null);
 }
 
 const DATE_ONLY_REGEX = /^\d{4}-\d{2}-\d{2}$/;


### PR DESCRIPTION
- Updated the `resolveProfileImageUrl` function to prefer images from the elections API over claimed campaign images, improving the accuracy of profile visuals.
- Added tests to validate the new image resolution logic, ensuring fallback mechanisms for claimed images are functioning correctly.
- Modified the candidate page metadata to utilize the new image resolution logic, enhancing Open Graph image handling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized display and SEO metadata changes with defensive parsing and unit tests; no auth or data-mutation paths.
> 
> **Overview**
> **Candidate profile photos** now use claimed campaign website assets when the elections API has no image: `resolveProfileImageUrl` still prefers the API image, then falls back to claimed `website.content.main.image`, then `logo`, with guards for malformed content.
> 
> The **candidate profile page** passes claimed campaign data into that helper for the hero and for **Open Graph** metadata. OG images always include a URL—absolute profile URLs when available, otherwise `DEFAULT_SHARE_IMAGE`—instead of omitting `openGraph.images` when no photo exists.
> 
> **Next.js image config** allows `assets.goodparty.org` as a remote image host (likely for claimed campaign assets).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0884823861d76b84b3c1c88906ab32702f2a4647. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->