### PR TITLE
Enhance election template token mapping by adding '[office]' and '[of…

### DIFF
--- a/src/lib/electionsTemplateHelpers.test.ts
+++ b/src/lib/electionsTemplateHelpers.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from 'bun:test';
+
+import { buildCandidatesTokens, buildPositionTokens } from '~/lib/electionsTemplateHelpers';
+import { resolveTokens } from '~/lib/resolveTokens';
+
+const tokenCtx = {
+	officeName: 'Mayor',
+	stateName: 'New York',
+	countyName: 'Kings',
+	cityName: 'Brooklyn',
+};
+
+describe('buildPositionTokens', () => {
+	test('resolves both [office name] and [office]', () => {
+		const tokens = buildPositionTokens(tokenCtx);
+		expect(resolveTokens('Running for [office name]?', tokens)).toBe('Running for Mayor?');
+		expect(resolveTokens('Running for [office]?', tokens)).toBe('Running for Mayor?');
+	});
+
+	test('does not supply [candidate name]', () => {
+		const tokens = buildPositionTokens(tokenCtx);
+		expect(resolveTokens('Meet [candidate name]', tokens)).toBe('Meet ');
+	});
+});
+
+describe('buildCandidatesTokens', () => {
+	test('resolves both [office name] and [office]', () => {
+		const tokens = buildCandidatesTokens(tokenCtx);
+		expect(resolveTokens('Not running for [office]?', tokens)).toBe('Not running for Mayor?');
+		expect(resolveTokens('See candidates for [office name]', tokens)).toBe('See candidates for Mayor');
+	});
+
+	test('does not supply [candidate name]', () => {
+		const tokens = buildCandidatesTokens(tokenCtx);
+		expect(resolveTokens('Meet [candidate name]', tokens)).toBe('Meet ');
+	});
+});

--- a/src/lib/electionsTemplateHelpers.tsx
+++ b/src/lib/electionsTemplateHelpers.tsx
@@ -100,6 +100,7 @@ export function buildPositionTokens(ctx: Pick<PositionPageContext, 'officeName' 
 	const locationName = ctx.cityName ?? ctx.countyName ?? ctx.stateName;
 	return {
 		'[office name]': ctx.officeName,
+		'[office]': ctx.officeName,
 		'[State]': ctx.stateName,
 		'[County or City]': locationName,
 	};
@@ -111,6 +112,7 @@ export function buildCandidatesTokens(
 	const locationParts = [ctx.cityName, ctx.countyName, ctx.stateName].filter(Boolean);
 	return {
 		'[office]': ctx.officeName,
+		'[office name]': ctx.officeName,
 		'[location]': locationParts.join(', '),
 	};
 }

--- a/src/sanity/schema/documents/goodpartyOrg_customTemplate.ts
+++ b/src/sanity/schema/documents/goodpartyOrg_customTemplate.ts
@@ -14,7 +14,10 @@ On any error in a custom template, the site uses the corresponding global templa
 
 Clone workflow: duplicate a global template document, change type to custom, add targets, and edit sections.
 
-Supported tokens: [State], [County], [City], [District], [office name], [County or City], [office], [location], [candidate name]`;
+Supported tokens in plain text fields:
+- Location: [State], [County], [City], [District]
+- Position / candidates: [office name], [State], [County or City], [office], [location]
+- Profile: [candidate name], [office name]`;
 
 export const goodpartyOrg_customTemplate = {
 	title: 'Custom Election Template',


### PR DESCRIPTION
…fice name]' tokens for improved context in position and candidate templates.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 030039effff3ea817e677100a42b37209bb3b718. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->