### PR TITLE
Fix issue with social links

### DIFF
--- a/src/app/candidate/[...slug]/page.tsx
+++ b/src/app/candidate/[...slug]/page.tsx
@@ -46,9 +46,9 @@ function buildSectionOverrides(
 
 	const links: OfficeData['links'] = [];
 	if (candidate.urls?.length) {
-		candidate.urls.forEach((url, i) => {
+		candidate.urls.forEach((url) => {
 			links.push({
-				label: formatSidebarLinkLabel(url, i),
+				label: formatSidebarLinkLabel(url),
 				icon: inferSidebarLinkIcon(url),
 				href: url,
 			});

--- a/src/app/candidate/[...slug]/page.tsx
+++ b/src/app/candidate/[...slug]/page.tsx
@@ -46,9 +46,9 @@ function buildSectionOverrides(
 
 	const links: OfficeData['links'] = [];
 	if (candidate.urls?.length) {
-		candidate.urls.forEach((url) => {
+		candidate.urls.forEach((url, i) => {
 			links.push({
-				label: formatSidebarLinkLabel(url),
+				label: formatSidebarLinkLabel(url, i),
 				icon: inferSidebarLinkIcon(url),
 				href: url,
 			});

--- a/src/lib/electionsHelpers.test.ts
+++ b/src/lib/electionsHelpers.test.ts
@@ -879,6 +879,8 @@ describe('inferSidebarLinkIcon', () => {
 		expect(inferSidebarLinkIcon('https://youtu.be/abc')).toBe('youtube');
 		expect(inferSidebarLinkIcon('https://www.tiktok.com/@user')).toBe('video');
 		expect(inferSidebarLinkIcon('https://example.com')).toBe('globe');
+		expect(inferSidebarLinkIcon('https://twitter.com/user')).toBe('twitter');
+		expect(inferSidebarLinkIcon('https://x.com/user')).toBe('twitter');
 	});
 });
 

--- a/src/lib/electionsHelpers.test.ts
+++ b/src/lib/electionsHelpers.test.ts
@@ -879,13 +879,22 @@ describe('inferSidebarLinkIcon', () => {
 });
 
 describe('formatSidebarLinkLabel', () => {
-	test('uses Website for first link', () => {
-		expect(formatSidebarLinkLabel('https://example.com', 0)).toBe('Website');
+	test('labels unknown hosts as Website regardless of position', () => {
+		expect(formatSidebarLinkLabel('https://example.com')).toBe('Website');
+		expect(formatSidebarLinkLabel('https://senatedemocrats.wa.gov/kauffman/')).toBe('Website');
 	});
 
-	test('detects platform labels', () => {
-		expect(formatSidebarLinkLabel('https://www.linkedin.com/in/user', 1)).toBe('LinkedIn');
-		expect(formatSidebarLinkLabel('mailto:a@b.com', 1)).toBe('Email');
+	test('detects platform labels from URL', () => {
+		expect(formatSidebarLinkLabel('https://www.linkedin.com/in/user')).toBe('LinkedIn');
+		expect(formatSidebarLinkLabel('mailto:a@b.com')).toBe('Email');
+		expect(formatSidebarLinkLabel('https://facebook.com/page')).toBe('Facebook');
+		expect(formatSidebarLinkLabel('https://www.instagram.com/user')).toBe('Instagram');
+		expect(formatSidebarLinkLabel('https://twitter.com/user')).toBe('Twitter');
+		expect(formatSidebarLinkLabel('https://x.com/user')).toBe('Twitter');
+		expect(formatSidebarLinkLabel('https://en.wikipedia.org/wiki/User')).toBe('Wikipedia');
+		expect(formatSidebarLinkLabel('https://www.youtube.com/watch?v=abc')).toBe('YouTube');
+		expect(formatSidebarLinkLabel('https://youtu.be/abc')).toBe('YouTube');
+		expect(formatSidebarLinkLabel('https://www.tiktok.com/@user')).toBe('TikTok');
 	});
 });
 

--- a/src/lib/electionsHelpers.test.ts
+++ b/src/lib/electionsHelpers.test.ts
@@ -874,27 +874,38 @@ describe('inferSidebarLinkIcon', () => {
 		expect(inferSidebarLinkIcon('mailto:test@example.com')).toBe('mail');
 		expect(inferSidebarLinkIcon('https://www.linkedin.com/in/user')).toBe('linkedin');
 		expect(inferSidebarLinkIcon('https://facebook.com/page')).toBe('facebook');
+		expect(inferSidebarLinkIcon('https://en.wikipedia.org/wiki/User')).toBe('book-open');
+		expect(inferSidebarLinkIcon('https://www.youtube.com/watch?v=abc')).toBe('youtube');
+		expect(inferSidebarLinkIcon('https://youtu.be/abc')).toBe('youtube');
+		expect(inferSidebarLinkIcon('https://www.tiktok.com/@user')).toBe('video');
 		expect(inferSidebarLinkIcon('https://example.com')).toBe('globe');
 	});
 });
 
 describe('formatSidebarLinkLabel', () => {
-	test('labels unknown hosts as Website regardless of position', () => {
-		expect(formatSidebarLinkLabel('https://example.com')).toBe('Website');
-		expect(formatSidebarLinkLabel('https://senatedemocrats.wa.gov/kauffman/')).toBe('Website');
+	test('uses hostname for unknown domains so multiple links stay distinguishable', () => {
+		expect(formatSidebarLinkLabel('https://example.com', 0)).toBe('Example.com');
+		expect(formatSidebarLinkLabel('https://senatedemocrats.wa.gov/kauffman/', 2)).toBe(
+			'Senatedemocrats.wa.gov',
+		);
+		expect(formatSidebarLinkLabel('https://www.voteclaudiakauffman.com/', 3)).toBe('Voteclaudiakauffman.com');
 	});
 
-	test('detects platform labels from URL', () => {
-		expect(formatSidebarLinkLabel('https://www.linkedin.com/in/user')).toBe('LinkedIn');
-		expect(formatSidebarLinkLabel('mailto:a@b.com')).toBe('Email');
-		expect(formatSidebarLinkLabel('https://facebook.com/page')).toBe('Facebook');
-		expect(formatSidebarLinkLabel('https://www.instagram.com/user')).toBe('Instagram');
-		expect(formatSidebarLinkLabel('https://twitter.com/user')).toBe('Twitter');
-		expect(formatSidebarLinkLabel('https://x.com/user')).toBe('Twitter');
-		expect(formatSidebarLinkLabel('https://en.wikipedia.org/wiki/User')).toBe('Wikipedia');
-		expect(formatSidebarLinkLabel('https://www.youtube.com/watch?v=abc')).toBe('YouTube');
-		expect(formatSidebarLinkLabel('https://youtu.be/abc')).toBe('YouTube');
-		expect(formatSidebarLinkLabel('https://www.tiktok.com/@user')).toBe('TikTok');
+	test('detects platform labels from URL regardless of position', () => {
+		expect(formatSidebarLinkLabel('https://www.linkedin.com/in/user', 0)).toBe('LinkedIn');
+		expect(formatSidebarLinkLabel('mailto:a@b.com', 1)).toBe('Email');
+		expect(formatSidebarLinkLabel('https://facebook.com/page', 0)).toBe('Facebook');
+		expect(formatSidebarLinkLabel('https://www.instagram.com/user', 2)).toBe('Instagram');
+		expect(formatSidebarLinkLabel('https://twitter.com/user', 1)).toBe('Twitter');
+		expect(formatSidebarLinkLabel('https://x.com/user', 1)).toBe('Twitter');
+		expect(formatSidebarLinkLabel('https://en.wikipedia.org/wiki/User', 0)).toBe('Wikipedia');
+		expect(formatSidebarLinkLabel('https://www.youtube.com/watch?v=abc', 1)).toBe('YouTube');
+		expect(formatSidebarLinkLabel('https://youtu.be/abc', 1)).toBe('YouTube');
+		expect(formatSidebarLinkLabel('https://www.tiktok.com/@user', 2)).toBe('TikTok');
+	});
+
+	test('falls back to position-based label when URL cannot be parsed', () => {
+		expect(formatSidebarLinkLabel('', 1)).toBe('Link 2');
 	});
 });
 

--- a/src/lib/electionsHelpers.ts
+++ b/src/lib/electionsHelpers.ts
@@ -800,7 +800,7 @@ export function inferSidebarLinkIcon(href: string): string {
 	if (lower.startsWith('mailto:')) return 'mail';
 	if (lower.includes('linkedin.com')) return 'linkedin';
 	if (lower.includes('facebook.com') || lower.includes('fb.com')) return 'facebook';
-	if (lower.includes('twitter.com') || lower.includes('x.com')) return 'twitter';
+	if (lower.includes('twitter.com') || /(?:^|[/.])x\.com(?:\/|$)/.test(lower)) return 'twitter';
 	if (lower.includes('instagram.com')) return 'instagram';
 	if (lower.includes('wikipedia.org')) return 'book-open';
 	if (lower.includes('youtube.com') || lower.includes('youtu.be')) return 'youtube';

--- a/src/lib/electionsHelpers.ts
+++ b/src/lib/electionsHelpers.ts
@@ -802,11 +802,14 @@ export function inferSidebarLinkIcon(href: string): string {
 	if (lower.includes('facebook.com') || lower.includes('fb.com')) return 'facebook';
 	if (lower.includes('twitter.com') || lower.includes('x.com')) return 'twitter';
 	if (lower.includes('instagram.com')) return 'instagram';
+	if (lower.includes('wikipedia.org')) return 'book-open';
+	if (lower.includes('youtube.com') || lower.includes('youtu.be')) return 'youtube';
+	if (lower.includes('tiktok.com')) return 'video';
 	return 'globe';
 }
 
 /** Human-readable label for a candidate profile link inferred from URL. */
-export function formatSidebarLinkLabel(href: string): string {
+export function formatSidebarLinkLabel(href: string, index: number): string {
 	const lower = href.toLowerCase();
 	if (lower.startsWith('mailto:')) return 'Email';
 	if (lower.includes('linkedin.com')) return 'LinkedIn';
@@ -816,7 +819,13 @@ export function formatSidebarLinkLabel(href: string): string {
 	if (lower.includes('wikipedia.org')) return 'Wikipedia';
 	if (lower.includes('youtube.com') || lower.includes('youtu.be')) return 'YouTube';
 	if (lower.includes('tiktok.com')) return 'TikTok';
-	return 'Website';
+	try {
+		const url = new URL(href.startsWith('http') ? href : `https://${href}`);
+		const host = url.hostname.replace(/^www\./, '');
+		return host.charAt(0).toUpperCase() + host.slice(1);
+	} catch {
+		return `Link ${index + 1}`;
+	}
 }
 
 export type SidebarLink = { label: string; icon: string; href: string };

--- a/src/lib/electionsHelpers.ts
+++ b/src/lib/electionsHelpers.ts
@@ -814,7 +814,7 @@ export function formatSidebarLinkLabel(href: string, index: number): string {
 	if (lower.startsWith('mailto:')) return 'Email';
 	if (lower.includes('linkedin.com')) return 'LinkedIn';
 	if (lower.includes('facebook.com') || lower.includes('fb.com')) return 'Facebook';
-	if (lower.includes('twitter.com') || lower.includes('x.com')) return 'Twitter';
+	if (lower.includes('twitter.com') || /(?:^|[/.])x\.com(?:\/|$)/.test(lower)) return 'Twitter';
 	if (lower.includes('instagram.com')) return 'Instagram';
 	if (lower.includes('wikipedia.org')) return 'Wikipedia';
 	if (lower.includes('youtube.com') || lower.includes('youtu.be')) return 'YouTube';

--- a/src/lib/electionsHelpers.ts
+++ b/src/lib/electionsHelpers.ts
@@ -805,22 +805,18 @@ export function inferSidebarLinkIcon(href: string): string {
 	return 'globe';
 }
 
-/** Human-readable label for a candidate profile link (first URL is always Website). */
-export function formatSidebarLinkLabel(href: string, index: number): string {
-	if (index === 0) return 'Website';
+/** Human-readable label for a candidate profile link inferred from URL. */
+export function formatSidebarLinkLabel(href: string): string {
 	const lower = href.toLowerCase();
 	if (lower.startsWith('mailto:')) return 'Email';
 	if (lower.includes('linkedin.com')) return 'LinkedIn';
 	if (lower.includes('facebook.com') || lower.includes('fb.com')) return 'Facebook';
 	if (lower.includes('twitter.com') || lower.includes('x.com')) return 'Twitter';
 	if (lower.includes('instagram.com')) return 'Instagram';
-	try {
-		const url = new URL(href.startsWith('http') ? href : `https://${href}`);
-		const host = url.hostname.replace(/^www\./, '');
-		return host.charAt(0).toUpperCase() + host.slice(1);
-	} catch {
-		return `Link ${index + 1}`;
-	}
+	if (lower.includes('wikipedia.org')) return 'Wikipedia';
+	if (lower.includes('youtube.com') || lower.includes('youtu.be')) return 'YouTube';
+	if (lower.includes('tiktok.com')) return 'TikTok';
+	return 'Website';
 }
 
 export type SidebarLink = { label: string; icon: string; href: string };

--- a/src/ui/ElectionsSidebar.mdx
+++ b/src/ui/ElectionsSidebar.mdx
@@ -52,6 +52,18 @@ Minimal variant with a single link and one info field. Demonstrates the componen
 
 Full sidebar without the CTA button. Useful when the call-to-action is handled elsewhere on the page.
 
+### Multiple Websites
+
+<Canvas of={ElectionsSidebarStories.MultipleWebsites} />
+
+Candidate profiles with several custom-domain links. Labels are derived from each URL hostname so government and campaign sites remain distinguishable.
+
+### Social Platforms
+
+<Canvas of={ElectionsSidebarStories.SocialPlatforms} />
+
+Platform links (LinkedIn, Instagram, Wikipedia, YouTube, TikTok) receive platform-specific labels and icons regardless of their position in the list.
+
 ## Props
 
 <Controls of={ElectionsSidebarStories.Default} />
@@ -72,10 +84,13 @@ Each `SidebarLink` contains:
 **Example:**
 ```typescript
 links: [
-  { label: 'Website', icon: 'globe', href: 'https://www.example.com' },
+  { label: 'LinkedIn', icon: 'linkedin', href: 'https://www.linkedin.com/in/candidate' },
+  { label: 'Ci.northville.mi.us', icon: 'globe', href: 'https://www.ci.northville.mi.us/' },
   { label: 'Email', icon: 'mail', href: 'mailto:contact@example.com' },
 ]
 ```
+
+On candidate profile pages, labels and icons are inferred from each URL via `formatSidebarLinkLabel` and `inferSidebarLinkIcon` in `electionsHelpers.ts`. Known platforms get platform names; other URLs use a capitalized hostname so multiple websites stay distinguishable.
 
 #### `aboutOffice` (optional)
 
@@ -113,12 +128,15 @@ Additional CSS classes to apply to the component.
 
 The component uses the Lucide icon set through `IconResolver`. Common icon names include:
 
-- `globe` - Website/URL icon
+- `globe` - Generic website/URL icon
 - `mail` - Email icon
 - `facebook` - Facebook social icon
-- `link` - Generic link icon
 - `twitter` - Twitter/X icon
 - `linkedin` - LinkedIn icon
+- `instagram` - Instagram icon
+- `youtube` - YouTube icon
+- `book-open` - Wikipedia icon
+- `video` - TikTok icon
 
 Icons are optional - links will render without icons if the `icon` property is omitted.
 

--- a/src/ui/ElectionsSidebar.stories.tsx
+++ b/src/ui/ElectionsSidebar.stories.tsx
@@ -1,5 +1,20 @@
 import type { Meta, StoryObj } from '@storybook/react';
+import { formatSidebarLinkLabel, inferSidebarLinkIcon } from '~/lib/electionsHelpers';
 import { ElectionsSidebar } from './ElectionsSidebar.tsx';
+
+function toSidebarLink(href: string, index: number) {
+	return {
+		label: formatSidebarLinkLabel(href, index),
+		icon: inferSidebarLinkIcon(href),
+		href,
+	};
+}
+
+const defaultLinks = [
+	toSidebarLink('https://www.linkedin.com/in/jane-candidate', 0),
+	toSidebarLink('https://www.facebook.com/jane', 1),
+	toSidebarLink('mailto:hello@example.com', 2),
+];
 
 const meta: Meta<typeof ElectionsSidebar> = {
 	title: 'New Components/Components/Elections Sidebar',
@@ -20,11 +35,7 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
 	args: {
-		links: [
-			{ label: 'Website', icon: 'globe', href: 'https://www.website.com' },
-			{ label: 'Facebook', icon: 'facebook', href: 'https://www.facebook.com/' },
-			{ label: 'Email', icon: 'mail', href: 'mailto:hello@example.com' },
-		],
+		links: defaultLinks,
 		aboutOffice: 'Body text here',
 		termLength: 'Body text here',
 		electionDate: 'Body text here',
@@ -37,11 +48,7 @@ export const Default: Story = {
 
 export const WithLinksOnly: Story = {
 	args: {
-		links: [
-			{ label: 'Website', icon: 'globe', href: 'https://www.website.com' },
-			{ label: 'Facebook', icon: 'facebook', href: 'https://www.facebook.com/' },
-			{ label: 'Email', icon: 'mail', href: 'mailto:hello@example.com' },
-		],
+		links: defaultLinks,
 	},
 };
 
@@ -59,20 +66,44 @@ export const WithInfoOnly: Story = {
 
 export const Minimal: Story = {
 	args: {
-		links: [{ label: 'Website', icon: 'globe', href: 'https://www.website.com' }],
+		links: [toSidebarLink('https://www.janeforoffice.com', 0)],
 		aboutOffice: 'Body text here',
 	},
 };
 
 export const WithoutCTA: Story = {
 	args: {
-		links: [
-			{ label: 'Website', icon: 'globe', href: 'https://www.website.com' },
-			{ label: 'Facebook', icon: 'facebook', href: 'https://www.facebook.com/' },
-			{ label: 'Email', icon: 'mail', href: 'mailto:hello@example.com' },
-		],
+		links: defaultLinks,
 		aboutOffice: 'Body text here',
 		termLength: 'Body text here',
 		electionDate: 'Body text here',
+	},
+};
+
+/** Mirrors candidate profiles with multiple custom-domain links (hostname labels). */
+export const MultipleWebsites: Story = {
+	args: {
+		links: [
+			toSidebarLink('https://www.facebook.com/voteclaudiakauffman/', 0),
+			toSidebarLink('https://www.linkedin.com/in/claudia-kauffman-5367762a/', 1),
+			toSidebarLink('https://senatedemocrats.wa.gov/kauffman/', 2),
+			toSidebarLink('https://www.voteclaudiakauffman.com/', 3),
+		],
+		aboutOffice: 'Washington State Senate, District 47',
+		termLength: '4 Years',
+		electionDate: 'November 5, 2024',
+	},
+};
+
+/** Social platforms at any array position, including LinkedIn first. */
+export const SocialPlatforms: Story = {
+	args: {
+		links: [
+			toSidebarLink('https://www.linkedin.com/in/dr-tracey-stallworth-25144aa0/', 0),
+			toSidebarLink('https://www.instagram.com/dr.traceystallworth/', 1),
+			toSidebarLink('https://en.wikipedia.org/wiki/Example', 2),
+			toSidebarLink('https://www.youtube.com/@candidate', 3),
+			toSidebarLink('https://www.tiktok.com/@candidate', 4),
+		],
 	},
 };

--- a/src/ui/ProfileContentBlock.mdx
+++ b/src/ui/ProfileContentBlock.mdx
@@ -16,7 +16,7 @@ The ProfileContentBlock component displays a two-column layout with an optional 
 Use this component when:
 - Displaying candidate profile content sections
 - Showing multiple content cards (About Me, Why Running, Top Issues, etc.)
-- Providing contact links (Website, Facebook, Email) in a sidebar
+- Providing contact links (LinkedIn, Facebook, custom websites, Email) in a sidebar
 - Displaying office information (About Office, Term Length, Election Date) in a sidebar
 - Creating a sticky sidebar for navigation or key information
 
@@ -60,7 +60,7 @@ ElectionsSidebar configuration. When provided, displays a sticky sidebar on the 
 **Type:** `ElectionsSidebarProps`
 
 Sidebar can include:
-- `links` - Array of link objects with label, optional icon, and href (e.g., Website, Facebook, Email)
+- `links` - Array of link objects with label, optional icon, and href (e.g., LinkedIn, Facebook, hostname-based website labels, Email)
 - `aboutOffice` - Text describing the office position
 - `termLength` - Text describing the term length
 - `electionDate` - Text showing the election date
@@ -100,7 +100,7 @@ When the sidebar is present on desktop (`lg:`) **and** content cards are rendere
 
 When the sidebar is the only content (no content cards), it spans the full `max-w-3xl` well and is not sticky.
 - Provides quick access to contact links, office information, and CTA
-- Displays links with icons (Website, Facebook, Email, etc.)
+- Displays links with icons (LinkedIn, Facebook, custom websites, Email, etc.)
 - Shows office details (About Office, Term Length, Election Date) with separators
 
 ## Content Cards

--- a/src/ui/ProfileContentBlock.stories.tsx
+++ b/src/ui/ProfileContentBlock.stories.tsx
@@ -1,5 +1,14 @@
 import type { Meta, StoryObj } from '@storybook/react';
+import { formatSidebarLinkLabel, inferSidebarLinkIcon } from '~/lib/electionsHelpers';
 import { ProfileContentBlock } from './ProfileContentBlock.tsx';
+
+function toSidebarLink(href: string, index: number) {
+	return {
+		label: formatSidebarLinkLabel(href, index),
+		icon: inferSidebarLinkIcon(href),
+		href,
+	};
+}
 
 const meta: Meta<typeof ProfileContentBlock> = {
 	title: 'New Components/Page Sections/Profile Content Block',
@@ -18,9 +27,9 @@ type Story = StoryObj<typeof meta>;
 
 const defaultSidebar = {
 	links: [
-		{ label: 'Website', icon: 'globe', href: 'https://www.website.com' },
-		{ label: 'Facebook', icon: 'facebook', href: 'https://www.facebook.com/' },
-		{ label: 'Email', icon: 'mail', href: 'mailto:hello@example.com' },
+		toSidebarLink('https://www.linkedin.com/in/jane-candidate', 0),
+		toSidebarLink('https://www.facebook.com/jane', 1),
+		toSidebarLink('mailto:hello@example.com', 2),
 	],
 	aboutOffice: 'Body text here',
 	termLength: 'Body text here',
@@ -83,9 +92,9 @@ export const MidnightBackground: Story = {
 		backgroundColor: 'midnight',
 		sidebar: {
 			links: [
-				{ label: 'Website', icon: 'globe', href: 'https://www.website.com' },
-				{ label: 'Facebook', icon: 'facebook', href: 'https://www.facebook.com/' },
-				{ label: 'Email', icon: 'mail', href: 'mailto:hello@example.com' },
+				toSidebarLink('https://www.linkedin.com/in/jane-candidate', 0),
+				toSidebarLink('https://www.facebook.com/jane', 1),
+				toSidebarLink('mailto:hello@example.com', 2),
 			],
 			aboutOffice: 'Body text here',
 			termLength: 'Body text here',
@@ -114,8 +123,8 @@ export const MultipleCards: Story = {
 		backgroundColor: 'cream',
 		sidebar: {
 			links: [
-				{ label: 'Website', icon: 'globe', href: 'https://www.website.com' },
-				{ label: 'Email', icon: 'mail', href: 'mailto:hello@example.com' },
+				toSidebarLink('https://www.janeforoffice.com', 0),
+				toSidebarLink('mailto:hello@example.com', 1),
 			],
 			aboutOffice: 'Body text here',
 			termLength: 'Body text here',
@@ -162,21 +171,9 @@ export const LongUrls: Story = {
 		backgroundColor: 'cream',
 		sidebar: {
 			links: [
-				{
-					label: 'LinkedIn',
-					icon: 'linkedin',
-					href: 'https://www.linkedin.com/in/dylan-hays-5263b0218',
-				},
-				{
-					label: 'Website',
-					icon: 'globe',
-					href: 'https://www.ci.northville.mi.us/government/city-council',
-				},
-				{
-					label: 'Campaign',
-					icon: 'globe',
-					href: 'https://www.krenzfornorthville.com/about-the-candidate',
-				},
+				toSidebarLink('https://www.linkedin.com/in/dylan-hays-5263b0218', 0),
+				toSidebarLink('https://www.ci.northville.mi.us/government/city-council', 1),
+				toSidebarLink('https://www.krenzfornorthville.com/about-the-candidate', 2),
 			],
 			aboutOffice:
 				'The City Legislature is the legislative branch of City Government. The Legislature is composed of a seven-member Council, elected from six Council districts and one at-large Council member.',


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Localized display logic for candidate sidebar links with expanded unit tests; claimed-website prepend behavior is unchanged.
> 
> **Overview**
> Fixes candidate profile sidebar links so labels and icons match the actual URL instead of treating the first link as a generic **Website**.
> 
> **`formatSidebarLinkLabel`** no longer forces index `0` to **Website**; known platforms (LinkedIn, Facebook, Instagram, Twitter/X, Wikipedia, YouTube, TikTok, email) get fixed names at any list position, and other URLs use a capitalized hostname (e.g. `Senatedemocrats.wa.gov`) so multiple campaign or government sites stay distinct. **`inferSidebarLinkIcon`** adds Wikipedia (`book-open`), YouTube, and TikTok (`video`).
> 
> Unit tests, Storybook stories (including **Multiple Websites** and **Social Platforms**), and Elections/Profile sidebar docs are updated to reflect URL-driven inference via `electionsHelpers`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d055603c534213b8d220b65731bc9135488d6b0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->