### PR TITLE
Fix PR #142 Feedback

### DIFF
--- a/src/lib/electionsHelpers.test.ts
+++ b/src/lib/electionsHelpers.test.ts
@@ -1337,6 +1337,40 @@ describe('claimed profile helpers', () => {
 		expect(htmlToPlainText('Tom &amp; Jerry')).toBe('Tom & Jerry');
 	});
 
+	test('htmlToPlainText skips horizontal rules', () => {
+		expect(htmlToPlainText('<p>Before</p><hr><p>After</p>')).toBe('Before
+
+After');
+	});
+
+	test('htmlToPlainText preserves heading casing', () => {
+		expect(htmlToPlainText('<h2>My Position</h2>')).toBe('My Position');
+	});
+
+	test('htmlToPlainText separates paragraph and heading with exactly two newlines', () => {
+		expect(htmlToPlainText('<p>Intro</p><h2>My Position</h2><p>More detail</p>')).toBe(
+			'Intro
+
+My Position
+
+More detail',
+		);
+	});
+
+	test('htmlToPlainText strips list bullets from ul items', () => {
+		expect(htmlToPlainText('<ul><li>First</li><li>Second</li></ul>')).toBe(' First
+ Second');
+	});
+
+	test('htmlToPlainText strips list numbers from ol items', () => {
+		expect(htmlToPlainText('<ol><li>Alpha</li><li>Beta</li></ol>')).toBe(' Alpha
+ Beta');
+	});
+
+	test('htmlToPlainText strips blockquote prefix', () => {
+		expect(htmlToPlainText('<blockquote>Some quote</blockquote>')).toBe('Some quote');
+	});
+
 	test('resolveProfileAboutText prefers elections API about over claimed occupation', () => {
 		expect(
 			resolveProfileAboutText('Election bio', {

--- a/src/lib/electionsHelpers.ts
+++ b/src/lib/electionsHelpers.ts
@@ -173,8 +173,18 @@ export function htmlToPlainText(value: string | null | undefined): string | unde
 		selectors: [
 			{ selector: 'a', options: { ignoreHref: true } },
 			{ selector: 'img', format: 'skip' },
+			{ selector: 'hr', format: 'skip' },
+			{ selector: 'h1', options: { uppercase: false, leadingLineBreaks: 2, trailingLineBreaks: 2 } },
+			{ selector: 'h2', options: { uppercase: false, leadingLineBreaks: 2, trailingLineBreaks: 2 } },
+			{ selector: 'h3', options: { uppercase: false, leadingLineBreaks: 2, trailingLineBreaks: 2 } },
+			{ selector: 'h4', options: { uppercase: false, leadingLineBreaks: 2, trailingLineBreaks: 2 } },
+			{ selector: 'h5', options: { uppercase: false, leadingLineBreaks: 2, trailingLineBreaks: 2 } },
+			{ selector: 'h6', options: { uppercase: false, leadingLineBreaks: 2, trailingLineBreaks: 2 } },
+			{ selector: 'ul', options: { itemPrefix: ' ', leadingLineBreaks: 2, trailingLineBreaks: 2 } },
+			{ selector: 'ol', format: 'unorderedList', options: { itemPrefix: ' ', leadingLineBreaks: 2, trailingLineBreaks: 2 } },
+			{ selector: 'blockquote', format: 'blockquote', options: { leadingLineBreaks: 2, trailingLineBreaks: 2, trimEmptyLines: true } },
 		],
-	}).trim();
+	}).replace(/^\n+|\n+$/g, '');
 	return text.length > 0 ? text : undefined;
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Localized display-formatting change in elections helpers; no auth or API behavior changes, though existing profile copy may render slightly differently.
> 
> **Overview**
> Tightens **`htmlToPlainText`** so claimed-campaign HTML (bios, issue descriptions on candidate profiles) converts to plain text with more predictable spacing and less markup noise.
> 
> The converter now **skips** `<hr>`, keeps **heading casing** (no uppercase), uses **double newlines** around headings/lists/blockquotes, renders **lists** with a leading space instead of bullets or numbers, and **strips only leading/trailing newlines** instead of a full `.trim()` so intentional internal spacing is preserved.
> 
> New unit tests lock in behavior for HR, headings, lists, blockquotes, and mixed paragraph/heading layouts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2cd279d447de7e51958374e5029d0f97f0554aae. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->