### PR TITLE
Refactor election pages to utilize new helper functions

### DIFF
--- a/src/app/elections/[state]/[county]/[city]/page.tsx
+++ b/src/app/elections/[state]/[county]/[city]/page.tsx
@@ -19,10 +19,13 @@ import {
 import { sanityFetch } from '~/sanity/sanityClient';
 import { quoteCollectionByIdQuery } from '~/sanity/groq';
 import {
+	buildOfficeItemsFromPlaceRaces,
 	getStateName,
 	hasSuspiciousFactsMatch,
+	PLACE_RACE_COLUMNS,
 	placeToFactsCards,
 	resolveLocalityName,
+	resolvePlaceRaceElectionDates,
 } from '~/lib/electionsHelpers';
 import { resolveAuthor } from '~/ui/_lib/resolveAuthor';
 import { resolveTextSize } from '~/ui/_lib/resolveTextSize';
@@ -67,7 +70,7 @@ export default async function Page({
 			includeChildren: false,
 			includeRaces: true,
 			placeColumns: 'slug,name,mtfcc,countyName',
-			raceColumns: 'slug,normalizedPositionName,electionDate,positionDescription,positionLevel',
+			raceColumns: PLACE_RACE_COLUMNS,
 		}),
 		getPlaceBySlug({
 			slug: countySlug,
@@ -89,7 +92,7 @@ export default async function Page({
 			includeChildren: false,
 			includeRaces: true,
 			placeColumns: 'slug,name,mtfcc,countyName',
-			raceColumns: 'slug,normalizedPositionName,electionDate,positionDescription,positionLevel',
+			raceColumns: PLACE_RACE_COLUMNS,
 		});
 	}
 
@@ -122,23 +125,18 @@ export default async function Page({
 			const level = r.positionLevel?.toUpperCase();
 			return level === 'LOCAL' || level === 'COUNTY';
 		});
-		const districtOffices = districtRaces.map(race => {
-			const positionSlug = race.slug.split('/').pop() ?? '';
-			return {
-				id: String(race.id),
+		const districtResolvedDates = await resolvePlaceRaceElectionDates(districtRaces);
+		const { offices: districtOffices, dataYears } = buildOfficeItemsFromPlaceRaces(
+			districtRaces,
+			districtResolvedDates,
+			{
 				type: 'District',
-				position: race.normalizedPositionName ?? race.name ?? 'Position',
-				nextElectionDate: race.electionDate ?? '',
-				href: `/elections/${state.toLowerCase()}/${county.toLowerCase()}/${city.toLowerCase()}/position/${positionSlug}`,
-			};
-		});
-		const dataYears = [
-			...new Set(
-				districtRaces
-					.map(r => (r.electionDate ? new Date(r.electionDate).getFullYear() : NaN))
-					.filter((y): y is number => !isNaN(y)),
-			),
-		].sort((a, b) => a - b);
+				buildHref: race => {
+					const positionSlug = race.slug.split('/').pop() ?? '';
+					return `/elections/${state.toLowerCase()}/${county.toLowerCase()}/${city.toLowerCase()}/position/${positionSlug}`;
+				},
+			},
+		);
 		const defaultYear = dataYears.includes(currentYear)
 			? currentYear
 			: (dataYears[0] ?? currentYear);
@@ -291,24 +289,19 @@ export default async function Page({
 		const level = r.positionLevel?.toUpperCase();
 		return level === 'LOCAL' || level === 'CITY';
 	});
-	const cityOffices = cityRaces.map(race => {
-		const positionSlug = race.slug.split('/').pop() ?? '';
-		return {
-			id: String(race.id),
+	const cityResolvedDates = await resolvePlaceRaceElectionDates(cityRaces);
+	const { offices: cityOffices, dataYears } = buildOfficeItemsFromPlaceRaces(
+		cityRaces,
+		cityResolvedDates,
+		{
 			type: 'City',
-			position: race.normalizedPositionName ?? race.name ?? 'Position',
-			nextElectionDate: race.electionDate ?? '',
-			href: `/elections/${state.toLowerCase()}/${county.toLowerCase()}/${city.toLowerCase()}/position/${positionSlug}`,
-		};
-	});
+			buildHref: race => {
+				const positionSlug = race.slug.split('/').pop() ?? '';
+				return `/elections/${state.toLowerCase()}/${county.toLowerCase()}/${city.toLowerCase()}/position/${positionSlug}`;
+			},
+		},
+	);
 
-	const dataYears = [
-		...new Set(
-			cityRaces
-				.map(r => (r.electionDate ? new Date(r.electionDate).getFullYear() : NaN))
-				.filter((y): y is number => !isNaN(y)),
-		),
-	].sort((a, b) => a - b);
 	const defaultYear = dataYears.includes(currentYear)
 		? currentYear
 		: (dataYears[0] ?? currentYear);

--- a/src/app/elections/[state]/[county]/page.tsx
+++ b/src/app/elections/[state]/[county]/page.tsx
@@ -19,11 +19,14 @@ import {
 import { sanityFetch } from '~/sanity/sanityClient';
 import { quoteCollectionByIdQuery } from '~/sanity/groq';
 import {
+	buildOfficeItemsFromPlaceRaces,
 	canonicalizeCountyEquivalentName,
 	getCountySuffixLabel,
 	getStateName,
+	PLACE_RACE_COLUMNS,
 	placeToFactsCards,
 	redirectCityPlaceToFourLevelUrl,
+	resolvePlaceRaceElectionDates,
 } from '~/lib/electionsHelpers';
 import { resolveAuthor } from '~/ui/_lib/resolveAuthor';
 import { resolveTextSize } from '~/ui/_lib/resolveTextSize';
@@ -66,7 +69,7 @@ export default async function Page({
 			includeChildren: false,
 			includeRaces: true,
 			placeColumns: 'slug,name,mtfcc,countyName',
-			raceColumns: 'slug,normalizedPositionName,electionDate,positionDescription,positionLevel',
+			raceColumns: PLACE_RACE_COLUMNS,
 		}),
 		sanityFetch({
 			query: quoteCollectionByIdQuery,
@@ -129,29 +132,24 @@ export default async function Page({
 		textSize: resolveTextSize('Medium'),
 	};
 
-	// County/local positions (e.g. County Sheriff, Library District Board, School Board) from place Races
 	const countyRaces = (placeData?.Races ?? []).filter(r => {
 		const level = r.positionLevel?.toUpperCase();
 		return level === 'COUNTY' || level === 'LOCAL';
 	});
-	const countyOffices = countyRaces.map(race => {
-		const positionSlug = race.slug.split('/').slice(2).join('/');
-		return {
-			id: String(race.id),
-			type: isDistrict ? 'District' : 'County',
-			position: race.normalizedPositionName ?? race.name ?? 'Position',
-			nextElectionDate: race.electionDate ?? '',
-			href: `/elections/${state.toLowerCase()}/${county.toLowerCase()}/position/${positionSlug}`,
-		};
-	});
+	const resolvedDates = await resolvePlaceRaceElectionDates(countyRaces);
+	const officeType = isDistrict ? 'District' : 'County';
+	const { offices: countyOffices, dataYears } = buildOfficeItemsFromPlaceRaces(
+		countyRaces,
+		resolvedDates,
+		{
+			type: officeType,
+			buildHref: race => {
+				const positionSlug = race.slug.split('/').slice(2).join('/');
+				return `/elections/${state.toLowerCase()}/${county.toLowerCase()}/position/${positionSlug}`;
+			},
+		},
+	);
 
-	const dataYears = [
-		...new Set(
-			countyRaces
-				.map(r => (r.electionDate ? new Date(r.electionDate).getFullYear() : NaN))
-				.filter((y): y is number => !isNaN(y)),
-		),
-	].sort((a, b) => a - b);
 	const defaultYear = dataYears.includes(currentYear)
 		? currentYear
 		: (dataYears[0] ?? currentYear);

--- a/src/app/elections/[state]/page.tsx
+++ b/src/app/elections/[state]/page.tsx
@@ -17,7 +17,12 @@ import {
 } from '~/constants/electionsStaticSections';
 import { sanityFetch } from '~/sanity/sanityClient';
 import { quoteCollectionByIdQuery } from '~/sanity/groq';
-import { getStateName } from '~/lib/electionsHelpers';
+import {
+	buildOfficeItemsFromPlaceRaces,
+	getStateName,
+	PLACE_RACE_COLUMNS,
+	resolvePlaceRaceElectionDates,
+} from '~/lib/electionsHelpers';
 import { resolveAuthor } from '~/ui/_lib/resolveAuthor';
 import { resolveTextSize } from '~/ui/_lib/resolveTextSize';
 import { BreadcrumbBlock } from '~/ui/BreadcrumbBlock';
@@ -57,7 +62,7 @@ export default async function Page({
 			slug: state.toLowerCase(),
 			includeChildren: false,
 			includeRaces: true,
-			raceColumns: 'slug,normalizedPositionName,electionDate,positionDescription,positionLevel',
+			raceColumns: PLACE_RACE_COLUMNS,
 		}),
 		sanityFetch({
 			query: quoteCollectionByIdQuery,
@@ -131,24 +136,14 @@ export default async function Page({
 		: (placeData?.Races ?? []).filter(
 				r => r.positionLevel?.toUpperCase() === 'STATE',
 			);
-	const stateOffices = stateRaces.map(race => {
-		const positionSlug = race.slug.split('/').slice(1).join('/');
-		return {
-			id: String(race.id),
-			type: 'State',
-			position: race.normalizedPositionName ?? race.name ?? 'Position',
-			nextElectionDate: race.electionDate ?? '',
-			href: `/elections/${state}/position/${positionSlug}`,
-		};
+	const resolvedDates = await resolvePlaceRaceElectionDates(stateRaces);
+	const { offices: stateOffices, dataYears } = buildOfficeItemsFromPlaceRaces(stateRaces, resolvedDates, {
+		type: 'State',
+		buildHref: race => {
+			const positionSlug = race.slug.split('/').slice(1).join('/');
+			return `/elections/${state}/position/${positionSlug}`;
+		},
 	});
-
-	const dataYears = [
-		...new Set(
-			stateRaces
-				.map(r => (r.electionDate ? new Date(r.electionDate).getFullYear() : NaN))
-				.filter((y): y is number => !isNaN(y)),
-		),
-	].sort((a, b) => a - b);
 
 	const defaultYear = dataYears.includes(currentYear)
 		? currentYear

--- a/src/lib/electionsApi.ts
+++ b/src/lib/electionsApi.ts
@@ -163,11 +163,15 @@ export async function getPositionById(id: string): Promise<PositionDetail | null
 export async function getRaceBySlug(
 	raceSlug: string,
 	includePlace = true,
+	filters?: { isPrimary?: boolean },
 ): Promise<RaceDetail | null> {
 	const searchParams = new URLSearchParams({
 		raceSlug,
 		includePlace: includePlace.toString(),
 	});
+	if (filters?.isPrimary !== undefined) {
+		searchParams.set('isPrimary', filters.isPrimary.toString());
+	}
 	const url = `${ELECTIONS_API_BASE_URL}/v1/races?${searchParams}`;
 	const data = await fetchJson<RaceDetail[]>(url, CACHE_OPTIONS);
 	return Array.isArray(data) && data.length > 0 ? (data[0] ?? null) : null;

--- a/src/lib/electionsHelpers.test.ts
+++ b/src/lib/electionsHelpers.test.ts
@@ -355,6 +355,10 @@ describe('getYearFromDateString', () => {
 	test('returns NaN for invalid string', () => {
 		expect(getYearFromDateString('invalid')).toBeNaN();
 	});
+
+	test('extracts year from ISO datetime using calendar date portion', () => {
+		expect(getYearFromDateString('2026-01-01T00:00:00.000Z')).toBe(2026);
+	});
 });
 
 describe('isElectionDateBeforeToday', () => {
@@ -454,6 +458,20 @@ describe('resolvePlaceRaceElectionDates', () => {
 		expect(resolved.size).toBe(0);
 	});
 
+	test('does not fetch races API when isPrimary is undefined', async () => {
+		let fetchCount = 0;
+		globalThis.fetch = (async () => {
+			fetchCount += 1;
+			return new Response(JSON.stringify([]), { status: 200 });
+		}) as typeof fetch;
+
+		const races = [placeRace({ electionDate: '2026-06-02T00:00:00.000Z', isPrimary: undefined })];
+		const resolved = await resolvePlaceRaceElectionDates(races, today);
+
+		expect(fetchCount).toBe(0);
+		expect(resolved.size).toBe(0);
+	});
+
 	test('falls back to place date when races API returns nothing', async () => {
 		withFetchMock([
 			{
@@ -493,6 +511,22 @@ describe('buildOfficeItemsFromPlaceRaces', () => {
 		expect(offices[0]?.nextElectionDate).toBe('2026-11-03T00:00:00.000Z');
 		expect(offices[1]?.nextElectionDate).toBe('2028-03-07T00:00:00.000Z');
 		expect(dataYears).toEqual([2026, 2028]);
+	});
+
+	test('handles year-boundary ISO datetime correctly', () => {
+		const races = [
+			placeRace({
+				electionDate: '2026-01-01T00:00:00.000Z',
+			}),
+		];
+		const resolvedDates = new Map<string, string>();
+
+		const { dataYears } = buildOfficeItemsFromPlaceRaces(races, resolvedDates, {
+			type: 'State',
+			buildHref: race => `/elections/ca/position/${race.slug.split('/').slice(1).join('/')}`,
+		});
+
+		expect(dataYears).toEqual([2026]);
 	});
 });
 

--- a/src/lib/electionsHelpers.test.ts
+++ b/src/lib/electionsHelpers.test.ts
@@ -361,13 +361,11 @@ describe('isElectionDateBeforeToday', () => {
 	const today = new Date(2026, 6, 1); // July 1, 2026 local
 
 	test('returns true for a past ISO datetime', () => {
-	test('returns true for a past ISO datetime', () => {
 		expect(isElectionDateBeforeToday('2026-06-02T00:00:00.000Z', today)).toBe(true);
 	});
 
 	test('returns false for UTC-midnight ISO datetime on same calendar day', () => {
 		expect(isElectionDateBeforeToday('2026-07-01T00:00:00.000Z', today)).toBe(false);
-	});
 	});
 
 	test('returns false for a future date-only string', () => {
@@ -380,10 +378,6 @@ describe('isElectionDateBeforeToday', () => {
 
 	test('returns false when election day is today', () => {
 		expect(isElectionDateBeforeToday('2026-07-01', today)).toBe(false);
-	});
-
-	test('returns false for UTC-midnight ISO datetime on same calendar day', () => {
-		expect(isElectionDateBeforeToday('2026-07-01T00:00:00.000Z', today)).toBe(false);
 	});
 
 	test('returns false for a malformed date string', () => {

--- a/src/lib/electionsHelpers.test.ts
+++ b/src/lib/electionsHelpers.test.ts
@@ -434,6 +434,20 @@ describe('resolvePlaceRaceElectionDates', () => {
 		expect(resolved.get('ca/lieutenant-governor')).toBe('2026-11-03T00:00:00.000Z');
 	});
 
+	test('does not fetch races API for a past general-election race', async () => {
+		let fetchCount = 0;
+		globalThis.fetch = (async () => {
+			fetchCount += 1;
+			return new Response(JSON.stringify([]), { status: 200 });
+		}) as typeof fetch;
+
+		const races = [placeRace({ electionDate: '2025-11-04T00:00:00.000Z', isPrimary: false })];
+		const resolved = await resolvePlaceRaceElectionDates(races, today);
+
+		expect(fetchCount).toBe(0);
+		expect(resolved.size).toBe(0);
+	});
+
 	test('falls back to place date when races API returns nothing', async () => {
 		withFetchMock([
 			{

--- a/src/lib/electionsHelpers.test.ts
+++ b/src/lib/electionsHelpers.test.ts
@@ -361,7 +361,13 @@ describe('isElectionDateBeforeToday', () => {
 	const today = new Date(2026, 6, 1); // July 1, 2026 local
 
 	test('returns true for a past ISO datetime', () => {
+	test('returns true for a past ISO datetime', () => {
 		expect(isElectionDateBeforeToday('2026-06-02T00:00:00.000Z', today)).toBe(true);
+	});
+
+	test('returns false for UTC-midnight ISO datetime on same calendar day', () => {
+		expect(isElectionDateBeforeToday('2026-07-01T00:00:00.000Z', today)).toBe(false);
+	});
 	});
 
 	test('returns false for a future date-only string', () => {

--- a/src/lib/electionsHelpers.test.ts
+++ b/src/lib/electionsHelpers.test.ts
@@ -379,6 +379,12 @@ describe('isElectionDateBeforeToday', () => {
 	test('returns false for UTC-midnight ISO datetime on same calendar day', () => {
 		expect(isElectionDateBeforeToday('2026-07-01T00:00:00.000Z', today)).toBe(false);
 	});
+
+	test('returns false for a malformed date string', () => {
+		expect(isElectionDateBeforeToday('TBD', today)).toBe(false);
+		expect(isElectionDateBeforeToday('', today)).toBe(false);
+		expect(isElectionDateBeforeToday('not-a-date', today)).toBe(false);
+	});
 });
 
 function placeRace(overrides: Partial<PlaceRace> = {}): PlaceRace {

--- a/src/lib/electionsHelpers.test.ts
+++ b/src/lib/electionsHelpers.test.ts
@@ -375,6 +375,10 @@ describe('isElectionDateBeforeToday', () => {
 	test('returns false when election day is today', () => {
 		expect(isElectionDateBeforeToday('2026-07-01', today)).toBe(false);
 	});
+
+	test('returns false for UTC-midnight ISO datetime on same calendar day', () => {
+		expect(isElectionDateBeforeToday('2026-07-01T00:00:00.000Z', today)).toBe(false);
+	});
 });
 
 function placeRace(overrides: Partial<PlaceRace> = {}): PlaceRace {
@@ -408,7 +412,10 @@ describe('resolvePlaceRaceElectionDates', () => {
 	test('fetches general election date when place date is in the past', async () => {
 		withFetchMock([
 			{
-				match: url => url.includes('/v1/races?') && url.includes('raceSlug=ca%2Flieutenant-governor'),
+				match: url =>
+					url.includes('/v1/races?') &&
+					url.includes('raceSlug=ca%2Flieutenant-governor') &&
+					url.includes('isPrimary=false'),
 				body: [
 					{
 						id: 1,

--- a/src/lib/electionsHelpers.test.ts
+++ b/src/lib/electionsHelpers.test.ts
@@ -4,6 +4,7 @@ import {
 	buildElectionPositionHrefFromRaceSlug,
 	buildFAQSchema,
 	buildJobPostingSchema,
+	buildOfficeItemsFromPlaceRaces,
 	buildRaceCandidatesHref,
 	buildRacePositionHref,
 	buildRaceSlug,
@@ -23,19 +24,21 @@ import {
 	getYearFromDateString,
 	hasSuspiciousFactsMatch,
 	inferSidebarLinkIcon,
+	isElectionDateBeforeToday,
 	placeToFactsCards,
 	redirectCityPlaceToFourLevelUrl,
 	redirectCityRaceToFourLevelUrl,
 	resolveClaimedCustomIssueText,
 	resolveClaimedTextField,
 	resolveLocalityName,
+	resolvePlaceRaceElectionDates,
 	resolveProfileAboutText,
 	resolveProfileImageUrl,
 	slugifyPositionName,
 	stripCountySuffix,
 } from './electionsHelpers';
 import { CITY_MTFCC, COUNTY_MTFCC, TOWN_MTFCC, isCityOrTownMtfcc } from './electionsApi';
-import type { PlaceItem, PlaceWithFacts, RaceDetail } from '~/types/elections';
+import type { PlaceItem, PlaceRace, PlaceWithFacts, RaceDetail } from '~/types/elections';
 
 const originalFetch = globalThis.fetch;
 
@@ -351,6 +354,118 @@ describe('getYearFromDateString', () => {
 
 	test('returns NaN for invalid string', () => {
 		expect(getYearFromDateString('invalid')).toBeNaN();
+	});
+});
+
+describe('isElectionDateBeforeToday', () => {
+	const today = new Date(2026, 6, 1); // July 1, 2026 local
+
+	test('returns true for a past ISO datetime', () => {
+		expect(isElectionDateBeforeToday('2026-06-02T00:00:00.000Z', today)).toBe(true);
+	});
+
+	test('returns false for a future date-only string', () => {
+		expect(isElectionDateBeforeToday('2026-11-03', today)).toBe(false);
+	});
+
+	test('returns false for undefined', () => {
+		expect(isElectionDateBeforeToday(undefined, today)).toBe(false);
+	});
+
+	test('returns false when election day is today', () => {
+		expect(isElectionDateBeforeToday('2026-07-01', today)).toBe(false);
+	});
+});
+
+function placeRace(overrides: Partial<PlaceRace> = {}): PlaceRace {
+	return {
+		id: '1',
+		slug: 'ca/lieutenant-governor',
+		normalizedPositionName: 'Lieutenant Governor',
+		electionDate: '2026-06-02T00:00:00.000Z',
+		isPrimary: true,
+		...overrides,
+	};
+}
+
+describe('resolvePlaceRaceElectionDates', () => {
+	const today = new Date(2026, 6, 1);
+
+	test('does not fetch races API when primary date is still upcoming', async () => {
+		let fetchCount = 0;
+		globalThis.fetch = (async () => {
+			fetchCount += 1;
+			return new Response(JSON.stringify([]), { status: 200 });
+		}) as typeof fetch;
+
+		const races = [placeRace({ electionDate: '2026-11-03T00:00:00.000Z', isPrimary: true })];
+		const resolved = await resolvePlaceRaceElectionDates(races, today);
+
+		expect(fetchCount).toBe(0);
+		expect(resolved.size).toBe(0);
+	});
+
+	test('fetches general election date when place date is in the past', async () => {
+		withFetchMock([
+			{
+				match: url => url.includes('/v1/races?') && url.includes('raceSlug=ca%2Flieutenant-governor'),
+				body: [
+					{
+						id: 1,
+						slug: 'ca/lieutenant-governor',
+						name: 'Lieutenant Governor',
+						state: 'CA',
+						electionDate: '2026-11-03T00:00:00.000Z',
+						isPrimary: false,
+					},
+				],
+			},
+		]);
+
+		const resolved = await resolvePlaceRaceElectionDates([placeRace()], today);
+
+		expect(resolved.get('ca/lieutenant-governor')).toBe('2026-11-03T00:00:00.000Z');
+	});
+
+	test('falls back to place date when races API returns nothing', async () => {
+		withFetchMock([
+			{
+				match: url => url.includes('/v1/races?'),
+				body: [],
+			},
+		]);
+
+		const races = [placeRace()];
+		const resolved = await resolvePlaceRaceElectionDates(races, today);
+
+		expect(resolved.get('ca/lieutenant-governor')).toBe('2026-06-02T00:00:00.000Z');
+	});
+});
+
+describe('buildOfficeItemsFromPlaceRaces', () => {
+	test('uses resolved dates for nextElectionDate and dataYears', () => {
+		const races = [
+			placeRace(),
+			placeRace({
+				id: '2',
+				slug: 'ca/governor',
+				normalizedPositionName: 'Governor',
+				electionDate: '2028-03-07T00:00:00.000Z',
+				isPrimary: true,
+			}),
+		];
+		const resolvedDates = new Map([
+			['ca/lieutenant-governor', '2026-11-03T00:00:00.000Z'],
+		]);
+
+		const { offices, dataYears } = buildOfficeItemsFromPlaceRaces(races, resolvedDates, {
+			type: 'State',
+			buildHref: race => `/elections/ca/position/${race.slug.split('/').slice(1).join('/')}`,
+		});
+
+		expect(offices[0]?.nextElectionDate).toBe('2026-11-03T00:00:00.000Z');
+		expect(offices[1]?.nextElectionDate).toBe('2028-03-07T00:00:00.000Z');
+		expect(dataYears).toEqual([2026, 2028]);
 	});
 });
 

--- a/src/lib/electionsHelpers.ts
+++ b/src/lib/electionsHelpers.ts
@@ -256,11 +256,10 @@ export function formatElectionDateFromApi(dateStr: string | undefined): string {
  * or a pre-formatted string like "November 5, 2026". Uses local-date parsing for ISO to avoid timezone shift.
  */
 export function getYearFromDateString(dateStr: string): number {
-	if (DATE_ONLY_REGEX.test(dateStr)) {
-		return parseDateOnlyAsLocal(dateStr).getFullYear();
+	const dateOnly = dateStr.slice(0, 10);
+	if (DATE_ONLY_REGEX.test(dateOnly)) {
+		return parseDateOnlyAsLocal(dateOnly).getFullYear();
 	}
-	const parsed = new Date(dateStr);
-	if (!Number.isNaN(parsed.getTime())) return parsed.getFullYear();
 	const yearMatch = /\b(19|20)\d{2}\b/.exec(dateStr);
 	return yearMatch ? parseInt(yearMatch[0], 10) : NaN;
 }
@@ -309,7 +308,7 @@ export async function resolvePlaceRaceElectionDates(
 	const staleSlugs = [
 		...new Set(
 			races
-				.filter(r => r.slug && r.electionDate && r.isPrimary !== false && isElectionDateBeforeToday(r.electionDate, today))
+				.filter(r => r.slug && r.electionDate && r.isPrimary === true && isElectionDateBeforeToday(r.electionDate, today))
 				.map(r => r.slug),
 		),
 	];

--- a/src/lib/electionsHelpers.ts
+++ b/src/lib/electionsHelpers.ts
@@ -305,7 +305,7 @@ export async function resolvePlaceRaceElectionDates(
 	const staleSlugs = [
 		...new Set(
 			races
-				.filter(r => r.slug && r.electionDate && isElectionDateBeforeToday(r.electionDate, today))
+				.filter(r => r.slug && r.electionDate && r.isPrimary !== false && isElectionDateBeforeToday(r.electionDate, today))
 				.map(r => r.slug),
 		),
 	];

--- a/src/lib/electionsHelpers.ts
+++ b/src/lib/electionsHelpers.ts
@@ -286,9 +286,13 @@ export function isElectionDateBeforeToday(
 	today: Date = new Date(),
 ): boolean {
 	if (!dateStr) return false;
-	const electionDay = startOfLocalDay(parseElectionDateAsLocal(dateStr));
-	const todayDay = startOfLocalDay(today);
-	return electionDay < todayDay;
+	try {
+		const electionDay = startOfLocalDay(parseElectionDateAsLocal(dateStr));
+		const todayDay = startOfLocalDay(today);
+		return electionDay < todayDay;
+	} catch {
+		return false;
+	}
 }
 
 /**

--- a/src/lib/electionsHelpers.ts
+++ b/src/lib/electionsHelpers.ts
@@ -1,7 +1,8 @@
 import { convert } from 'html-to-text';
 
 import { US_STATES } from '~/constants/usStates';
-import type { CandidacyItem, FindByRaceIdResponse, PlaceItem, PlaceWithFacts, RaceDetail } from '~/types/elections';
+import type { CandidacyItem, FindByRaceIdResponse, PlaceItem, PlaceRace, PlaceWithFacts, RaceDetail } from '~/types/elections';
+import type { OfficeItem } from '~/ui/ListOfOfficesBlock';
 import type { FactsCardProps } from '~/ui/FactsCard';
 
 import { permanentRedirect } from 'next/navigation';
@@ -262,6 +263,95 @@ export function getYearFromDateString(dateStr: string): number {
 	if (!Number.isNaN(parsed.getTime())) return parsed.getFullYear();
 	const yearMatch = /\b(19|20)\d{2}\b/.exec(dateStr);
 	return yearMatch ? parseInt(yearMatch[0], 10) : NaN;
+}
+
+/** Race columns for location pages that build office lists from place races. */
+export const PLACE_RACE_COLUMNS =
+	'slug,normalizedPositionName,electionDate,positionDescription,positionLevel,isPrimary';
+
+function startOfLocalDay(date: Date): Date {
+	return new Date(date.getFullYear(), date.getMonth(), date.getDate());
+}
+
+function parseElectionDateAsLocal(dateStr: string): Date {
+	if (DATE_ONLY_REGEX.test(dateStr)) {
+		return parseDateOnlyAsLocal(dateStr);
+	}
+	return startOfLocalDay(new Date(dateStr));
+}
+
+/** True when the election calendar day is strictly before today (local time). */
+export function isElectionDateBeforeToday(
+	dateStr: string | undefined,
+	today: Date = new Date(),
+): boolean {
+	if (!dateStr) return false;
+	const electionDay = startOfLocalDay(parseElectionDateAsLocal(dateStr));
+	const todayDay = startOfLocalDay(today);
+	return electionDay < todayDay;
+}
+
+/**
+ * For place races whose electionDate is already past, fetches the general-election
+ * record via getRaceBySlug (races API filters to isPrimary:false).
+ */
+export async function resolvePlaceRaceElectionDates(
+	races: PlaceRace[],
+	today: Date = new Date(),
+): Promise<Map<string, string>> {
+	const { getRaceBySlug } = await import('~/lib/electionsApi');
+	const resolved = new Map<string, string>();
+
+	const staleSlugs = [
+		...new Set(
+			races
+				.filter(r => r.slug && r.electionDate && isElectionDateBeforeToday(r.electionDate, today))
+				.map(r => r.slug),
+		),
+	];
+
+	await Promise.all(
+		staleSlugs.map(async slug => {
+			const placeRace = races.find(r => r.slug === slug);
+			const fallback = placeRace?.electionDate ?? '';
+			const race = await getRaceBySlug(slug);
+			resolved.set(slug, race?.electionDate ?? fallback);
+		}),
+	);
+
+	return resolved;
+}
+
+export type BuildOfficeItemsFromPlaceRacesConfig = {
+	type: string;
+	buildHref: (race: PlaceRace) => string;
+};
+
+export function buildOfficeItemsFromPlaceRaces(
+	races: PlaceRace[],
+	resolvedDates: Map<string, string>,
+	config: BuildOfficeItemsFromPlaceRacesConfig,
+): { offices: OfficeItem[]; dataYears: number[] } {
+	const offices: OfficeItem[] = races.map(race => ({
+		id: String(race.id),
+		type: config.type,
+		position: race.normalizedPositionName ?? race.name ?? 'Position',
+		nextElectionDate: resolvedDates.get(race.slug) ?? race.electionDate ?? '',
+		href: config.buildHref(race),
+	}));
+
+	const dataYears = [
+		...new Set(
+			races
+				.map(r => {
+					const dateStr = resolvedDates.get(r.slug) ?? r.electionDate;
+					return dateStr ? getYearFromDateString(dateStr) : NaN;
+				})
+				.filter((y): y is number => !Number.isNaN(y)),
+		),
+	].sort((a, b) => a - b);
+
+	return { offices, dataYears };
 }
 
 export function formatFilingPeriod(

--- a/src/lib/electionsHelpers.ts
+++ b/src/lib/electionsHelpers.ts
@@ -277,7 +277,7 @@ function parseElectionDateAsLocal(dateStr: string): Date {
 	if (DATE_ONLY_REGEX.test(dateStr)) {
 		return parseDateOnlyAsLocal(dateStr);
 	}
-	return startOfLocalDay(new Date(dateStr));
+	return parseDateOnlyAsLocal(dateStr.slice(0, 10));
 }
 
 /** True when the election calendar day is strictly before today (local time). */
@@ -293,7 +293,7 @@ export function isElectionDateBeforeToday(
 
 /**
  * For place races whose electionDate is already past, fetches the general-election
- * record via getRaceBySlug (races API filters to isPrimary:false).
+ * record via getRaceBySlug with isPrimary:false.
  */
 export async function resolvePlaceRaceElectionDates(
 	races: PlaceRace[],
@@ -314,7 +314,7 @@ export async function resolvePlaceRaceElectionDates(
 		staleSlugs.map(async slug => {
 			const placeRace = races.find(r => r.slug === slug);
 			const fallback = placeRace?.electionDate ?? '';
-			const race = await getRaceBySlug(slug);
+			const race = await getRaceBySlug(slug, false, { isPrimary: false });
 			resolved.set(slug, race?.electionDate ?? fallback);
 		}),
 	);

--- a/src/types/elections.ts
+++ b/src/types/elections.ts
@@ -158,6 +158,7 @@ export interface PlaceRace {
 	positionLevel?: string;
 	positionDescription?: string;
 	electionDate?: string;
+	isPrimary?: boolean;
 }
 
 export interface PlaceItem {


### PR DESCRIPTION
- Updated election page components to use `buildOfficeItemsFromPlaceRaces` for constructing office data from race information.
- Replaced hardcoded race column definitions with a constant `PLACE_RACE_COLUMNS` for consistency.
- Integrated `resolvePlaceRaceElectionDates` to fetch and resolve election dates for races, enhancing data accuracy.
- Improved code readability and maintainability by consolidating logic for office item creation across state, county, and city election pages.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> User-visible election dates and year filters on core elections pages can change when primaries have passed, and stale slugs trigger additional races API calls at request time (with fallback to place data).
> 
> **Overview**
> State, county, and city **election landing pages** now build office lists through shared helpers instead of duplicated inline mapping.
> 
> **`resolvePlaceRaceElectionDates`** runs before list rendering: when a place race’s `electionDate` is already in the past (local calendar day), it calls **`getRaceBySlug`** to pick up the **general-election** date; upcoming dates skip extra fetches. **`buildOfficeItemsFromPlaceRaces`** turns races plus that map into `OfficeItem`s and year filters, with per-page `buildHref` callbacks unchanged.
> 
> Place fetches use **`PLACE_RACE_COLUMNS`** (adds **`isPrimary`**) via a new optional field on **`PlaceRace`**. Unit tests cover stale-date resolution, no-fetch when dates are still future, and resolved dates driving **`nextElectionDate`** / **`dataYears`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 139663247c4c5d3506876f858f529d35158084f9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->