### PR TITLE
Enhance profile image handling and configuration updates

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -71,6 +71,7 @@ const nextConfig = {
 			{ hostname: 'cdn.sanity.io' },
 			{ hostname: 'election-api.goodparty.org' },
 			{ hostname: 'election-api-dev.goodparty.org' },
+			{ hostname: 'img.clerk.com' },
 		],
 	},
 	experimental: {

--- a/src/app/candidate/[...slug]/page.tsx
+++ b/src/app/candidate/[...slug]/page.tsx
@@ -89,7 +89,7 @@ function buildSectionOverrides(
 		component_profileHero: {
 			candidateName,
 			office,
-			profileImageUrl: resolveProfileImageUrl(candidate.image),
+			profileImageUrl: resolveProfileImageUrl(candidate.image, claimed?.avatar),
 			isEmpowered: isClaimed,
 		},
 		component_profileContentBlock: {
@@ -203,7 +203,7 @@ export async function generateMetadata({
 	const claimed = await loadClaimedCampaignForCandidate(candidate);
 	const candidateName = [candidate.firstName, candidate.lastName].filter(Boolean).join(' ') || 'Candidate';
 	const positionName = candidate.positionName ?? 'Office';
-	const profileImageUrl = resolveProfileImageUrl(candidate.image);
+	const profileImageUrl = resolveProfileImageUrl(candidate.image, claimed?.avatar);
 
 	return {
 		title: `${candidateName} for ${positionName} | Good Party`,

--- a/src/lib/electionsHelpers.test.ts
+++ b/src/lib/electionsHelpers.test.ts
@@ -1150,6 +1150,21 @@ describe('claimed profile helpers', () => {
 		expect(resolveProfileImageUrl(' https://example.com/a.jpg ')).toBe('https://example.com/a.jpg');
 		expect(resolveProfileImageUrl('   ')).toBeUndefined();
 	});
+
+	test('resolveProfileImageUrl prefers claimed avatar over BallotReady image', () => {
+		expect(
+			resolveProfileImageUrl('https://example.com/ballotready.jpg', 'https://example.com/clerk.jpg'),
+		).toBe('https://example.com/clerk.jpg');
+		expect(resolveProfileImageUrl(null, 'https://example.com/clerk.jpg')).toBe(
+			'https://example.com/clerk.jpg',
+		);
+		expect(resolveProfileImageUrl('https://example.com/ballotready.jpg', null)).toBe(
+			'https://example.com/ballotready.jpg',
+		);
+		expect(resolveProfileImageUrl('https://example.com/ballotready.jpg', '   ')).toBe(
+			'https://example.com/ballotready.jpg',
+		);
+	});
 });
 
 describe('redirectCityRaceToFourLevelUrl', () => {

--- a/src/lib/electionsHelpers.ts
+++ b/src/lib/electionsHelpers.ts
@@ -167,11 +167,12 @@ export function resolveProfileAboutText(
 	return resolveClaimedTextField(claimed?.details?.occupation);
 }
 
-/** Prefers elections API image; public-campaigns does not expose profile photos. */
+/** Prefers claimed campaign avatar; falls back to elections API (BallotReady) image. */
 export function resolveProfileImageUrl(
 	candidateImage: string | null | undefined,
+	claimedAvatar?: string | null | undefined,
 ): string | undefined {
-	const image = candidateImage?.trim();
+	const image = claimedAvatar?.trim() || candidateImage?.trim();
 	return image && image.length > 0 ? image : undefined;
 }
 

--- a/src/types/elections.ts
+++ b/src/types/elections.ts
@@ -122,6 +122,7 @@ export interface FindByRaceIdResponse {
 		customIssues?: Array<{ title: string; description?: string; position?: string }>;
 	} | null;
 	updatedAt: string;
+	avatar: string | null;
 	website: {
 		id: number;
 		vanityPath: string;


### PR DESCRIPTION
- Added support for a new image source from 'img.clerk.com' in the Next.js configuration.
- Updated the `resolveProfileImageUrl` function to prioritize claimed avatars over the default candidate images, improving the accuracy of profile representations.
- Modified related components to utilize the updated image resolution logic, ensuring consistent display of candidate images across the application.
- Added tests to verify the new image resolution behavior, ensuring robustness in handling various image scenarios.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized display and config changes for profile images; no auth or data-model migrations beyond typing the new avatar field.
> 
> **Overview**
> Claimed candidates can now show their **campaign avatar** instead of only the BallotReady elections API photo. `resolveProfileImageUrl` takes an optional claimed avatar and uses it when present (after trim), otherwise the existing candidate image behavior is unchanged.
> 
> The candidate profile page passes `claimed?.avatar` into that helper for the hero and for Open Graph metadata. `FindByRaceIdResponse` now includes `avatar: string | null` so the type matches the campaigns API.
> 
> **Next.js image config** adds `img.clerk.com` to `remotePatterns` so Clerk-hosted avatars can load through `next/image`. Unit tests cover avatar-over-BallotReady priority and empty-string fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 102e68335515da24a9aff5690cf68fba5e3d1bfd. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->