### PR TITLE
Enhance token resolution

### DIFF
--- a/src/PageSections/ClaimProfileBlockSection.test.ts
+++ b/src/PageSections/ClaimProfileBlockSection.test.ts
@@ -3,6 +3,17 @@ import {
 	resolveClaimProfileBlockBackgroundColor,
 	resolveExampleCardPartyAffiliation,
 } from './ClaimProfileBlockSection';
+import { resolveSectionText } from '~/lib/resolveSectionText';
+
+describe('ClaimProfileBlockSection token resolution', () => {
+	test('resolves [candidate name] in headline and body', () => {
+		const tokens = { '[candidate name]': 'Jane Doe', '[office name]': 'Mayor' };
+		expect(resolveSectionText('Claim profile for [candidate name]', tokens)).toBe(
+			'Claim profile for Jane Doe',
+		);
+		expect(resolveSectionText('Running for [office name]', tokens)).toBe('Running for Mayor');
+	});
+});
 
 describe('resolveClaimProfileBlockBackgroundColor', () => {
 	test('maps CMS midnight value', () => {

--- a/src/PageSections/ClaimProfileBlockSection.test.ts
+++ b/src/PageSections/ClaimProfileBlockSection.test.ts
@@ -1,17 +1,32 @@
 import { describe, expect, test } from 'bun:test';
 import {
 	resolveClaimProfileBlockBackgroundColor,
+	resolveClaimProfileBlockText,
 	resolveExampleCardPartyAffiliation,
 } from './ClaimProfileBlockSection';
-import { resolveSectionText } from '~/lib/resolveSectionText';
 
-describe('ClaimProfileBlockSection token resolution', () => {
-	test('resolves [candidate name] in headline and body', () => {
+describe('resolveClaimProfileBlockText', () => {
+	test('resolves profile tokens in headline and body from CMS content', () => {
 		const tokens = { '[candidate name]': 'Jane Doe', '[office name]': 'Mayor' };
-		expect(resolveSectionText('Claim profile for [candidate name]', tokens)).toBe(
-			'Claim profile for Jane Doe',
-		);
-		expect(resolveSectionText('Running for [office name]', tokens)).toBe('Running for Mayor');
+		expect(
+			resolveClaimProfileBlockText(
+				{
+					field_headline: 'Claim profile for [candidate name]',
+					field_body: 'Running for [office name]',
+				},
+				tokens,
+			),
+		).toEqual({
+			headline: 'Claim profile for Jane Doe',
+			body: 'Running for Mayor',
+		});
+	});
+
+	test('returns undefined fields when CMS content is absent', () => {
+		expect(resolveClaimProfileBlockText(null, { '[candidate name]': 'Jane Doe' })).toEqual({
+			headline: undefined,
+			body: undefined,
+		});
 	});
 });
 

--- a/src/PageSections/ClaimProfileBlockSection.tsx
+++ b/src/PageSections/ClaimProfileBlockSection.tsx
@@ -1,10 +1,13 @@
 import type { SectionOverrides, Sections } from '~/PageSections';
 import { isButtonType, transformButton } from '~/lib/buttonTransformer';
+import type { TokenMap } from '~/lib/resolveTokens';
+import { resolveSectionText } from '~/lib/resolveSectionText';
 import { ClaimProfileBlock } from '~/ui/ClaimProfileBlock';
 import { stegaClean } from 'next-sanity';
 
 type Props = Extract<Sections, { _type: 'component_claimProfileBlock' }> & {
 	claimProfileOverride?: SectionOverrides['component_claimProfileBlock'];
+	tokens?: TokenMap;
 };
 
 export function resolveExampleCardPartyAffiliation(
@@ -23,7 +26,7 @@ export function resolveClaimProfileBlockBackgroundColor(
 	return 'cream';
 }
 
-export function ClaimProfileBlockSection({ claimProfileOverride, ...section }: Props) {
+export function ClaimProfileBlockSection({ claimProfileOverride, tokens, ...section }: Props) {
 	const bgValue = stegaClean(section.claimProfileBlockDesignSettings?.field_blockColorCreamMidnight);
 	const backgroundColor = resolveClaimProfileBlockBackgroundColor(bgValue);
 
@@ -42,8 +45,8 @@ export function ClaimProfileBlockSection({ claimProfileOverride, ...section }: P
 			<ClaimProfileBlock
 				layout={claimProfileOverride?.layout ?? 'card'}
 				backgroundColor={backgroundColor}
-				headline={section.claimProfileBlockContent?.field_headline}
-				body={section.claimProfileBlockContent?.field_body}
+				headline={resolveSectionText(section.claimProfileBlockContent?.field_headline, tokens)}
+				body={resolveSectionText(section.claimProfileBlockContent?.field_body, tokens)}
 				claimButton={
 					claimButton ?? {
 						buttonType: 'internal',

--- a/src/PageSections/ClaimProfileBlockSection.tsx
+++ b/src/PageSections/ClaimProfileBlockSection.tsx
@@ -26,6 +26,18 @@ export function resolveClaimProfileBlockBackgroundColor(
 	return 'cream';
 }
 
+type ClaimProfileContent = Extract<Sections, { _type: 'component_claimProfileBlock' }>['claimProfileBlockContent'];
+
+export function resolveClaimProfileBlockText(
+	content: ClaimProfileContent,
+	tokens?: TokenMap,
+): { headline?: string; body?: string } {
+	return {
+		headline: resolveSectionText(content?.field_headline, tokens),
+		body: resolveSectionText(content?.field_body, tokens),
+	};
+}
+
 export function ClaimProfileBlockSection({ claimProfileOverride, tokens, ...section }: Props) {
 	const bgValue = stegaClean(section.claimProfileBlockDesignSettings?.field_blockColorCreamMidnight);
 	const backgroundColor = resolveClaimProfileBlockBackgroundColor(bgValue);
@@ -36,6 +48,7 @@ export function ClaimProfileBlockSection({ claimProfileOverride, tokens, ...sect
 			? transformButton(ctaButton)
 			: undefined;
 	const exampleCard = section.claimProfileBlockContent?.exampleCard;
+	const { headline, body } = resolveClaimProfileBlockText(section.claimProfileBlockContent, tokens);
 
 	return (
 		<section
@@ -45,8 +58,8 @@ export function ClaimProfileBlockSection({ claimProfileOverride, tokens, ...sect
 			<ClaimProfileBlock
 				layout={claimProfileOverride?.layout ?? 'card'}
 				backgroundColor={backgroundColor}
-				headline={resolveSectionText(section.claimProfileBlockContent?.field_headline, tokens)}
-				body={resolveSectionText(section.claimProfileBlockContent?.field_body, tokens)}
+				headline={headline}
+				body={body}
 				claimButton={
 					claimButton ?? {
 						buttonType: 'internal',

--- a/src/PageSections/GoodPartyOrgPledgeSection.test.ts
+++ b/src/PageSections/GoodPartyOrgPledgeSection.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from 'bun:test';
+
+import { resolveRichTextTokens } from '~/lib/resolveSectionText';
+
+describe('GoodPartyOrgPledgeSection token resolution', () => {
+	test('resolves profile tokens in portable-text span strings', () => {
+		const value = [
+			{
+				_key: 'copy',
+				_type: 'block',
+				children: [
+					{ _key: 'span', _type: 'span', marks: [], text: 'Pledge for [candidate name]' },
+				],
+				markDefs: [],
+				style: 'normal',
+			},
+		];
+
+		const result = resolveRichTextTokens(value, { '[candidate name]': 'Jane Doe' });
+
+		expect(result?.[0]?.children?.[0]?.text).toBe('Pledge for Jane Doe');
+	});
+});

--- a/src/PageSections/GoodPartyOrgPledgeSection.test.ts
+++ b/src/PageSections/GoodPartyOrgPledgeSection.test.ts
@@ -1,23 +1,57 @@
 import { describe, expect, test } from 'bun:test';
 
-import { resolveRichTextTokens } from '~/lib/resolveSectionText';
+import {
+	resolveGoodPartyOrgPledgeCard,
+	resolveGoodPartyOrgPledgeHeader,
+} from './GoodPartyOrgPledgeSection';
 
-describe('GoodPartyOrgPledgeSection token resolution', () => {
-	test('resolves profile tokens in portable-text span strings', () => {
-		const value = [
+const profileTokens = { '[candidate name]': 'Jane Doe', '[office name]': 'Mayor' };
+
+const portableTextBlock = (text: string) => [
+	{
+		_key: 'copy',
+		_type: 'block',
+		children: [{ _key: 'span', _type: 'span', marks: [], text }],
+		markDefs: [],
+		style: 'normal',
+	},
+];
+
+function firstSpanText(value: unknown): string | undefined {
+	const blocks = value as Array<{ children?: Array<{ text?: string }> }> | null | undefined;
+	return blocks?.[0]?.children?.[0]?.text;
+}
+
+describe('resolveGoodPartyOrgPledgeHeader', () => {
+	test('resolves profile tokens in header plain-text and richtext fields', () => {
+		const result = resolveGoodPartyOrgPledgeHeader(
 			{
-				_key: 'copy',
-				_type: 'block',
-				children: [
-					{ _key: 'span', _type: 'span', marks: [], text: 'Pledge for [candidate name]' },
-				],
-				markDefs: [],
-				style: 'normal',
+				field_title: 'Pledge for [candidate name]',
+				field_label: 'Office: [office name]',
+				field_caption: 'Candidate [candidate name]',
+				block_summaryText: portableTextBlock('All candidates including [candidate name] agree:'),
 			},
-		];
+			profileTokens,
+		);
 
-		const result = resolveRichTextTokens(value, { '[candidate name]': 'Jane Doe' });
+		expect(result.title).toBe('Pledge for Jane Doe');
+		expect(result.label).toBe('Office: Mayor');
+		expect(result.caption).toBe('Candidate Jane Doe');
+		expect(firstSpanText(result.copy)).toBe('All candidates including Jane Doe agree:');
+	});
+});
 
-		expect(result?.[0]?.children?.[0]?.text).toBe('Pledge for Jane Doe');
+describe('resolveGoodPartyOrgPledgeCard', () => {
+	test('resolves profile tokens in card title and richtext content', () => {
+		const result = resolveGoodPartyOrgPledgeCard(
+			{
+				field_title: '[candidate name] pledge',
+				block_summaryText: portableTextBlock('Support [office name] candidates like [candidate name].'),
+			},
+			profileTokens,
+		);
+
+		expect(result.title).toBe('Jane Doe pledge');
+		expect(firstSpanText(result.content)).toBe('Support Mayor candidates like Jane Doe.');
 	});
 });

--- a/src/PageSections/GoodPartyOrgPledgeSection.tsx
+++ b/src/PageSections/GoodPartyOrgPledgeSection.tsx
@@ -2,6 +2,8 @@ import { stegaClean } from 'next-sanity';
 
 import type { Sections } from '~/PageSections';
 import { transformButtons, normalizeRawCtaToButton } from '~/lib/buttonTransformer.tsx';
+import type { TokenMap } from '~/lib/resolveTokens';
+import { resolveSectionText, resolveRichTextTokens } from '~/lib/resolveSectionText';
 import { resolveBg } from '~/ui/_lib/resolveBg.ts';
 import { resolveIconColor } from '~/ui/_lib/resolveComponentColor.tsx';
 import { resolveTextSize } from '~/ui/_lib/resolveTextSize.ts';
@@ -9,7 +11,11 @@ import { resolveTextSize } from '~/ui/_lib/resolveTextSize.ts';
 import { GoodPartyOrgPledge } from '~/ui/GoodPartyOrgPledge.tsx';
 import { RichData } from '~/ui/RichData.tsx';
 
-export function GoodPartyOrgPledgeSection(section: Extract<Sections, { _type: 'component_goodPartyOrgPledge' }>) {
+type Props = Extract<Sections, { _type: 'component_goodPartyOrgPledge' }> & {
+	tokens?: TokenMap;
+};
+
+export function GoodPartyOrgPledgeSection({ tokens, ...section }: Props) {
 	const backgroundColor = section.goodPartyOrgPledgeDesignSettings?.field_blockColorCreamMidnight
 		? resolveBg(stegaClean(section.goodPartyOrgPledgeDesignSettings.field_blockColorCreamMidnight))
 		: 'cream';
@@ -25,10 +31,14 @@ export function GoodPartyOrgPledgeSection(section: Extract<Sections, { _type: 'c
 				backgroundColor={backgroundColor}
 				iconBg={iconColor}
 				header={{
-					title: section.summaryInfo?.field_title,
-					label: section.summaryInfo?.field_label,
-					caption: section.summaryInfo?.field_caption,
-					copy: <RichData value={section.summaryInfo?.block_summaryText} />,
+					title: resolveSectionText(section.summaryInfo?.field_title, tokens),
+					label: resolveSectionText(section.summaryInfo?.field_label, tokens),
+					caption: resolveSectionText(section.summaryInfo?.field_caption, tokens),
+					copy: (
+						<RichData
+							value={resolveRichTextTokens(section.summaryInfo?.block_summaryText, tokens)}
+						/>
+					),
 					buttons: transformButtons(section.summaryInfo?.list_buttons),
 					textSize: resolveTextSize(section.summaryInfo?.field_textSize),
 				}}
@@ -40,8 +50,8 @@ export function GoodPartyOrgPledgeSection(section: Extract<Sections, { _type: 'c
 
 					return {
 						icon: card.field_icon,
-						title: card.field_title,
-						content: <RichData value={card.block_summaryText} />,
+						title: resolveSectionText(card.field_title, tokens),
+						content: <RichData value={resolveRichTextTokens(card.block_summaryText, tokens)} />,
 						button: pledgeButton ? transformButtons([pledgeButton])?.[0] : undefined,
 					};
 				})}

--- a/src/PageSections/GoodPartyOrgPledgeSection.tsx
+++ b/src/PageSections/GoodPartyOrgPledgeSection.tsx
@@ -15,6 +15,31 @@ type Props = Extract<Sections, { _type: 'component_goodPartyOrgPledge' }> & {
 	tokens?: TokenMap;
 };
 
+type PledgeSection = Extract<Sections, { _type: 'component_goodPartyOrgPledge' }>;
+type PledgeSummaryInfo = PledgeSection['summaryInfo'];
+type PledgeCardFields = NonNullable<
+	NonNullable<PledgeSection['goodPartyOrgPledgeItems']>['list_pledgeCards']
+>[number];
+
+export function resolveGoodPartyOrgPledgeHeader(
+	summaryInfo: PledgeSummaryInfo,
+	tokens?: TokenMap,
+) {
+	return {
+		title: resolveSectionText(summaryInfo?.field_title, tokens),
+		label: resolveSectionText(summaryInfo?.field_label, tokens),
+		caption: resolveSectionText(summaryInfo?.field_caption, tokens),
+		copy: resolveRichTextTokens(summaryInfo?.block_summaryText, tokens),
+	};
+}
+
+export function resolveGoodPartyOrgPledgeCard(card: PledgeCardFields, tokens?: TokenMap) {
+	return {
+		title: resolveSectionText(card.field_title, tokens),
+		content: resolveRichTextTokens(card.block_summaryText, tokens),
+	};
+}
+
 export function GoodPartyOrgPledgeSection({ tokens, ...section }: Props) {
 	const backgroundColor = section.goodPartyOrgPledgeDesignSettings?.field_blockColorCreamMidnight
 		? resolveBg(stegaClean(section.goodPartyOrgPledgeDesignSettings.field_blockColorCreamMidnight))
@@ -24,6 +49,7 @@ export function GoodPartyOrgPledgeSection({ tokens, ...section }: Props) {
 		? resolveIconColor(stegaClean(section.goodPartyOrgPledgeDesignSettings.field_iconColor6ColorsWhiteMixed))
 		: 'blue';
 	const iconColor = resolvedIconColor === 'white' ? 'blue' : resolvedIconColor;
+	const header = resolveGoodPartyOrgPledgeHeader(section.summaryInfo, tokens);
 
 	return (
 		<section id={stegaClean(section.componentSettings?.field_anchorId)} data-section='GoodParty.org Pledge'>
@@ -31,14 +57,10 @@ export function GoodPartyOrgPledgeSection({ tokens, ...section }: Props) {
 				backgroundColor={backgroundColor}
 				iconBg={iconColor}
 				header={{
-					title: resolveSectionText(section.summaryInfo?.field_title, tokens),
-					label: resolveSectionText(section.summaryInfo?.field_label, tokens),
-					caption: resolveSectionText(section.summaryInfo?.field_caption, tokens),
-					copy: (
-						<RichData
-							value={resolveRichTextTokens(section.summaryInfo?.block_summaryText, tokens)}
-						/>
-					),
+					title: header.title,
+					label: header.label,
+					caption: header.caption,
+					copy: <RichData value={header.copy} />,
 					buttons: transformButtons(section.summaryInfo?.list_buttons),
 					textSize: resolveTextSize(section.summaryInfo?.field_textSize),
 				}}
@@ -47,11 +69,12 @@ export function GoodPartyOrgPledgeSection({ tokens, ...section }: Props) {
 					const pledgeButton = cta
 						? normalizeRawCtaToButton(cta, `${card._key ?? ''}-pledge-cta`)
 						: undefined;
+					const resolvedCard = resolveGoodPartyOrgPledgeCard(card, tokens);
 
 					return {
 						icon: card.field_icon,
-						title: resolveSectionText(card.field_title, tokens),
-						content: <RichData value={resolveRichTextTokens(card.block_summaryText, tokens)} />,
+						title: resolvedCard.title,
+						content: <RichData value={resolvedCard.content} />,
 						button: pledgeButton ? transformButtons([pledgeButton])?.[0] : undefined,
 					};
 				})}

--- a/src/PageSections/index.tsx
+++ b/src/PageSections/index.tsx
@@ -189,6 +189,7 @@ export function PageSections(props: Props) {
 							<ComponentErrorBoundary key={section._key} componentName='Claim Profile Block'>
 								<ClaimProfileBlockSection
 									{...section}
+									tokens={props.tokens}
 									claimProfileOverride={props.sectionOverrides?.component_claimProfileBlock}
 								/>
 							</ComponentErrorBoundary>
@@ -395,7 +396,7 @@ export function PageSections(props: Props) {
 					case 'component_goodPartyOrgPledge':
 						return (
 							<ComponentErrorBoundary key={section._key} componentName='GoodParty.org Pledge'>
-								<GoodPartyOrgPledgeSection {...section} />
+								<GoodPartyOrgPledgeSection {...section} tokens={props.tokens} />
 							</ComponentErrorBoundary>
 						);
 					case 'component_locationLandingPageHero':

--- a/src/app/candidate/[...slug]/page.tsx
+++ b/src/app/candidate/[...slug]/page.tsx
@@ -18,6 +18,7 @@ import type { SectionOverrides } from '~/PageSections';
 import type { CandidacyItem, FindByRaceIdResponse } from '~/types/elections';
 import type { ProfileData, OfficeData } from '~/PageSections/ProfileContentBlockSection';
 import { SITE_NAME } from '~/lib/url';
+import { buildProfileTokens } from '~/lib/electionsTemplateHelpers';
 import { renderElectionTemplatePage } from '~/lib/renderElectionTemplatePage';
 
 export const revalidate = 3600;
@@ -193,10 +194,10 @@ export default async function Page({
 			candidateSlug: slug,
 		},
 		sectionOverrides,
-		tokens: {
-			'[candidate name]': candidateName,
-			'[office name]': candidate.positionName ?? 'Office',
-		},
+		tokens: buildProfileTokens({
+			candidateName,
+			officeName: candidate.positionName ?? 'Office',
+		}),
 	});
 }
 

--- a/src/lib/electionTokenContract.test.ts
+++ b/src/lib/electionTokenContract.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from 'bun:test';
+
+import { buildElectionsIndexTokens } from '~/lib/electionsIndexTemplates';
+import {
+	buildCandidatesTokens,
+	buildPositionTokens,
+	buildProfileTokens,
+} from '~/lib/electionsTemplateHelpers';
+import type { TokenMap } from '~/lib/resolveTokens';
+
+const tokenCtx = {
+	officeName: 'Mayor',
+	stateName: 'New York',
+	countyName: 'Kings',
+	cityName: 'Brooklyn',
+};
+
+function expectTokensInclude(contract: string[], tokenMap: TokenMap) {
+	for (const token of contract) {
+		expect(token in tokenMap).toBe(true);
+	}
+}
+
+describe('election token contract', () => {
+	test('location state builder supplies documented tokens', () => {
+		expectTokensInclude(
+			['[State]'],
+			buildElectionsIndexTokens({ locationLevel: 'state', stateName: tokenCtx.stateName }),
+		);
+	});
+
+	test('location county builder supplies documented tokens', () => {
+		expectTokensInclude(
+			['[State]', '[County]'],
+			buildElectionsIndexTokens({
+				locationLevel: 'county',
+				stateName: tokenCtx.stateName,
+				countyName: tokenCtx.countyName,
+			}),
+		);
+	});
+
+	test('location city builder supplies documented tokens', () => {
+		expectTokensInclude(
+			['[State]', '[County]', '[City]'],
+			buildElectionsIndexTokens({
+				locationLevel: 'city',
+				stateName: tokenCtx.stateName,
+				countyName: tokenCtx.countyName,
+				cityName: tokenCtx.cityName,
+			}),
+		);
+	});
+
+	test('location district builder supplies documented tokens', () => {
+		expectTokensInclude(
+			['[State]', '[District]'],
+			buildElectionsIndexTokens({
+				locationLevel: 'district',
+				stateName: tokenCtx.stateName,
+				countyName: tokenCtx.countyName,
+			}),
+		);
+	});
+
+	test('position builder supplies documented tokens', () => {
+		expectTokensInclude(
+			['[office name]', '[office]', '[State]', '[County or City]', '[location]'],
+			buildPositionTokens(tokenCtx),
+		);
+	});
+
+	test('candidates builder supplies documented tokens', () => {
+		expectTokensInclude(
+			['[office name]', '[office]', '[State]', '[County or City]', '[location]'],
+			buildCandidatesTokens(tokenCtx),
+		);
+	});
+
+	test('profile builder supplies documented tokens', () => {
+		expectTokensInclude(
+			['[candidate name]', '[office name]'],
+			buildProfileTokens({ candidateName: 'Jane Doe', officeName: 'Mayor' }),
+		);
+	});
+});

--- a/src/lib/electionsTemplateHelpers.tsx
+++ b/src/lib/electionsTemplateHelpers.tsx
@@ -122,6 +122,13 @@ export function buildCandidatesTokens(
 	};
 }
 
+export function buildProfileTokens(ctx: { candidateName: string; officeName: string }): TokenMap {
+	return {
+		'[candidate name]': ctx.candidateName,
+		'[office name]': ctx.officeName,
+	};
+}
+
 export function buildPositionSectionOverrides(ctx: PositionPageContext): SectionOverrides {
 	const race = ctx.race;
 	return {

--- a/src/lib/resolveSectionText.test.ts
+++ b/src/lib/resolveSectionText.test.ts
@@ -17,7 +17,8 @@ describe('resolveRichTextTokens', () => {
 		];
 
 		const result = resolveRichTextTokens(value, { '[office]': 'Mayor' });
+		const blocks = result as Array<{ children?: Array<{ text?: string }> }> | null | undefined;
 
-		expect(result?.[0]?.children?.[0]?.text).toBe('Candidates for Mayor');
+		expect(blocks?.[0]?.children?.[0]?.text).toBe('Candidates for Mayor');
 	});
 });


### PR DESCRIPTION
Enhance token resolution in `ClaimProfileBlockSection` and `GoodPartyOrgPledgeSection`

- Added support for token resolution in `ClaimProfileBlockSection` and `GoodPartyOrgPledgeSection` by integrating `resolveSectionText` and `resolveRichTextTokens`.
- Updated tests to verify the correct resolution of tokens in both sections.
- Introduced `buildProfileTokens` function to streamline token creation for candidate and office names.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 518f798efb0d916e8bd655f7097934eaaa1e3b68. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->