### PR TITLE
Update global styles to change overflow behavior

### DIFF
--- a/src/ui/_styles/globals.css
+++ b/src/ui/_styles/globals.css
@@ -129,7 +129,7 @@
 		scroll-padding-top: 8rem;
 		padding: 0 !important;
 		scroll-behavior: smooth;
-		overflow-x: hidden;
+		overflow-x: clip;
 		h1[id],
 		h2[id] {
 			scroll-margin-top: 2.5rem;


### PR DESCRIPTION
- Modified the `overflow-x` property in `globals.css` from `hidden` to `clip` to improve layout handling and prevent unintended horizontal scrolling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single global CSS property change with no auth, data, or business-logic impact; main risk is minor layout/scroll differences in edge browsers.
> 
> **Overview**
> Updates the global `html, body` rule in `globals.css` so horizontal overflow is handled with **`overflow-x: clip`** instead of **`overflow-x: hidden`**.
> 
> The goal is the same—no page-level horizontal scroll from wide content—but **`clip`** avoids some side effects of **`hidden`** (e.g. scroll-container behavior that can interfere with layout and scrolling). Localized horizontal scrolling (tables, etc.) still uses **`overflow-x-auto`** on those components.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce3eccd5ec8a5f1aedd8fff983af8d7fbf039a60. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->