### PR TITLE
Change symbol to correct value.

### DIFF
--- a/src/ui/CalculatorTextBlock.tsx
+++ b/src/ui/CalculatorTextBlock.tsx
@@ -266,7 +266,7 @@ export function CalculatorTextBlock(props: CalculatorTextBlockProps) {
 									{props.calculator?.othersCostLabel ?? 'Total cost'}
 								</Text>
 								<Text as='span' styleType='caption' className={hexagonDetail()}>
-									{props.calculator?.othersPerRecordDetail ?? '£0.1 per record'}
+									{props.calculator?.othersPerRecordDetail ?? '$0.1 per record'}
 								</Text>
 							</div>
 						</div>


### PR DESCRIPTION
Originally we had an incorrect symbol in the designs and requirements.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single fallback string change in UI copy with no logic, auth, or data handling impact.
> 
> **Overview**
> Corrects the **Others** hexagon fallback copy for per-record pricing from **£0.1** to **$0.1** when CMS does not supply `othersPerRecordDetail`.
> 
> This aligns the static label with `formatCurrency`, which already formats amounts as **USD**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc4dcfb9797fc19ade6e143e7a9ab3c6ac49ee1a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->