### PR TITLE
Fix PR #142 Feedback

### DIFF
--- a/src/lib/electionsHelpers.test.ts
+++ b/src/lib/electionsHelpers.test.ts
@@ -1337,14 +1337,8 @@ describe('claimed profile helpers', () => {
 		expect(htmlToPlainText('Tom &amp; Jerry')).toBe('Tom & Jerry');
 	});
 
-	test('htmlToPlainText strips list formatting artifacts', () => {
-		expect(htmlToPlainText('<ul><li>One</li><li>Two</li></ul>')).toBe('One\n\nTwo');
-		expect(htmlToPlainText('<ol><li>First</li><li>Second</li></ol>')).toBe('First\n\nSecond');
-	});
-
-	test('htmlToPlainText skips horizontal rules and blockquote prefixes', () => {
+	test('htmlToPlainText skips horizontal rules', () => {
 		expect(htmlToPlainText('<p>Before</p><hr><p>After</p>')).toBe('Before\n\nAfter');
-		expect(htmlToPlainText('<blockquote>Quoted text</blockquote>')).toBe('Quoted text');
 	});
 
 	test('htmlToPlainText preserves heading casing', () => {

--- a/src/lib/electionsHelpers.test.ts
+++ b/src/lib/electionsHelpers.test.ts
@@ -1338,7 +1338,9 @@ describe('claimed profile helpers', () => {
 	});
 
 	test('htmlToPlainText skips horizontal rules', () => {
-		expect(htmlToPlainText('<p>Before</p><hr><p>After</p>')).toBe('Before\n\nAfter');
+		expect(htmlToPlainText('<p>Before</p><hr><p>After</p>')).toBe('Before
+
+After');
 	});
 
 	test('htmlToPlainText preserves heading casing', () => {
@@ -1347,8 +1349,26 @@ describe('claimed profile helpers', () => {
 
 	test('htmlToPlainText separates paragraph and heading with exactly two newlines', () => {
 		expect(htmlToPlainText('<p>Intro</p><h2>My Position</h2><p>More detail</p>')).toBe(
-			'Intro\n\nMy Position\n\nMore detail',
+			'Intro
+
+My Position
+
+More detail',
 		);
+	});
+
+	test('htmlToPlainText strips list bullets from ul items', () => {
+		expect(htmlToPlainText('<ul><li>First</li><li>Second</li></ul>')).toBe(' First
+ Second');
+	});
+
+	test('htmlToPlainText strips list numbers from ol items', () => {
+		expect(htmlToPlainText('<ol><li>Alpha</li><li>Beta</li></ol>')).toBe(' Alpha
+ Beta');
+	});
+
+	test('htmlToPlainText strips blockquote prefix', () => {
+		expect(htmlToPlainText('<blockquote>Some quote</blockquote>')).toBe('Some quote');
 	});
 
 	test('resolveProfileAboutText prefers elections API about over claimed occupation', () => {

--- a/src/lib/electionsHelpers.test.ts
+++ b/src/lib/electionsHelpers.test.ts
@@ -1337,6 +1337,20 @@ describe('claimed profile helpers', () => {
 		expect(htmlToPlainText('Tom &amp; Jerry')).toBe('Tom & Jerry');
 	});
 
+	test('htmlToPlainText strips list formatting artifacts', () => {
+		expect(htmlToPlainText('<ul><li>One</li><li>Two</li></ul>')).toBe('One\n\nTwo');
+		expect(htmlToPlainText('<ol><li>First</li><li>Second</li></ol>')).toBe('First\n\nSecond');
+	});
+
+	test('htmlToPlainText skips horizontal rules and blockquote prefixes', () => {
+		expect(htmlToPlainText('<p>Before</p><hr><p>After</p>')).toBe('Before\n\nAfter');
+		expect(htmlToPlainText('<blockquote>Quoted text</blockquote>')).toBe('Quoted text');
+	});
+
+	test('htmlToPlainText preserves heading casing', () => {
+		expect(htmlToPlainText('<h2>My Position</h2>')).toBe('My Position');
+	});
+
 	test('resolveProfileAboutText prefers elections API about over claimed occupation', () => {
 		expect(
 			resolveProfileAboutText('Election bio', {

--- a/src/lib/electionsHelpers.test.ts
+++ b/src/lib/electionsHelpers.test.ts
@@ -1345,6 +1345,12 @@ describe('claimed profile helpers', () => {
 		expect(htmlToPlainText('<h2>My Position</h2>')).toBe('My Position');
 	});
 
+	test('htmlToPlainText separates paragraph and heading with exactly two newlines', () => {
+		expect(htmlToPlainText('<p>Intro</p><h2>My Position</h2><p>More detail</p>')).toBe(
+			'Intro\n\nMy Position\n\nMore detail',
+		);
+	});
+
 	test('resolveProfileAboutText prefers elections API about over claimed occupation', () => {
 		expect(
 			resolveProfileAboutText('Election bio', {

--- a/src/lib/electionsHelpers.ts
+++ b/src/lib/electionsHelpers.ts
@@ -184,7 +184,7 @@ export function htmlToPlainText(value: string | null | undefined): string | unde
 			{ selector: 'ol', format: 'unorderedList', options: { itemPrefix: ' ', leadingLineBreaks: 2, trailingLineBreaks: 2 } },
 			{ selector: 'blockquote', format: 'blockquote', options: { leadingLineBreaks: 2, trailingLineBreaks: 2, trimEmptyLines: true } },
 		],
-	}).trim();
+	}).replace(/^\n+|\n+$/g, '');
 	return text.length > 0 ? text : undefined;
 }
 

--- a/src/lib/electionsHelpers.ts
+++ b/src/lib/electionsHelpers.ts
@@ -174,12 +174,12 @@ export function htmlToPlainText(value: string | null | undefined): string | unde
 			{ selector: 'a', options: { ignoreHref: true } },
 			{ selector: 'img', format: 'skip' },
 			{ selector: 'hr', format: 'skip' },
-			{ selector: 'h1', options: { uppercase: false } },
-			{ selector: 'h2', options: { uppercase: false } },
-			{ selector: 'h3', options: { uppercase: false } },
-			{ selector: 'h4', options: { uppercase: false } },
-			{ selector: 'h5', options: { uppercase: false } },
-			{ selector: 'h6', options: { uppercase: false } },
+			{ selector: 'h1', options: { uppercase: false, leadingLineBreaks: 2, trailingLineBreaks: 2 } },
+			{ selector: 'h2', options: { uppercase: false, leadingLineBreaks: 2, trailingLineBreaks: 2 } },
+			{ selector: 'h3', options: { uppercase: false, leadingLineBreaks: 2, trailingLineBreaks: 2 } },
+			{ selector: 'h4', options: { uppercase: false, leadingLineBreaks: 2, trailingLineBreaks: 2 } },
+			{ selector: 'h5', options: { uppercase: false, leadingLineBreaks: 2, trailingLineBreaks: 2 } },
+			{ selector: 'h6', options: { uppercase: false, leadingLineBreaks: 2, trailingLineBreaks: 2 } },
 		],
 	}).trim();
 	return text.length > 0 ? text : undefined;

--- a/src/lib/electionsHelpers.ts
+++ b/src/lib/electionsHelpers.ts
@@ -182,7 +182,7 @@ export function htmlToPlainText(value: string | null | undefined): string | unde
 			{ selector: 'h6', options: { uppercase: false, leadingLineBreaks: 2, trailingLineBreaks: 2 } },
 			{ selector: 'ul', options: { itemPrefix: ' ', leadingLineBreaks: 2, trailingLineBreaks: 2 } },
 			{ selector: 'ol', format: 'unorderedList', options: { itemPrefix: ' ', leadingLineBreaks: 2, trailingLineBreaks: 2 } },
-			{ selector: 'blockquote', format: 'block', options: { leadingLineBreaks: 2, trailingLineBreaks: 2, trimEmptyLines: true } },
+			{ selector: 'blockquote', format: 'blockquote', options: { leadingLineBreaks: 2, trailingLineBreaks: 2, trimEmptyLines: true } },
 		],
 	}).trim();
 	return text.length > 0 ? text : undefined;

--- a/src/lib/electionsHelpers.ts
+++ b/src/lib/electionsHelpers.ts
@@ -180,6 +180,9 @@ export function htmlToPlainText(value: string | null | undefined): string | unde
 			{ selector: 'h4', options: { uppercase: false, leadingLineBreaks: 2, trailingLineBreaks: 2 } },
 			{ selector: 'h5', options: { uppercase: false, leadingLineBreaks: 2, trailingLineBreaks: 2 } },
 			{ selector: 'h6', options: { uppercase: false, leadingLineBreaks: 2, trailingLineBreaks: 2 } },
+			{ selector: 'ul', options: { itemPrefix: ' ', leadingLineBreaks: 2, trailingLineBreaks: 2 } },
+			{ selector: 'ol', options: { itemPrefix: ' ', leadingLineBreaks: 2, trailingLineBreaks: 2 } },
+			{ selector: 'blockquote', format: 'block', options: { leadingLineBreaks: 2, trailingLineBreaks: 2, trimEmptyLines: true } },
 		],
 	}).trim();
 	return text.length > 0 ? text : undefined;

--- a/src/lib/electionsHelpers.ts
+++ b/src/lib/electionsHelpers.ts
@@ -181,7 +181,7 @@ export function htmlToPlainText(value: string | null | undefined): string | unde
 			{ selector: 'h5', options: { uppercase: false, leadingLineBreaks: 2, trailingLineBreaks: 2 } },
 			{ selector: 'h6', options: { uppercase: false, leadingLineBreaks: 2, trailingLineBreaks: 2 } },
 			{ selector: 'ul', options: { itemPrefix: ' ', leadingLineBreaks: 2, trailingLineBreaks: 2 } },
-			{ selector: 'ol', options: { itemPrefix: ' ', leadingLineBreaks: 2, trailingLineBreaks: 2 } },
+			{ selector: 'ol', format: 'unorderedList', options: { itemPrefix: ' ', leadingLineBreaks: 2, trailingLineBreaks: 2 } },
 			{ selector: 'blockquote', format: 'block', options: { leadingLineBreaks: 2, trailingLineBreaks: 2, trimEmptyLines: true } },
 		],
 	}).trim();

--- a/src/lib/electionsHelpers.ts
+++ b/src/lib/electionsHelpers.ts
@@ -173,6 +173,17 @@ export function htmlToPlainText(value: string | null | undefined): string | unde
 		selectors: [
 			{ selector: 'a', options: { ignoreHref: true } },
 			{ selector: 'img', format: 'skip' },
+			{ selector: 'hr', format: 'skip' },
+			{ selector: 'h1', options: { uppercase: false } },
+			{ selector: 'h2', options: { uppercase: false } },
+			{ selector: 'h3', options: { uppercase: false } },
+			{ selector: 'h4', options: { uppercase: false } },
+			{ selector: 'h5', options: { uppercase: false } },
+			{ selector: 'h6', options: { uppercase: false } },
+			{ selector: 'ul', format: 'block' },
+			{ selector: 'ol', format: 'block' },
+			{ selector: 'li', format: 'block', options: { leadingLineBreaks: 1, trailingLineBreaks: 0 } },
+			{ selector: 'blockquote', format: 'block', options: { leadingLineBreaks: 1, trailingLineBreaks: 1 } },
 		],
 	}).trim();
 	return text.length > 0 ? text : undefined;

--- a/src/lib/electionsHelpers.ts
+++ b/src/lib/electionsHelpers.ts
@@ -180,10 +180,6 @@ export function htmlToPlainText(value: string | null | undefined): string | unde
 			{ selector: 'h4', options: { uppercase: false } },
 			{ selector: 'h5', options: { uppercase: false } },
 			{ selector: 'h6', options: { uppercase: false } },
-			{ selector: 'ul', format: 'block' },
-			{ selector: 'ol', format: 'block' },
-			{ selector: 'li', format: 'block', options: { leadingLineBreaks: 1, trailingLineBreaks: 0 } },
-			{ selector: 'blockquote', format: 'block', options: { leadingLineBreaks: 1, trailingLineBreaks: 1 } },
 		],
 	}).trim();
 	return text.length > 0 ? text : undefined;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Display-only formatting for candidate bios and issues; behavior is covered by new unit tests with no auth or data-path changes.
> 
> **Overview**
> Tightens **`htmlToPlainText`** so claimed-campaign HTML (bios, issue descriptions) renders more predictably as plain text on candidate profile cards.
> 
> The converter now **skips** `<hr>`, keeps **heading casing** (no forced uppercase), uses **double newlines** around headings and lists, renders **ordered lists** without numeric prefixes (space-prefixed lines like unordered lists), and **drops blockquote** `>` prefixes. Trailing/leading whitespace is trimmed with a **newline-only** regex instead of `.trim()`, so intentional leading spaces on list lines are preserved.
> 
> New unit tests lock in those behaviors for HRs, headings, mixed block flow, `ul`/`ol`, and blockquotes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bf6bf4ad545365d886f9da42726a25a185c5c30. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->