### PR TITLE
Fix PR 142 delegate review blockers

### DIFF
--- a/src/app/api/hubspot/newsletter/route.test.ts
+++ b/src/app/api/hubspot/newsletter/route.test.ts
@@ -74,7 +74,7 @@ describe('POST /api/hubspot/newsletter', () => {
 		expect(fetchMock).toHaveBeenCalledTimes(1);
 	});
 
-	test('forwards HubSpot error status and details', async () => {
+	test('forwards HubSpot 4xx error status and details', async () => {
 		const hubspotError = { message: 'INVALID_EMAIL', status: 'error' };
 		const fetchMock = mock(async () =>
 			new Response(JSON.stringify(hubspotError), { status: 400 }),
@@ -90,5 +90,20 @@ describe('POST /api/hubspot/newsletter', () => {
 			error: 'HubSpot submission failed',
 			details: hubspotError,
 		});
+	});
+
+	test('returns generic 502 for HubSpot 5xx errors without details', async () => {
+		const hubspotError = { message: 'Internal server error', traceId: 'abc-123' };
+		const fetchMock = mock(async () =>
+			new Response(JSON.stringify(hubspotError), { status: 503 }),
+		);
+		globalThis.fetch = fetchMock as typeof fetch;
+
+		const { POST } = await import('./route');
+		const response = await POST(
+			createRequest({ formId: VALID_FORM_ID, email: 'user@example.com' }),
+		);
+		expect(response.status).toBe(502);
+		expect(await response.json()).toEqual({ error: 'HubSpot submission failed' });
 	});
 });

--- a/src/app/api/hubspot/newsletter/route.ts
+++ b/src/app/api/hubspot/newsletter/route.ts
@@ -65,7 +65,13 @@ export async function POST(request: NextRequest) {
 	const result = await hubspotResponse.json().catch(() => ({}));
 
 	if (!hubspotResponse.ok) {
-		return NextResponse.json({ error: 'HubSpot submission failed', details: result }, { status: hubspotResponse.status });
+		const isClientError = hubspotResponse.status >= 400 && hubspotResponse.status < 500;
+		return NextResponse.json(
+			isClientError
+				? { error: 'HubSpot submission failed', details: result }
+				: { error: 'HubSpot submission failed' },
+			{ status: isClientError ? hubspotResponse.status : 502 },
+		);
 	}
 
 	return NextResponse.json({ ok: true });

--- a/src/lib/isSafeRelativeRedirect.test.ts
+++ b/src/lib/isSafeRelativeRedirect.test.ts
@@ -21,4 +21,8 @@ describe('isSafeRelativeRedirect', () => {
 	it('blocks absolute URLs', () => {
 		expect(isSafeRelativeRedirect('https://evil.com')).toBe(false);
 	});
+
+	it('blocks double-encoded protocol-relative URL bypass', () => {
+		expect(isSafeRelativeRedirect('/%252F%252Fevil.com')).toBe(false);
+	});
 });

--- a/src/lib/isSafeRelativeRedirect.ts
+++ b/src/lib/isSafeRelativeRedirect.ts
@@ -1,9 +1,13 @@
 export function isSafeRelativeRedirect(path: string): boolean {
 	let decoded = path;
 	try {
-		decoded = decodeURIComponent(path);
+		let prev: string;
+		do {
+			prev = decoded;
+			decoded = decodeURIComponent(decoded);
+		} while (decoded !== prev);
 	} catch {
-		// malformed %-encoding — use original
+		// malformed %-encoding — use last successfully decoded value
 	}
 	return decoded.startsWith('/') && !decoded.startsWith('//') && !decoded.startsWith('/\\');
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes open-redirect validation and public API error shapes; behavior is intentionally stricter and reduces information disclosure on upstream failures.
> 
> **Overview**
> Addresses review blockers by tightening **open-redirect checks** and **HubSpot proxy error handling**.
> 
> `isSafeRelativeRedirect` now **fully decodes** percent-encoding in a loop until the string stabilizes, so double-encoded paths like `/%252F%252Fevil.com` cannot slip through as safe relative URLs. Malformed sequences still fall back to the last good decode before the existing `/`, `//`, and `/\` rules run.
> 
> The newsletter API still **passes through HubSpot 4xx** status and response `details` for client errors. For **HubSpot 5xx**, it responds with a **generic 502** and omits upstream `details` (e.g. trace IDs) so server-side failures are not leaked to clients. Tests were split/added for 4xx vs 5xx behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b70eb1d683b0c8a83d0ed217579c93b9bdc013b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->