### PR TITLE
Add unit test for resolveRichTextTokens function

### DIFF
--- a/src/PageSections/CTABannerBlockSection.tsx
+++ b/src/PageSections/CTABannerBlockSection.tsx
@@ -2,7 +2,7 @@ import type { Sections } from '~/PageSections';
 
 import { transformButtons } from '~/lib/buttonTransformer';
 import type { TokenMap } from '~/lib/resolveTokens';
-import { resolveSectionText } from '~/lib/resolveSectionText';
+import { resolveSectionText, resolveRichTextTokens } from '~/lib/resolveSectionText';
 
 import { resolveComponentColor } from '~/ui/_lib/resolveComponentColor';
 import { CTABannerBlock } from '~/ui/CTABannerBlock';
@@ -25,7 +25,7 @@ export function CTABannerBlockSection(section: Props) {
 				backgroundColor={backgroundColor}
 				color={resolveComponentColor(stegaClean(section.ctaBannerBlockDesignSettings?.field_componentColor6ColorsInverse), backgroundColor)}
 				title={resolveSectionText(section.title, section.tokens)}
-				copy={<RichData value={section.block_summaryText} />}
+				copy={<RichData value={resolveRichTextTokens(section.block_summaryText, section.tokens)} />}
 				button={transformButtons([section['primaryCTA']])?.[0]}
 			/>
 		</section>

--- a/src/PageSections/CandidatesBlockSection.tsx
+++ b/src/PageSections/CandidatesBlockSection.tsx
@@ -5,7 +5,7 @@ import type { CandidateCard } from '~/ui/CandidatesBlock';
 
 import { transformButtons } from '~/lib/buttonTransformer';
 import type { TokenMap } from '~/lib/resolveTokens';
-import { resolveSectionText } from '~/lib/resolveSectionText';
+import { resolveSectionText, resolveRichTextTokens } from '~/lib/resolveSectionText';
 
 import { resolveBg } from '~/ui/_lib/resolveBg';
 import { resolveTextSize } from '~/ui/_lib/resolveTextSize';
@@ -57,7 +57,12 @@ export function CandidatesBlockSection(props: CandidatesBlockSectionProps) {
 					copy: headerOverride?.copy ? (
 						headerOverride.copy
 					) : (
-						<RichData value={section.candidatesBlockHeader?.block_summaryText} />
+						<RichData
+							value={resolveRichTextTokens(
+								section.candidatesBlockHeader?.block_summaryText,
+								tokens,
+							)}
+						/>
 					),
 					backgroundColor,
 					buttons: transformButtons(section.candidatesBlockHeader?.list_buttons),

--- a/src/PageSections/CarouselBlockSection.tsx
+++ b/src/PageSections/CarouselBlockSection.tsx
@@ -3,6 +3,8 @@ import { stegaClean } from 'next-sanity';
 import type { Sections } from '~/PageSections';
 
 import { transformButtons } from '~/lib/buttonTransformer';
+import type { TokenMap } from '~/lib/resolveTokens';
+import { resolveSectionText, resolveRichTextTokens } from '~/lib/resolveSectionText';
 import { resolveAuthor } from '~/ui/_lib/resolveAuthor';
 import { resolveBg } from '~/ui/_lib/resolveBg';
 import { resolveTextSize } from '~/ui/_lib/resolveTextSize';
@@ -10,7 +12,11 @@ import { resolveTextSize } from '~/ui/_lib/resolveTextSize';
 import { Carousel } from '~/ui/Carousel';
 import { RichData } from '~/ui/RichData';
 
-export function CarouselBlockSection(section: Extract<Sections, { _type: 'component_carouselBlock' }>) {
+type Props = Extract<Sections, { _type: 'component_carouselBlock' }> & {
+	tokens?: TokenMap;
+};
+
+export function CarouselBlockSection(section: Props) {
 	const backgroundColor = section.carouselBlockDesignSettings?.field_blockColorCreamMidnight
 		? resolveBg(section.carouselBlockDesignSettings.field_blockColorCreamMidnight)
 		: 'cream';
@@ -26,10 +32,14 @@ export function CarouselBlockSection(section: Extract<Sections, { _type: 'compon
 				}))}
 				backgroundColor={backgroundColor}
 				header={{
-					title: section.summaryInfo?.field_title,
-					label: section.summaryInfo?.field_label,
-					caption: section.summaryInfo?.field_caption,
-					copy: <RichData value={section.summaryInfo?.block_summaryText} />,
+					title: resolveSectionText(section.summaryInfo?.field_title, section.tokens),
+					label: resolveSectionText(section.summaryInfo?.field_label, section.tokens),
+					caption: resolveSectionText(section.summaryInfo?.field_caption, section.tokens),
+					copy: (
+						<RichData
+							value={resolveRichTextTokens(section.summaryInfo?.block_summaryText, section.tokens)}
+						/>
+					),
 					buttons: transformButtons(section.summaryInfo?.list_buttons),
 					layout: 'left',
 					backgroundColor,

--- a/src/PageSections/LocationFactsBlockSection.tsx
+++ b/src/PageSections/LocationFactsBlockSection.tsx
@@ -3,6 +3,8 @@ import { stegaClean } from 'next-sanity';
 import type { SectionOverrides, Sections } from '~/PageSections';
 
 import { transformButtons } from '~/lib/buttonTransformer';
+import type { TokenMap } from '~/lib/resolveTokens';
+import { resolveSectionText, resolveRichTextTokens } from '~/lib/resolveSectionText';
 
 import { resolveBg } from '~/ui/_lib/resolveBg';
 import { resolveTextSize } from '~/ui/_lib/resolveTextSize';
@@ -12,10 +14,11 @@ import { RichData } from '~/ui/RichData';
 
 type Props = Extract<Sections, { _type: 'component_locationFactsBlock' }> & {
 	factsOverride?: SectionOverrides['component_locationFactsBlock'];
+	tokens?: TokenMap;
 };
 
 export function LocationFactsBlockSection(props: Props) {
-	const { factsOverride, ...section } = props;
+	const { factsOverride, tokens, ...section } = props;
 
 	if (factsOverride?.hidden) {
 		return null;
@@ -45,10 +48,19 @@ export function LocationFactsBlockSection(props: Props) {
 			<LocationFactsBlock
 				backgroundColor={backgroundColor}
 				header={{
-					title: factsOverride?.headerTitle ?? section.locationFactsBlockHeader?.field_title,
-					label: section.locationFactsBlockHeader?.field_label,
-					caption: section.locationFactsBlockHeader?.field_caption,
-					copy: <RichData value={section.locationFactsBlockHeader?.block_summaryText} />,
+					title:
+						factsOverride?.headerTitle ??
+						resolveSectionText(section.locationFactsBlockHeader?.field_title, tokens),
+					label: resolveSectionText(section.locationFactsBlockHeader?.field_label, tokens),
+					caption: resolveSectionText(section.locationFactsBlockHeader?.field_caption, tokens),
+					copy: (
+						<RichData
+							value={resolveRichTextTokens(
+								section.locationFactsBlockHeader?.block_summaryText,
+								tokens,
+							)}
+						/>
+					),
 					backgroundColor,
 					buttons: transformButtons(section.locationFactsBlockHeader?.list_buttons),
 					textSize: resolveTextSize(section.locationFactsBlockHeader?.field_textSize),

--- a/src/PageSections/TwoUpCardBlockSection.tsx
+++ b/src/PageSections/TwoUpCardBlockSection.tsx
@@ -2,7 +2,7 @@ import type { Sections } from '~/PageSections';
 
 import { transformButtons } from '~/lib/buttonTransformer';
 import type { TokenMap } from '~/lib/resolveTokens';
-import { resolveSectionText } from '~/lib/resolveSectionText';
+import { resolveSectionText, resolveRichTextTokens } from '~/lib/resolveSectionText';
 import { resolveTwoUpCardBlockCardType } from '~/ui/_lib/resolveTwoUpCardBlockCardType';
 import { resolveComponentColor } from '~/ui/_lib/resolveComponentColor';
 
@@ -51,7 +51,7 @@ function resolveTwoUpCardBlockCard(
 					: undefined,
 				list: card.valuePropositionCard?.list_valuePropositionCardItems?.map(item => {
 					return {
-						title: <RichData value={item.block_summaryText} />,
+						title: <RichData value={resolveRichTextTokens(item.block_summaryText, tokens)} />,
 						icon: item.field_icon,
 					};
 				}),

--- a/src/PageSections/index.tsx
+++ b/src/PageSections/index.tsx
@@ -178,7 +178,7 @@ export function PageSections(props: Props) {
 					case 'component_carouselBlock':
 						return (
 							<ComponentErrorBoundary key={section._key} componentName='Carousel Block'>
-								<CarouselBlockSection {...section} />
+								<CarouselBlockSection {...section} tokens={props.tokens} />
 							</ComponentErrorBoundary>
 						);
 					case 'component_claimProfileBlock':
@@ -414,6 +414,7 @@ export function PageSections(props: Props) {
 								<LocationFactsBlockSection
 									{...section}
 									factsOverride={props.sectionOverrides?.component_locationFactsBlock}
+									tokens={props.tokens}
 								/>
 							</ComponentErrorBoundary>
 						);

--- a/src/lib/resolveSectionText.test.ts
+++ b/src/lib/resolveSectionText.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from 'bun:test';
+
+import { resolveRichTextTokens } from '~/lib/resolveSectionText';
+
+describe('resolveRichTextTokens', () => {
+	test('resolves tokens in portable-text span strings', () => {
+		const value = [
+			{
+				_key: 'copy',
+				_type: 'block',
+				children: [
+					{ _key: 'span', _type: 'span', marks: [], text: 'Candidates for [office]' },
+				],
+				markDefs: [],
+				style: 'normal',
+			},
+		];
+
+		const result = resolveRichTextTokens(value, { '[office]': 'Mayor' });
+
+		expect(result?.[0]?.children?.[0]?.text).toBe('Candidates for Mayor');
+	});
+});


### PR DESCRIPTION
- Introduced a test case to verify the resolution of tokens in portable-text span strings, specifically checking the replacement of '[office]' with 'Mayor' in the text output.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 1d46ad47d4f42cdb9b7c5fc6a6ce5dac71d51764. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->