### PR TITLE
Fix PR 142 delegate review blockers (round 2)

### DIFF
--- a/src/app/api/hubspot/newsletter/route.test.ts
+++ b/src/app/api/hubspot/newsletter/route.test.ts
@@ -74,7 +74,7 @@ describe('POST /api/hubspot/newsletter', () => {
 		expect(fetchMock).toHaveBeenCalledTimes(1);
 	});
 
-	test('forwards HubSpot error status and details', async () => {
+	test('forwards HubSpot 4xx error status and details', async () => {
 		const hubspotError = { message: 'INVALID_EMAIL', status: 'error' };
 		const fetchMock = mock(async () =>
 			new Response(JSON.stringify(hubspotError), { status: 400 }),
@@ -90,5 +90,20 @@ describe('POST /api/hubspot/newsletter', () => {
 			error: 'HubSpot submission failed',
 			details: hubspotError,
 		});
+	});
+
+	test('returns generic 502 for HubSpot 5xx errors without details', async () => {
+		const hubspotError = { message: 'Internal server error', traceId: 'abc-123' };
+		const fetchMock = mock(async () =>
+			new Response(JSON.stringify(hubspotError), { status: 503 }),
+		);
+		globalThis.fetch = fetchMock as typeof fetch;
+
+		const { POST } = await import('./route');
+		const response = await POST(
+			createRequest({ formId: VALID_FORM_ID, email: 'user@example.com' }),
+		);
+		expect(response.status).toBe(502);
+		expect(await response.json()).toEqual({ error: 'HubSpot submission failed' });
 	});
 });

--- a/src/app/api/hubspot/newsletter/route.ts
+++ b/src/app/api/hubspot/newsletter/route.ts
@@ -65,7 +65,13 @@ export async function POST(request: NextRequest) {
 	const result = await hubspotResponse.json().catch(() => ({}));
 
 	if (!hubspotResponse.ok) {
-		return NextResponse.json({ error: 'HubSpot submission failed', details: result }, { status: hubspotResponse.status });
+		const isClientError = hubspotResponse.status >= 400 && hubspotResponse.status < 500;
+		return NextResponse.json(
+			isClientError
+				? { error: 'HubSpot submission failed', details: result }
+				: { error: 'HubSpot submission failed' },
+			{ status: isClientError ? hubspotResponse.status : 502 },
+		);
 	}
 
 	return NextResponse.json({ ok: true });

--- a/src/lib/isSafeRelativeRedirect.test.ts
+++ b/src/lib/isSafeRelativeRedirect.test.ts
@@ -21,4 +21,8 @@ describe('isSafeRelativeRedirect', () => {
 	it('blocks absolute URLs', () => {
 		expect(isSafeRelativeRedirect('https://evil.com')).toBe(false);
 	});
+
+	it('blocks double-encoded protocol-relative URL bypass', () => {
+		expect(isSafeRelativeRedirect('/%252F%252Fevil.com')).toBe(false);
+	});
 });

--- a/src/lib/isSafeRelativeRedirect.ts
+++ b/src/lib/isSafeRelativeRedirect.ts
@@ -1,9 +1,13 @@
 export function isSafeRelativeRedirect(path: string): boolean {
 	let decoded = path;
 	try {
-		decoded = decodeURIComponent(path);
+		let prev: string;
+		do {
+			prev = decoded;
+			decoded = decodeURIComponent(decoded);
+		} while (decoded !== prev);
 	} catch {
-		// malformed %-encoding — use original
+		// malformed %-encoding — use last successfully decoded value
 	}
 	return decoded.startsWith('/') && !decoded.startsWith('//') && !decoded.startsWith('/\\');
 }


### PR DESCRIPTION
## Summary
- Loop-decode redirect paths in `isSafeRelativeRedirect` to block double-encoded open-redirect bypasses (`/%252F%252Fevil.com`)
- Add regression test for the double-encoding bypass
- Sanitize HubSpot 5xx responses: return generic 502 with no internal `details`; keep 4xx forwarding unchanged

Addresses the 3 remaining blockers from delegate-reviewer on PR #142.

## Test plan
- [x] `bun test src/lib/isSafeRelativeRedirect.test.ts src/app/api/hubspot/newsletter/route.test.ts`
- [ ] Merge to `develop`, then comment `delegate review` on PR #142

Made with [Cursor](https://cursor.com)