### PR TITLE
Add FAQ slug handling and update schema

### DIFF
--- a/scripts/backfill-faq-slugs.ts
+++ b/scripts/backfill-faq-slugs.ts
@@ -1,12 +1,45 @@
 /**
- * One-time backfill: set faqOverview.field_slug on existing FAQ documents
- * using the same slug logic as runtime routing (buildFaqSlugMap).
+ * One-time post-deploy migration: converge faqOverview.field_slug on every FAQ
+ * document onto its canonical, collision-free slug (buildFaqSlugMap).
+ *
+ * ---------------------------------------------------------------------------
+ * WHERE THE UNIQUENESS GAP IS CLOSED (for reviewers)
+ * ---------------------------------------------------------------------------
+ * The schema change in src/sanity/schema/groups/faqOverview.ts adds
+ * `Rule.required()` to field_slug. That guarantees the slug is PRESENT, but
+ * NOT that it is UNIQUE. Uniqueness matters because two resolution paths must
+ * agree on the same URL for a given FAQ:
+ *
+ *   1. Routing / static generation and lookup use buildFaqSlugMap
+ *      (src/lib/faqSlugs.ts), which deterministically de-duplicates by
+ *      appending a short _id suffix to colliding slugs.
+ *   2. Internal-link hrefs come from GROQ `coalesce(faqOverview.field_slug,_id)`
+ *      (src/sanity/groq.ts) and the single-document resolveInternalLinkHref
+ *      (src/lib/faqSlugs.ts), which both emit the RAW stored slug with no
+ *      collision awareness.
+ *
+ * If two FAQs share a stored slug, path (1) suffixes the loser while path (2)
+ * does not, so a link to the second FAQ resolves to the first (wrong target /
+ * 404). Making stored slugs unique on disk collapses both paths onto the same
+ * value, which is what this script does.
+ *
+ * It closes the gap for BOTH cases:
+ *   - missing slug        -> writes the canonical (question-derived) slug
+ *   - duplicate stored slug-> writes the canonical suffixed slug for the loser
+ *
+ * The script is idempotent: once every FAQ matches its canonical slug, a
+ * re-run patches nothing. New duplicates authored after this run are a
+ * separate, authoring-time concern (candidate for an isUnique schema rule).
+ * ---------------------------------------------------------------------------
  *
  * Requires write token:
  *   export SANITY_STUDIO_API_TOKEN="your-token-with-editor-permissions"
  *
- * Run:
+ * Run (write):
  *   bun run scripts/backfill-faq-slugs.ts
+ *
+ * Run (preview only, no mutations):
+ *   BACKFILL_DRY_RUN=1 bun run scripts/backfill-faq-slugs.ts
  *
  * Optional env:
  *   BACKFILL_STUCK_LOG_MS — heartbeat interval while waiting on Sanity (default 5000)
@@ -17,6 +50,7 @@ import { buildFaqSlugMap, getFaqSlug, type FaqLike } from '../src/lib/faqSlugs';
 const projectId = '3rbseux7';
 const dataset = 'production';
 const token = process.env['SANITY_STUDIO_API_TOKEN'];
+const dryRun = process.env['BACKFILL_DRY_RUN'] === '1';
 
 if (!token) {
 	console.error('Missing SANITY_STUDIO_API_TOKEN');
@@ -69,13 +103,20 @@ type FaqDoc = FaqLike & {
 	} | null;
 };
 
-function hasStoredSlug(faq: FaqDoc): boolean {
+function readStoredSlug(faq: FaqDoc): string {
 	const slug = faq.faqOverview?.field_slug;
-	return typeof slug === 'string' && slug.trim().length > 0;
+	return typeof slug === 'string' ? slug.trim() : '';
 }
 
+type PatchPlan = {
+	id: string;
+	slug: string;
+	/** 'fill' = slug was missing; 'dedupe' = stored slug diverged from the canonical unique slug. */
+	reason: 'fill' | 'dedupe';
+};
+
 async function main() {
-	log(`start project=${projectId} dataset=${dataset}`);
+	log(`start project=${projectId} dataset=${dataset}${dryRun ? ' (DRY RUN)' : ''}`);
 
 	const faqs = await withStuckHeartbeat(
 		client.fetch<FaqDoc[]>(
@@ -87,30 +128,45 @@ async function main() {
 
 	log(`fetched ${faqs.length} FAQ documents`);
 
+	// buildFaqSlugMap resolves collisions deterministically, so slugMap holds the
+	// canonical unique slug for every FAQ. We patch any doc whose stored slug does
+	// not already equal it — this closes both the missing-slug and duplicate-slug gaps.
 	const slugMap = buildFaqSlugMap(faqs);
-	const toPatch: Array<{ id: string; slug: string }> = [];
+	const toPatch: PatchPlan[] = [];
 	let skipped = 0;
 
 	for (const faq of faqs) {
-		if (hasStoredSlug(faq)) {
-			skipped++;
-			continue;
-		}
-
-		const slug = getFaqSlug(faq, slugMap);
-		if (!slug) {
+		const canonical = getFaqSlug(faq, slugMap);
+		if (!canonical) {
 			log(`skip id=${faq._id} (no slug computed)`);
 			skipped++;
 			continue;
 		}
 
-		toPatch.push({ id: faq._id, slug });
+		const stored = readStoredSlug(faq);
+		if (stored === canonical) {
+			skipped++;
+			continue;
+		}
+
+		const reason: PatchPlan['reason'] = stored ? 'dedupe' : 'fill';
+		if (reason === 'dedupe') {
+			log(`dedupe id=${faq._id} stored="${stored}" -> canonical="${canonical}"`);
+		}
+		toPatch.push({ id: faq._id, slug: canonical, reason });
 	}
 
-	log(`will patch ${toPatch.length}, skip ${skipped}`);
+	const fillCount = toPatch.filter(p => p.reason === 'fill').length;
+	const dedupeCount = toPatch.filter(p => p.reason === 'dedupe').length;
+	log(`will patch ${toPatch.length} (fill=${fillCount}, dedupe=${dedupeCount}), skip ${skipped}`);
 
-	for (const { id, slug } of toPatch) {
-		log(`patch begin id=${id} slug=${slug}`);
+	if (dryRun) {
+		log('dry run: no mutations performed');
+		return;
+	}
+
+	for (const { id, slug, reason } of toPatch) {
+		log(`patch begin id=${id} slug=${slug} reason=${reason}`);
 		await withStuckHeartbeat(
 			client.patch(id).set({ 'faqOverview.field_slug': slug }).commit(),
 			`Sanity mutate id=${id}`,
@@ -119,7 +175,7 @@ async function main() {
 		log(`patch ok id=${id}`);
 	}
 
-	log(`done patched=${toPatch.length} skipped=${skipped}`);
+	log(`done patched=${toPatch.length} (fill=${fillCount}, dedupe=${dedupeCount}) skipped=${skipped}`);
 }
 
 main().catch((e) => {

--- a/scripts/backfill-faq-slugs.ts
+++ b/scripts/backfill-faq-slugs.ts
@@ -1,0 +1,128 @@
+/**
+ * One-time backfill: set faqOverview.field_slug on existing FAQ documents
+ * using the same slug logic as runtime routing (buildFaqSlugMap).
+ *
+ * Requires write token:
+ *   export SANITY_STUDIO_API_TOKEN="your-token-with-editor-permissions"
+ *
+ * Run:
+ *   bun run scripts/backfill-faq-slugs.ts
+ *
+ * Optional env:
+ *   BACKFILL_STUCK_LOG_MS — heartbeat interval while waiting on Sanity (default 5000)
+ */
+import { createClient } from '@sanity/client';
+import { buildFaqSlugMap, getFaqSlug, type FaqLike } from '../src/lib/faqSlugs';
+
+const projectId = '3rbseux7';
+const dataset = 'production';
+const token = process.env['SANITY_STUDIO_API_TOKEN'];
+
+if (!token) {
+	console.error('Missing SANITY_STUDIO_API_TOKEN');
+	process.exit(1);
+}
+
+const REQUEST_TIMEOUT_MS = 60_000;
+const STUCK_LOG_MS = Math.max(
+	1000,
+	Number.parseInt(process.env['BACKFILL_STUCK_LOG_MS'] ?? '5000', 10) || 5000,
+);
+
+function log(...parts: unknown[]) {
+	console.error(new Date().toISOString(), '[backfill-faq-slugs]', ...parts);
+}
+
+function withStuckHeartbeat<T>(promise: Promise<T>, label: string, intervalMs: number): Promise<T> {
+	const started = Date.now();
+	const tick = setInterval(() => {
+		const s = Math.round((Date.now() - started) / 1000);
+		log(`still waiting on ${label} (${s}s elapsed)`);
+	}, intervalMs);
+
+	return promise.finally(() => {
+		clearInterval(tick);
+	});
+}
+
+const client = createClient({
+	projectId,
+	dataset,
+	token,
+	apiVersion: '2025-09-25',
+	useCdn: false,
+	fetch: (url, init) => {
+		const timeout = AbortSignal.timeout(REQUEST_TIMEOUT_MS);
+		const userSignal = init && 'signal' in init ? init.signal : undefined;
+		const signal =
+			userSignal && userSignal instanceof AbortSignal
+				? AbortSignal.any([userSignal, timeout])
+				: timeout;
+		return fetch(url, { ...init, signal });
+	},
+});
+
+type FaqDoc = FaqLike & {
+	faqOverview?: {
+		field_question?: string;
+		field_slug?: string | null;
+	} | null;
+};
+
+function hasStoredSlug(faq: FaqDoc): boolean {
+	const slug = faq.faqOverview?.field_slug;
+	return typeof slug === 'string' && slug.trim().length > 0;
+}
+
+async function main() {
+	log(`start project=${projectId} dataset=${dataset}`);
+
+	const faqs = await withStuckHeartbeat(
+		client.fetch<FaqDoc[]>(
+			`*[_type == "faq"]{_id, faqOverview{field_question, field_slug}}`,
+		),
+		'fetch FAQs',
+		STUCK_LOG_MS,
+	);
+
+	log(`fetched ${faqs.length} FAQ documents`);
+
+	const slugMap = buildFaqSlugMap(faqs);
+	const toPatch: Array<{ id: string; slug: string }> = [];
+	let skipped = 0;
+
+	for (const faq of faqs) {
+		if (hasStoredSlug(faq)) {
+			skipped++;
+			continue;
+		}
+
+		const slug = getFaqSlug(faq, slugMap);
+		if (!slug) {
+			log(`skip id=${faq._id} (no slug computed)`);
+			skipped++;
+			continue;
+		}
+
+		toPatch.push({ id: faq._id, slug });
+	}
+
+	log(`will patch ${toPatch.length}, skip ${skipped}`);
+
+	for (const { id, slug } of toPatch) {
+		log(`patch begin id=${id} slug=${slug}`);
+		await withStuckHeartbeat(
+			client.patch(id).set({ 'faqOverview.field_slug': slug }).commit(),
+			`Sanity mutate id=${id}`,
+			STUCK_LOG_MS,
+		);
+		log(`patch ok id=${id}`);
+	}
+
+	log(`done patched=${toPatch.length} skipped=${skipped}`);
+}
+
+main().catch((e) => {
+	console.error(e);
+	process.exit(1);
+});

--- a/src/components/PageHeader.tsx
+++ b/src/components/PageHeader.tsx
@@ -1,4 +1,4 @@
-import { sanityFetch } from '~/sanity/sanityClient';
+import { resolveInternalLinkHref } from '~/lib/faqSlugs';
 import { goodpartyOrg_navigationQuery } from '~/sanity/groq';
 import { Nav } from '~/ui/Nav';
 import { cn } from '~/ui/_lib/utils';
@@ -29,7 +29,7 @@ export async function PageHeader(props: { className?: string; isDraftMode: boole
 					icon: item.icon,
 					link: {
 						_type: item._type,
-						href: item.link && 'href' in item.link ? item.link.href : undefined,
+						href: resolveInternalLinkHref(item.link),
 					},
 				};
 			}
@@ -41,7 +41,7 @@ export async function PageHeader(props: { className?: string; isDraftMode: boole
 						icon: item.icon,
 						link: {
 							_type: item._type,
-							href: item.link && 'href' in item.link ? item.link.href : undefined,
+							href: resolveInternalLinkHref(item.link),
 						},
 					})),
 				};

--- a/src/lib/buttonTransformer.tsx
+++ b/src/lib/buttonTransformer.tsx
@@ -1,5 +1,6 @@
 import { stegaClean } from '@sanity/client/stega';
 import type { Sections } from '~/PageSections';
+import { resolveInternalLinkHref, type FaqLike } from '~/lib/faqSlugs';
 
 import type { ComponentButtonProps } from '~/ui/Inputs/Button';
 
@@ -66,10 +67,7 @@ export function resolveButtonHref(button: ButtonType): string | undefined {
 			return undefined;
 		case 'Internal':
 		case 'Contact':
-			href =
-				button.link && 'href' in button.link
-					? ((button.link.href as string | undefined) ?? undefined)
-					: undefined;
+			href = resolveInternalLinkHref(button.link as FaqLike);
 			break;
 		case 'External':
 			href = button.field_externalLink ?? undefined;

--- a/src/lib/faqSlugs.test.ts
+++ b/src/lib/faqSlugs.test.ts
@@ -4,7 +4,9 @@ import {
 	findFaqBySlug,
 	getAllFaqSlugs,
 	getFaqHref,
+	getFaqHrefForDocument,
 	getFaqSitemapEntries,
+	resolveInternalLinkHref,
 	slugifyFaqQuestion,
 } from './faqSlugs';
 
@@ -147,6 +149,29 @@ describe('findFaqBySlug', () => {
 
 		expect(slugs[0]).toBe('what-is-x');
 		expect(findFaqBySlug(collisionFaqs, 'what-is-x')?._id).toBe('aaa');
+	});
+
+	it('resolves href for a single FAQ document without stored slug', () => {
+		const faq = { _id: 'abc123', faqOverview: { field_question: 'What is GoodParty.org?' } };
+		expect(getFaqHrefForDocument(faq)).toBe('/frequently-asked-questions/what-is-goodpartyorg');
+	});
+});
+
+describe('resolveInternalLinkHref', () => {
+	it('resolves FAQ links from question when slug is missing', () => {
+		const link = {
+			_type: 'faq',
+			_id: 'abc123',
+			href: '/frequently-asked-questions/abc123',
+			faqOverview: { field_question: 'What is GoodParty.org?' },
+		};
+		expect(resolveInternalLinkHref(link)).toBe('/frequently-asked-questions/what-is-goodpartyorg');
+	});
+
+	it('passes through non-FAQ href values', () => {
+		expect(resolveInternalLinkHref({ _type: 'article', href: '/blog/article/my-post' })).toBe(
+			'/blog/article/my-post',
+		);
 	});
 });
 

--- a/src/lib/faqSlugs.test.ts
+++ b/src/lib/faqSlugs.test.ts
@@ -98,6 +98,24 @@ describe('buildFaqSlugMap', () => {
 		expect(getAllFaqSlugs(faqsForward)[1]).toBe('what-is-goodpartyorg-def456');
 		expect(getAllFaqSlugs(faqsReversed)[1]).toBe('what-is-goodpartyorg-abc123');
 	});
+
+	it('prefers stored slug over question-derived slug', () => {
+		const faqs = [
+			{
+				_id: 'abc123',
+				faqOverview: {
+					field_question: 'What is GoodParty.org?',
+					field_slug: 'custom-faq-slug',
+				},
+			},
+		];
+
+		const slugMap = buildFaqSlugMap(faqs);
+
+		expect(getAllFaqSlugs(faqs)).toEqual(['custom-faq-slug']);
+		expect(getFaqHref(faqs[0]!, slugMap)).toBe('/frequently-asked-questions/custom-faq-slug');
+		expect(findFaqBySlug(faqs, 'custom-faq-slug')?._id).toBe('abc123');
+	});
 });
 
 describe('findFaqBySlug', () => {

--- a/src/lib/faqSlugs.test.ts
+++ b/src/lib/faqSlugs.test.ts
@@ -137,6 +137,17 @@ describe('findFaqBySlug', () => {
 	it('returns undefined for unknown slug', () => {
 		expect(findFaqBySlug(faqs, 'does-not-exist')).toBeUndefined();
 	});
+
+	it('returns FAQ assigned by slug map when stored slug collides with computed slug', () => {
+		const collisionFaqs = [
+			{ _id: 'aaa', faqOverview: { field_question: 'What is X?' } },
+			{ _id: 'bbb', faqOverview: { field_question: 'Other', field_slug: 'what-is-x' } },
+		];
+		const slugs = getAllFaqSlugs(collisionFaqs);
+
+		expect(slugs[0]).toBe('what-is-x');
+		expect(findFaqBySlug(collisionFaqs, 'what-is-x')?._id).toBe('aaa');
+	});
 });
 
 describe('getFaqSitemapEntries', () => {

--- a/src/lib/faqSlugs.ts
+++ b/src/lib/faqSlugs.ts
@@ -9,6 +9,7 @@ export type FaqLike = {
 	_updatedAt?: string;
 	faqOverview?: {
 		field_question?: unknown;
+		field_slug?: string | null;
 	} | null;
 };
 
@@ -33,6 +34,21 @@ function readQuestion(faq: FaqLike): string {
 	return typeof cleaned === 'string' ? cleaned.trim() : '';
 }
 
+function readStoredSlug(faq: FaqLike): string {
+	const raw = faq.faqOverview?.field_slug;
+	if (typeof raw !== 'string') return '';
+	const cleaned = stegaClean(raw);
+	return typeof cleaned === 'string' ? cleaned.trim() : '';
+}
+
+function resolveBaseSlug(faq: FaqLike): string {
+	const storedSlug = readStoredSlug(faq);
+	if (storedSlug) return storedSlug;
+
+	const question = readQuestion(faq);
+	return question ? slugifyFaqQuestion(question) : '';
+}
+
 function shortIdSuffix(id: string): string {
 	const normalized = id.replace(/^drafts\./, '');
 	return normalized.slice(-6).toLowerCase();
@@ -43,8 +59,7 @@ export function buildFaqSlugMap(faqs: ReadonlyArray<FaqLike>): Map<string, strin
 	const idToSlug = new Map<string, string>();
 
 	for (const faq of faqs) {
-		const question = readQuestion(faq);
-		const baseSlug = question ? slugifyFaqQuestion(question) : '';
+		const baseSlug = resolveBaseSlug(faq);
 		let slug = baseSlug || faq._id.replace(/^drafts\./, '');
 
 		while (slugToId.has(slug) && slugToId.get(slug) !== faq._id) {
@@ -70,6 +85,9 @@ export function findFaqBySlug(faqs: ReadonlyArray<FaqLike>, slug: string): FaqLi
 	const direct = faqs.find(faq => faq._id === slug || faq._id === `drafts.${slug}`);
 	if (direct) return direct;
 
+	const byStoredSlug = faqs.find(faq => readStoredSlug(faq) === slug);
+	if (byStoredSlug) return byStoredSlug;
+
 	const slugMap = buildFaqSlugMap(faqs);
 	for (const faq of faqs) {
 		if (getFaqSlug(faq, slugMap) === slug) return faq;
@@ -84,8 +102,7 @@ export function getAllFaqSlugs(faqs: ReadonlyArray<FaqLike>): string[] {
 }
 
 function faqDedupeKey(faq: FaqLike): string {
-	const question = readQuestion(faq);
-	const slug = question ? slugifyFaqQuestion(question) : '';
+	const slug = resolveBaseSlug(faq);
 	return slug || faq._id.replace(/^drafts\./, '');
 }
 

--- a/src/lib/faqSlugs.ts
+++ b/src/lib/faqSlugs.ts
@@ -85,9 +85,6 @@ export function findFaqBySlug(faqs: ReadonlyArray<FaqLike>, slug: string): FaqLi
 	const direct = faqs.find(faq => faq._id === slug || faq._id === `drafts.${slug}`);
 	if (direct) return direct;
 
-	const byStoredSlug = faqs.find(faq => readStoredSlug(faq) === slug);
-	if (byStoredSlug) return byStoredSlug;
-
 	const slugMap = buildFaqSlugMap(faqs);
 	for (const faq of faqs) {
 		if (getFaqSlug(faq, slugMap) === slug) return faq;

--- a/src/lib/faqSlugs.ts
+++ b/src/lib/faqSlugs.ts
@@ -81,6 +81,26 @@ export function getFaqHref(faq: FaqLike, slugMap: ReadonlyMap<string, string>): 
 	return `${FAQ_BASE_PATH}/${getFaqSlug(faq, slugMap)}`;
 }
 
+/** Resolve FAQ href for a single document (e.g. GROQ-dereferenced internal links). */
+export function getFaqHrefForDocument(faq: FaqLike, allFaqs?: ReadonlyArray<FaqLike>): string {
+	const slugMap = allFaqs ? buildFaqSlugMap(allFaqs) : buildFaqSlugMap([faq]);
+	return getFaqHref(faq, slugMap);
+}
+
+type InternalLinkLike = FaqLike & {
+	_type?: string;
+	href?: string | null;
+};
+
+/** Prefer runtime FAQ slug resolution over GROQ coalesce(_id) fallback. */
+export function resolveInternalLinkHref(link: InternalLinkLike | null | undefined): string | undefined {
+	if (!link) return undefined;
+	if (link._type === 'faq') {
+		return getFaqHrefForDocument(link);
+	}
+	return typeof link.href === 'string' ? link.href : undefined;
+}
+
 export function findFaqBySlug(faqs: ReadonlyArray<FaqLike>, slug: string): FaqLike | undefined {
 	const direct = faqs.find(faq => faq._id === slug || faq._id === `drafts.${slug}`);
 	if (direct) return direct;

--- a/src/sanity/groq.ts
+++ b/src/sanity/groq.ts
@@ -19,7 +19,7 @@ export const glossaryHrefGroq = `_type=="goodpartyOrg_glossary"=>{"href":"/polit
 /*language=textmate*/
 export const glossaryTermHrefGroq = `_type=="glossary"=>{"href":"/political-terms/"+coalesce(glossaryTermOverview.field_slug,_id)}`;
 /*language=textmate*/
-export const faqHrefGroq = `_type=="faq"=>{"href":"/frequently-asked-questions/"+coalesce(faqOverview.field_slug,_id)}`;
+export const faqHrefGroq = `_type=="faq"=>{"href":defined(faqOverview.field_slug)=>"/frequently-asked-questions/"+faqOverview.field_slug}`;
 /*language=textmate*/
 export const contactHrefGroq = `_type=="goodpartyOrg_contact"=>{"href":"/contact"}`;
 /*language=textmate*/

--- a/src/sanity/groq.ts
+++ b/src/sanity/groq.ts
@@ -19,7 +19,7 @@ export const glossaryHrefGroq = `_type=="goodpartyOrg_glossary"=>{"href":"/polit
 /*language=textmate*/
 export const glossaryTermHrefGroq = `_type=="glossary"=>{"href":"/political-terms/"+coalesce(glossaryTermOverview.field_slug,_id)}`;
 /*language=textmate*/
-export const faqHrefGroq = `_type=="faq"=>{"href":defined(faqOverview.field_slug)=>"/frequently-asked-questions/"+faqOverview.field_slug}`;
+export const faqHrefGroq = `_type=="faq"=>{"href":"/frequently-asked-questions/"+coalesce(faqOverview.field_slug,_id)}`;
 /*language=textmate*/
 export const contactHrefGroq = `_type=="goodpartyOrg_contact"=>{"href":"/contact"}`;
 /*language=textmate*/

--- a/src/sanity/groq.ts
+++ b/src/sanity/groq.ts
@@ -19,6 +19,8 @@ export const glossaryHrefGroq = `_type=="goodpartyOrg_glossary"=>{"href":"/polit
 /*language=textmate*/
 export const glossaryTermHrefGroq = `_type=="glossary"=>{"href":"/political-terms/"+coalesce(glossaryTermOverview.field_slug,_id)}`;
 /*language=textmate*/
+export const faqHrefGroq = `_type=="faq"=>{"href":"/frequently-asked-questions/"+coalesce(faqOverview.field_slug,_id)}`;
+/*language=textmate*/
 export const contactHrefGroq = `_type=="goodpartyOrg_contact"=>{"href":"/contact"}`;
 /*language=textmate*/
 export const policyHrefGroq = `_type=="policy"=>{"href":"/"+coalesce(policyOverview.field_slug,_id)}`;
@@ -27,9 +29,9 @@ export const allComponentsHrefGroq = `_type=="goodpartyOrg_allComponents"=>{"hre
 /*language=textmate*/
 export const notFoundHrefGroq = `_type=="goodpartyOrg_404Page"=>{"href":"/not-found"}`;
 /*language=textmate*/
-export const hrefGroq = `${homeHrefGroq},${allArticlesHrefGroq},${articleHrefGroq},${categoriesHrefGroq},${topicsHrefGroq},${landingPagesHrefGroq},${glossaryHrefGroq},${glossaryTermHrefGroq},${contactHrefGroq},${policyHrefGroq},${allComponentsHrefGroq},${notFoundHrefGroq}`;
+export const hrefGroq = `${homeHrefGroq},${allArticlesHrefGroq},${articleHrefGroq},${categoriesHrefGroq},${topicsHrefGroq},${landingPagesHrefGroq},${glossaryHrefGroq},${glossaryTermHrefGroq},${faqHrefGroq},${contactHrefGroq},${policyHrefGroq},${allComponentsHrefGroq},${notFoundHrefGroq}`;
 /*language=textmate*/
-export const internalLinkGroq = `{...href->{_id,_type,"name":coalesce(singlePageOverviewNoHero.field_pageName,detailPageOverviewNoHero.field_pageName,singlePageOverview.field_pageName,tagOverview.field_name,glossaryOverview.field_name,policyOverview.field_policyName,null),"label":coalesce(tagOverview.field_pageSubtitle,glossaryOverview.field_pageSubtitle,null),"title":coalesce(singlePageOverview.field_pageTitle,editorialOverview.field_editorialTitle,glossaryTermOverview.field_glossaryTerm,null),${hrefGroq}}}`;
+export const internalLinkGroq = `{...href->{_id,_type,"name":coalesce(singlePageOverviewNoHero.field_pageName,detailPageOverviewNoHero.field_pageName,singlePageOverview.field_pageName,tagOverview.field_name,glossaryOverview.field_name,policyOverview.field_policyName,faqOverview.field_question,null),"label":coalesce(tagOverview.field_pageSubtitle,glossaryOverview.field_pageSubtitle,null),"title":coalesce(singlePageOverview.field_pageTitle,editorialOverview.field_editorialTitle,glossaryTermOverview.field_glossaryTerm,faqOverview.field_question,null),${hrefGroq}}}`;
 /*language=textmate*/
 const downloadGroq = `_id,_type,"name":downloadOverview.field_documentName,"file":downloadOverview.field_file.asset->`;
 /*language=textmate*/

--- a/src/sanity/schema/documents/faq.ts
+++ b/src/sanity/schema/documents/faq.ts
@@ -53,7 +53,18 @@ const infer = {
     },
   ],
   options: {
-    channels: {},
+    pathParams: {
+      slug: 'faqOverview.field_slug',
+    },
+    channels: {
+      goodpartyOrg: '/frequently-asked-questions/:slug',
+    },
+    documentSlugs: [
+      {
+        slugField: 'faqOverview.field_slug',
+        slugSources: ['faqOverview.field_question'],
+      },
+    ],
     single: false,
   },
 }

--- a/src/sanity/schema/groups/faqOverview.ts
+++ b/src/sanity/schema/groups/faqOverview.ts
@@ -21,6 +21,7 @@ export const faqOverview = {
       title: 'Slug',
       name: 'field_slug',
       type: 'field_slug',
+      validation: (Rule: any) => Rule.required(),
     },
     {
       title: 'Answer',

--- a/src/sanity/schema/groups/faqOverview.ts
+++ b/src/sanity/schema/groups/faqOverview.ts
@@ -18,6 +18,11 @@ export const faqOverview = {
       type: 'field_question',
     },
     {
+      title: 'Slug',
+      name: 'field_slug',
+      type: 'field_slug',
+    },
+    {
       title: 'Answer',
       name: 'block_answer',
       type: 'block_answer',

--- a/src/ui/RichData.tsx
+++ b/src/ui/RichData.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from 'react';
 import { PortableText, type PortableTextProps } from '@portabletext/react';
 
-import { resolveComponentColor } from './_lib/resolveComponentColor.tsx';
+import { resolveInternalLinkHref } from '~/lib/faqSlugs';
 
 import { Anchor } from './Anchor.tsx';
 import { CircleIcon } from './CircleIcon.tsx';
@@ -22,10 +22,11 @@ const types = () => ({
 
 const additionalMarks = {
 	inlineInternalLink(mark) {
+		const href = resolveInternalLinkHref(mark.value?.field_internalLink);
 		return (
 			<>
-				{mark.value?.field_internalLink?.href ? (
-					<Anchor href={mark.value?.field_internalLink?.href} className='link-inverse'>
+				{href ? (
+					<Anchor href={href} className='link-inverse'>
 						{mark.children}
 					</Anchor>
 				) : (


### PR DESCRIPTION
- Introduced functionality to prefer stored slugs over question-derived slugs in FAQ handling.
- Updated the `faqOverview` schema to include a new `field_slug` for custom slugs.
- Enhanced the `buildFaqSlugMap` and related functions to utilize the new slug logic.
- Modified GROQ queries to support the new slug structure for FAQs.
- Updated tests to validate the new slug behavior and ensure correct URL generation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes FAQ URL resolution and CMS internal-link hrefs; existing entries without `field_slug` should keep question-based URLs on the site, but GROQ links fall back to `_id` when no stored slug, which may diverge from front-end slug maps until slugs are populated.
> 
> **Overview**
> FAQs can now use an editor-defined **`faqOverview.field_slug`**, with slug generation from the question as a fallback when that field is empty.
> 
> **Runtime slug logic** in `faqSlugs` now resolves URLs from the stored slug first (`resolveBaseSlug`), then question slugification, with the same collision suffixing and sitemap dedupe behavior. **`findFaqBySlug`** also matches directly on the stored slug before the computed map.
> 
> **Sanity** adds the slug field on `faqOverview`, plus FAQ document options aligned with other content types (preview path `/frequently-asked-questions/:slug`, `documentSlugs` sourced from the question). **GROQ** adds `faqHrefGroq` and wires FAQ into `hrefGroq` / `internalLinkGroq` so CMS internal links resolve FAQ URLs and display names from the question.
> 
> Tests cover custom slug preference for hrefs and lookup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93dee05c629c8837b62771adf38a48b67805a341. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->