### PR TITLE
Add token resolution for location in elections template helpers

### DIFF
--- a/src/lib/electionTemplates.test.ts
+++ b/src/lib/electionTemplates.test.ts
@@ -112,4 +112,29 @@ describe('pickBestCustomTemplate', () => {
 		const ctx: ElectionTemplateContext = { templateType: 'location', placeSlug: 'ny' };
 		expect(pickBestCustomTemplate(docs, ctx)).toBeNull();
 	});
+
+	test('uses raceSlug over positionSlug for position target when both are supplied', () => {
+		const docs = [
+			{
+				_id: 'by-race-slug',
+				field_enabled: true,
+				field_priority: 100,
+				field_electionTemplateType: 'position' as const,
+				list_targets: [{ field_electionTargetType: 'position' as const, field_electionTargetSlug: 'mayor-2024' }],
+			},
+			{
+				_id: 'by-position-slug',
+				field_enabled: true,
+				field_priority: 100,
+				field_electionTemplateType: 'position' as const,
+				list_targets: [{ field_electionTargetType: 'position' as const, field_electionTargetSlug: 'mayor' }],
+			},
+		];
+		const ctx: ElectionTemplateContext = {
+			templateType: 'position',
+			raceSlug: 'mayor-2024',
+			positionSlug: 'mayor',
+		};
+		expect(pickBestCustomTemplate(docs, ctx)?._id).toBe('by-race-slug');
+	});
 });

--- a/src/lib/electionsTemplateHelpers.test.ts
+++ b/src/lib/electionsTemplateHelpers.test.ts
@@ -17,6 +17,11 @@ describe('buildPositionTokens', () => {
 		expect(resolveTokens('Running for [office]?', tokens)).toBe('Running for Mayor?');
 	});
 
+	test('resolves [location]', () => {
+		const tokens = buildPositionTokens(tokenCtx);
+		expect(resolveTokens('Running in [location]', tokens)).toBe('Running in Brooklyn, Kings, New York');
+	});
+
 	test('does not supply [candidate name]', () => {
 		const tokens = buildPositionTokens(tokenCtx);
 		expect(resolveTokens('Meet [candidate name]', tokens)).toBe('Meet ');
@@ -28,6 +33,13 @@ describe('buildCandidatesTokens', () => {
 		const tokens = buildCandidatesTokens(tokenCtx);
 		expect(resolveTokens('Not running for [office]?', tokens)).toBe('Not running for Mayor?');
 		expect(resolveTokens('See candidates for [office name]', tokens)).toBe('See candidates for Mayor');
+	});
+
+	test('resolves [location], [State], and [County or City]', () => {
+		const tokens = buildCandidatesTokens(tokenCtx);
+		expect(resolveTokens('Candidates in [location]', tokens)).toBe('Candidates in Brooklyn, Kings, New York');
+		expect(resolveTokens('Candidates in [State]', tokens)).toBe('Candidates in New York');
+		expect(resolveTokens('Candidates in [County or City]', tokens)).toBe('Candidates in Brooklyn');
 	});
 
 	test('does not supply [candidate name]', () => {

--- a/src/lib/electionsTemplateHelpers.tsx
+++ b/src/lib/electionsTemplateHelpers.tsx
@@ -98,21 +98,26 @@ export function buildPositionBottomItems(race: RaceDetail) {
 
 export function buildPositionTokens(ctx: Pick<PositionPageContext, 'officeName' | 'stateName' | 'countyName' | 'cityName'>): TokenMap {
 	const locationName = ctx.cityName ?? ctx.countyName ?? ctx.stateName;
+	const locationParts = [ctx.cityName, ctx.countyName, ctx.stateName].filter(Boolean);
 	return {
 		'[office name]': ctx.officeName,
 		'[office]': ctx.officeName,
 		'[State]': ctx.stateName,
 		'[County or City]': locationName,
+		'[location]': locationParts.join(', '),
 	};
 }
 
 export function buildCandidatesTokens(
 	ctx: Pick<PositionPageContext, 'officeName' | 'stateName' | 'countyName' | 'cityName'>,
 ): TokenMap {
+	const locationName = ctx.cityName ?? ctx.countyName ?? ctx.stateName;
 	const locationParts = [ctx.cityName, ctx.countyName, ctx.stateName].filter(Boolean);
 	return {
 		'[office]': ctx.officeName,
 		'[office name]': ctx.officeName,
+		'[State]': ctx.stateName,
+		'[County or City]': locationName,
 		'[location]': locationParts.join(', '),
 	};
 }


### PR DESCRIPTION
- Introduced new tokens '[location]', '[State]', and '[County or City]' in buildPositionTokens and buildCandidatesTokens functions for enhanced context.
- Added unit tests to verify the correct resolution of these new tokens in various scenarios.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 8dda1a8f95ff719f14a81413bd520ccb02e9b354. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->