### PR TITLE
Refactor election templates to support location levels

### DIFF
--- a/scripts/audit-tmpl-documents.ts
+++ b/scripts/audit-tmpl-documents.ts
@@ -35,10 +35,10 @@ const LEGACY_TO_GLOBAL: Record<string, string> = {
 	tmpl_candidateProfile: 'globalTemplate_candidateProfile / candidateProfile',
 	tmpl_electionsPosition: 'globalTemplate_position / position',
 	tmpl_electionsCandidates: 'globalTemplate_positionCandidates / positionCandidates',
-	tmpl_electionsStateIndex: 'globalTemplate_location / location (baseline)',
-	tmpl_electionsCountyIndex: 'custom location template (place target) or fold into global',
-	tmpl_electionsCityIndex: 'custom location template (place target) or fold into global',
-	tmpl_electionsDistrictIndex: 'custom location template (place target) or fold into global',
+	tmpl_electionsStateIndex: 'globalTemplate_locationState / locationState',
+	tmpl_electionsCountyIndex: 'globalTemplate_locationCounty / locationCounty',
+	tmpl_electionsCityIndex: 'globalTemplate_locationCity / locationCity',
+	tmpl_electionsDistrictIndex: 'globalTemplate_locationDistrict / locationDistrict',
 };
 
 type LegacyDoc = {

--- a/scripts/migrate-tmpl-to-election-templates.ts
+++ b/scripts/migrate-tmpl-to-election-templates.ts
@@ -28,7 +28,10 @@ const LEGACY_GLOBAL_MAP: Record<
 	tmpl_candidateProfile: 'globalTemplate_candidateProfile',
 	tmpl_electionsPosition: 'globalTemplate_position',
 	tmpl_electionsCandidates: 'globalTemplate_positionCandidates',
-	tmpl_electionsStateIndex: 'globalTemplate_location',
+	tmpl_electionsStateIndex: 'globalTemplate_locationState',
+	tmpl_electionsCountyIndex: 'globalTemplate_locationCounty',
+	tmpl_electionsCityIndex: 'globalTemplate_locationCity',
+	tmpl_electionsDistrictIndex: 'globalTemplate_locationDistrict',
 };
 
 const client = createClient({

--- a/src/lib/electionTemplateDefaults.test.ts
+++ b/src/lib/electionTemplateDefaults.test.ts
@@ -2,7 +2,15 @@ import { describe, expect, test } from 'bun:test';
 import { getCodeDefaultElectionTemplate } from '~/lib/electionTemplateDefaults';
 import type { ElectionTemplateType } from '~/lib/electionTemplates';
 
-const TEMPLATE_TYPES: ElectionTemplateType[] = ['location', 'position', 'positionCandidates', 'candidateProfile'];
+const TEMPLATE_TYPES: ElectionTemplateType[] = [
+	'locationState',
+	'locationCounty',
+	'locationCity',
+	'locationDistrict',
+	'position',
+	'positionCandidates',
+	'candidateProfile',
+];
 
 describe('getCodeDefaultElectionTemplate', () => {
 	for (const templateType of TEMPLATE_TYPES) {

--- a/src/lib/electionTemplateDefaults.ts
+++ b/src/lib/electionTemplateDefaults.ts
@@ -2,6 +2,9 @@ import type { Sections } from '~/PageSections';
 import { PROFILE_PAGE_SECTIONS } from '~/app/candidate/[...slug]/profilePageSections';
 import {
 	tmplElectionsCandidatesSections,
+	tmplElectionsCityIndexSections,
+	tmplElectionsCountyIndexSections,
+	tmplElectionsDistrictIndexSections,
 	tmplElectionsPositionSections,
 	tmplElectionsStateIndexSections,
 } from '~/lib/electionsTemplateSeedSections';
@@ -25,8 +28,14 @@ export function getCodeDefaultElectionTemplate(templateType: ElectionTemplateTyp
 			return stripUnresolvableSeedBlocks(tmplElectionsPositionSections as unknown as Sections[]);
 		case 'positionCandidates':
 			return stripUnresolvableSeedBlocks(tmplElectionsCandidatesSections as unknown as Sections[]);
-		case 'location':
+		case 'locationState':
 			return stripUnresolvableSeedBlocks(tmplElectionsStateIndexSections as unknown as Sections[]);
+		case 'locationCounty':
+			return stripUnresolvableSeedBlocks(tmplElectionsCountyIndexSections as unknown as Sections[]);
+		case 'locationCity':
+			return stripUnresolvableSeedBlocks(tmplElectionsCityIndexSections as unknown as Sections[]);
+		case 'locationDistrict':
+			return stripUnresolvableSeedBlocks(tmplElectionsDistrictIndexSections as unknown as Sections[]);
 		default:
 			return [];
 	}

--- a/src/lib/electionTemplatePreview.test.ts
+++ b/src/lib/electionTemplatePreview.test.ts
@@ -38,6 +38,15 @@ describe('buildElectionTemplatePreviewPath', () => {
 		).toBe('/elections/tx/congressional-district-1');
 	});
 
+	test('builds legacy location path', () => {
+		expect(
+			buildElectionTemplatePreviewPath('location', {
+				field_electionTargetType: 'place',
+				field_electionTargetSlug: 'ny/kings',
+			}),
+		).toBe('/elections/ny/kings');
+	});
+
 	test('builds position path with position slug', () => {
 		expect(
 			buildElectionTemplatePreviewPath('position', {

--- a/src/lib/electionTemplatePreview.test.ts
+++ b/src/lib/electionTemplatePreview.test.ts
@@ -2,13 +2,40 @@ import { describe, expect, test } from 'bun:test';
 import { buildElectionTemplatePreviewPath } from '~/lib/electionTemplatePreview';
 
 describe('buildElectionTemplatePreviewPath', () => {
-	test('builds location path', () => {
+	test('builds state location path', () => {
 		expect(
-			buildElectionTemplatePreviewPath('location', {
+			buildElectionTemplatePreviewPath('locationState', {
 				field_electionTargetType: 'place',
 				field_electionTargetSlug: 'ny',
 			}),
 		).toBe('/elections/ny');
+	});
+
+	test('builds county location path', () => {
+		expect(
+			buildElectionTemplatePreviewPath('locationCounty', {
+				field_electionTargetType: 'place',
+				field_electionTargetSlug: 'ny/kings',
+			}),
+		).toBe('/elections/ny/kings');
+	});
+
+	test('builds city location path', () => {
+		expect(
+			buildElectionTemplatePreviewPath('locationCity', {
+				field_electionTargetType: 'place',
+				field_electionTargetSlug: 'ny/kings/brooklyn',
+			}),
+		).toBe('/elections/ny/kings/brooklyn');
+	});
+
+	test('builds district location path', () => {
+		expect(
+			buildElectionTemplatePreviewPath('locationDistrict', {
+				field_electionTargetType: 'place',
+				field_electionTargetSlug: 'tx/congressional-district-1',
+			}),
+		).toBe('/elections/tx/congressional-district-1');
 	});
 
 	test('builds position path with position slug', () => {

--- a/src/lib/electionTemplatePreview.ts
+++ b/src/lib/electionTemplatePreview.ts
@@ -19,7 +19,10 @@ export function buildElectionTemplatePreviewPath(
 	const positionSlug = previewTarget.field_positionSlug?.replace(/^\/+|\/+$/g, '');
 
 	switch (templateType) {
-		case 'location':
+		case 'locationState':
+		case 'locationCounty':
+		case 'locationCity':
+		case 'locationDistrict':
 			return `/elections/${slug}`;
 		case 'position':
 			return positionSlug ? `/elections/${slug}/position/${positionSlug}` : `/elections/${slug}`;

--- a/src/lib/electionTemplatePreview.ts
+++ b/src/lib/electionTemplatePreview.ts
@@ -19,6 +19,7 @@ export function buildElectionTemplatePreviewPath(
 	const positionSlug = previewTarget.field_positionSlug?.replace(/^\/+|\/+$/g, '');
 
 	switch (templateType) {
+		case 'location':
 		case 'locationState':
 		case 'locationCounty':
 		case 'locationCity':

--- a/src/lib/electionTemplates.test.ts
+++ b/src/lib/electionTemplates.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test';
 import {
 	locationTemplateTypeFromLevel,
 	pickBestCustomTemplate,
+	templateTypesForQuery,
 	type ElectionTemplateContext,
 } from '~/lib/electionTemplates';
 
@@ -9,6 +10,16 @@ const baseCtx: ElectionTemplateContext = {
 	templateType: 'locationCity',
 	placeSlug: 'ny/kings/brooklyn',
 };
+
+describe('templateTypesForQuery', () => {
+	test('includes legacy location type for location level templates', () => {
+		expect(templateTypesForQuery('locationCounty')).toEqual(['locationCounty', 'location']);
+	});
+
+	test('returns only the template type for non-location templates', () => {
+		expect(templateTypesForQuery('position')).toEqual(['position']);
+	});
+});
 
 describe('locationTemplateTypeFromLevel', () => {
 	test('maps each location level to its template type', () => {

--- a/src/lib/electionTemplates.test.ts
+++ b/src/lib/electionTemplates.test.ts
@@ -1,10 +1,23 @@
 import { describe, expect, test } from 'bun:test';
-import { pickBestCustomTemplate, type ElectionTemplateContext } from '~/lib/electionTemplates';
+import {
+	locationTemplateTypeFromLevel,
+	pickBestCustomTemplate,
+	type ElectionTemplateContext,
+} from '~/lib/electionTemplates';
 
 const baseCtx: ElectionTemplateContext = {
-	templateType: 'location',
+	templateType: 'locationCity',
 	placeSlug: 'ny/kings/brooklyn',
 };
+
+describe('locationTemplateTypeFromLevel', () => {
+	test('maps each location level to its template type', () => {
+		expect(locationTemplateTypeFromLevel('state')).toBe('locationState');
+		expect(locationTemplateTypeFromLevel('county')).toBe('locationCounty');
+		expect(locationTemplateTypeFromLevel('city')).toBe('locationCity');
+		expect(locationTemplateTypeFromLevel('district')).toBe('locationDistrict');
+	});
+});
 
 describe('pickBestCustomTemplate', () => {
 	test('prefers candidate target over place when template types match', () => {
@@ -40,14 +53,14 @@ describe('pickBestCustomTemplate', () => {
 				_id: 'ny',
 				field_enabled: true,
 				field_priority: 1,
-				field_electionTemplateType: 'location' as const,
+				field_electionTemplateType: 'locationCity' as const,
 				list_targets: [{ field_electionTargetType: 'place' as const, field_electionTargetSlug: 'ny' }],
 			},
 			{
 				_id: 'ny-kings',
 				field_enabled: true,
 				field_priority: 50,
-				field_electionTemplateType: 'location' as const,
+				field_electionTemplateType: 'locationCity' as const,
 				list_targets: [
 					{ field_electionTargetType: 'place' as const, field_electionTargetSlug: 'ny/kings' },
 				],
@@ -62,18 +75,18 @@ describe('pickBestCustomTemplate', () => {
 				_id: 'high-priority',
 				field_enabled: true,
 				field_priority: 200,
-				field_electionTemplateType: 'location' as const,
+				field_electionTemplateType: 'locationState' as const,
 				list_targets: [{ field_electionTargetType: 'place' as const, field_electionTargetSlug: 'ny' }],
 			},
 			{
 				_id: 'low-priority',
 				field_enabled: true,
 				field_priority: 10,
-				field_electionTemplateType: 'location' as const,
+				field_electionTemplateType: 'locationState' as const,
 				list_targets: [{ field_electionTargetType: 'place' as const, field_electionTargetSlug: 'ny' }],
 			},
 		];
-		const ctx: ElectionTemplateContext = { templateType: 'location', placeSlug: 'ny' };
+		const ctx: ElectionTemplateContext = { templateType: 'locationState', placeSlug: 'ny' };
 		expect(pickBestCustomTemplate(docs, ctx)?._id).toBe('low-priority');
 	});
 
@@ -82,7 +95,7 @@ describe('pickBestCustomTemplate', () => {
 			_id: 'older',
 			field_enabled: true,
 			field_priority: 100,
-			field_electionTemplateType: 'location' as const,
+			field_electionTemplateType: 'locationState' as const,
 			_updatedAt: '2024-01-01T00:00:00Z',
 			list_targets: [{ field_electionTargetType: 'place' as const, field_electionTargetSlug: 'ny' }],
 		};
@@ -90,11 +103,11 @@ describe('pickBestCustomTemplate', () => {
 			_id: 'newer',
 			field_enabled: true,
 			field_priority: 100,
-			field_electionTemplateType: 'location' as const,
+			field_electionTemplateType: 'locationState' as const,
 			_updatedAt: '2024-06-01T00:00:00Z',
 			list_targets: [{ field_electionTargetType: 'place' as const, field_electionTargetSlug: 'ny' }],
 		};
-		const ctx: ElectionTemplateContext = { templateType: 'location', placeSlug: 'ny' };
+		const ctx: ElectionTemplateContext = { templateType: 'locationState', placeSlug: 'ny' };
 		expect(pickBestCustomTemplate([older, newer], ctx)?._id).toBe('newer');
 		expect(pickBestCustomTemplate([newer, older], ctx)?._id).toBe('newer');
 	});
@@ -105,12 +118,26 @@ describe('pickBestCustomTemplate', () => {
 				_id: 'disabled',
 				field_enabled: false,
 				field_priority: 1,
+				field_electionTemplateType: 'locationState' as const,
+				list_targets: [{ field_electionTargetType: 'place' as const, field_electionTargetSlug: 'ny' }],
+			},
+		];
+		const ctx: ElectionTemplateContext = { templateType: 'locationState', placeSlug: 'ny' };
+		expect(pickBestCustomTemplate(docs, ctx)).toBeNull();
+	});
+
+	test('matches legacy location custom templates against any location level type', () => {
+		const docs = [
+			{
+				_id: 'legacy-location',
+				field_enabled: true,
+				field_priority: 100,
 				field_electionTemplateType: 'location' as const,
 				list_targets: [{ field_electionTargetType: 'place' as const, field_electionTargetSlug: 'ny' }],
 			},
 		];
-		const ctx: ElectionTemplateContext = { templateType: 'location', placeSlug: 'ny' };
-		expect(pickBestCustomTemplate(docs, ctx)).toBeNull();
+		const ctx: ElectionTemplateContext = { templateType: 'locationCounty', placeSlug: 'ny/kings' };
+		expect(pickBestCustomTemplate(docs, ctx)?._id).toBe('legacy-location');
 	});
 
 	test('uses raceSlug over positionSlug for position target when both are supplied', () => {

--- a/src/lib/electionTemplates.ts
+++ b/src/lib/electionTemplates.ts
@@ -199,7 +199,18 @@ export function pickBestCustomTemplate(
 	return best;
 }
 
-async function fetchGlobalTemplate(templateType: ElectionTemplateType): Promise<Sections[] | null> {
+export function templateTypesForQuery(
+	templateType: ElectionTemplateType,
+): Array<ElectionTemplateType | LegacyLocationTemplateType> {
+	if (isLocationTemplateType(templateType)) {
+		return [templateType, 'location'];
+	}
+	return [templateType];
+}
+
+async function fetchGlobalTemplateByType(
+	templateType: ElectionTemplateType | LegacyLocationTemplateType,
+): Promise<Sections[] | null> {
 	try {
 		const doc = (await sanityFetch({
 			query: globalElectionTemplateQuery,
@@ -213,18 +224,21 @@ async function fetchGlobalTemplate(templateType: ElectionTemplateType): Promise<
 	}
 }
 
-function customTemplateTypesForQuery(templateType: ElectionTemplateType): Array<ElectionTemplateType | LegacyLocationTemplateType> {
+async function fetchGlobalTemplate(templateType: ElectionTemplateType): Promise<Sections[] | null> {
+	const primary = await fetchGlobalTemplateByType(templateType);
+	if (primary) return primary;
+
 	if (isLocationTemplateType(templateType)) {
-		return [templateType, 'location'];
+		return fetchGlobalTemplateByType('location');
 	}
-	return [templateType];
+	return null;
 }
 
 async function fetchCustomTemplateTargets(templateType: ElectionTemplateType): Promise<CustomTemplateTargetsDoc[]> {
 	try {
 		const docs = (await sanityFetch({
 			query: customElectionTemplateTargetsQuery,
-			params: { templateTypes: customTemplateTypesForQuery(templateType) },
+			params: { templateTypes: templateTypesForQuery(templateType) },
 			tags: ['goodpartyOrg_customTemplate', `goodpartyOrg_customTemplate_${templateType}`],
 		})) as CustomTemplateTargetsDoc[] | null;
 		return docs ?? [];

--- a/src/lib/electionTemplates.ts
+++ b/src/lib/electionTemplates.ts
@@ -8,7 +8,53 @@ import {
 import { sanityFetch } from '~/sanity/sanityClient';
 import type { TokenMap } from '~/lib/resolveTokens';
 
-export type ElectionTemplateType = 'location' | 'position' | 'positionCandidates' | 'candidateProfile';
+export type LocationLevel = 'state' | 'county' | 'city' | 'district';
+
+export type LocationTemplateType =
+	| 'locationState'
+	| 'locationCounty'
+	| 'locationCity'
+	| 'locationDistrict';
+
+export type ElectionTemplateType =
+	| LocationTemplateType
+	| 'position'
+	| 'positionCandidates'
+	| 'candidateProfile';
+
+/** @deprecated Legacy custom docs may still use this type for all location levels. */
+export type LegacyLocationTemplateType = 'location';
+
+export const LOCATION_TEMPLATE_TYPES: readonly LocationTemplateType[] = [
+	'locationState',
+	'locationCounty',
+	'locationCity',
+	'locationDistrict',
+] as const;
+
+export function isLocationTemplateType(
+	templateType: ElectionTemplateType | LegacyLocationTemplateType | string | undefined,
+): templateType is LocationTemplateType {
+	return (
+		templateType === 'locationState' ||
+		templateType === 'locationCounty' ||
+		templateType === 'locationCity' ||
+		templateType === 'locationDistrict'
+	);
+}
+
+export function locationTemplateTypeFromLevel(level: LocationLevel): LocationTemplateType {
+	switch (level) {
+		case 'state':
+			return 'locationState';
+		case 'county':
+			return 'locationCounty';
+		case 'city':
+			return 'locationCity';
+		case 'district':
+			return 'locationDistrict';
+	}
+}
 
 export type ElectionTargetType = 'place' | 'position' | 'candidate';
 
@@ -41,10 +87,20 @@ type CustomTemplateTargetsDoc = {
 	_id: string;
 	field_enabled?: boolean;
 	field_priority?: number;
-	field_electionTemplateType?: ElectionTemplateType;
+	field_electionTemplateType?: ElectionTemplateType | LegacyLocationTemplateType;
 	_updatedAt?: string;
 	list_targets?: SanityTarget[];
 };
+
+function customTemplateTypeMatches(
+	docType: ElectionTemplateType | LegacyLocationTemplateType | undefined,
+	ctxType: ElectionTemplateType,
+): boolean {
+	if (!docType) return false;
+	if (docType === ctxType) return true;
+	if (docType === 'location' && isLocationTemplateType(ctxType)) return true;
+	return false;
+}
 
 type GlobalTemplateDoc = {
 	pageSections?: { list_pageSections?: Sections[] | null } | null;
@@ -95,7 +151,7 @@ function targetMatches(docTarget: SanityTarget, ctxTarget: ElectionTemplateTarge
 
 function scoreCustomTemplate(doc: CustomTemplateTargetsDoc, ctx: ElectionTemplateContext): number | null {
 	if (doc.field_enabled === false) return null;
-	if (doc.field_electionTemplateType !== ctx.templateType) return null;
+	if (!customTemplateTypeMatches(doc.field_electionTemplateType, ctx.templateType)) return null;
 
 	const ctxTargetsList = contextTargets(ctx);
 	if (!ctxTargetsList.length || !doc.list_targets?.length) return null;
@@ -157,11 +213,18 @@ async function fetchGlobalTemplate(templateType: ElectionTemplateType): Promise<
 	}
 }
 
+function customTemplateTypesForQuery(templateType: ElectionTemplateType): Array<ElectionTemplateType | LegacyLocationTemplateType> {
+	if (isLocationTemplateType(templateType)) {
+		return [templateType, 'location'];
+	}
+	return [templateType];
+}
+
 async function fetchCustomTemplateTargets(templateType: ElectionTemplateType): Promise<CustomTemplateTargetsDoc[]> {
 	try {
 		const docs = (await sanityFetch({
 			query: customElectionTemplateTargetsQuery,
-			params: { templateType },
+			params: { templateTypes: customTemplateTypesForQuery(templateType) },
 			tags: ['goodpartyOrg_customTemplate', `goodpartyOrg_customTemplate_${templateType}`],
 		})) as CustomTemplateTargetsDoc[] | null;
 		return docs ?? [];

--- a/src/lib/electionsTemplateSeedSections.ts
+++ b/src/lib/electionsTemplateSeedSections.ts
@@ -479,9 +479,21 @@ export const tmplElectionsDistrictIndexSections = [
 ];
 
 const GLOBAL_TEMPLATE_PREVIEW_TARGETS = {
-	location: {
+	locationState: {
 		field_electionTargetType: 'place',
 		field_electionTargetSlug: 'ny',
+	},
+	locationCounty: {
+		field_electionTargetType: 'place',
+		field_electionTargetSlug: 'ny/kings',
+	},
+	locationCity: {
+		field_electionTargetType: 'place',
+		field_electionTargetSlug: 'ny/kings/brooklyn',
+	},
+	locationDistrict: {
+		field_electionTargetType: 'place',
+		field_electionTargetSlug: 'tx/congressional-district-1',
 	},
 	position: {
 		field_electionTargetType: 'place',
@@ -520,12 +532,36 @@ export const globalElectionTemplateSeedDocuments = [
 		pageSections: { list_pageSections: tmplElectionsCandidatesSections },
 	},
 	{
-		_id: 'globalTemplate_location',
+		_id: 'globalTemplate_locationState',
 		_type: 'goodpartyOrg_globalTemplate',
-		field_title: 'Location Index',
-		field_electionTemplateType: 'location',
-		previewTarget: GLOBAL_TEMPLATE_PREVIEW_TARGETS.location,
+		field_title: 'Location - State',
+		field_electionTemplateType: 'locationState',
+		previewTarget: GLOBAL_TEMPLATE_PREVIEW_TARGETS.locationState,
 		pageSections: { list_pageSections: tmplElectionsStateIndexSections },
+	},
+	{
+		_id: 'globalTemplate_locationCounty',
+		_type: 'goodpartyOrg_globalTemplate',
+		field_title: 'Location - County',
+		field_electionTemplateType: 'locationCounty',
+		previewTarget: GLOBAL_TEMPLATE_PREVIEW_TARGETS.locationCounty,
+		pageSections: { list_pageSections: tmplElectionsCountyIndexSections },
+	},
+	{
+		_id: 'globalTemplate_locationCity',
+		_type: 'goodpartyOrg_globalTemplate',
+		field_title: 'Location - City',
+		field_electionTemplateType: 'locationCity',
+		previewTarget: GLOBAL_TEMPLATE_PREVIEW_TARGETS.locationCity,
+		pageSections: { list_pageSections: tmplElectionsCityIndexSections },
+	},
+	{
+		_id: 'globalTemplate_locationDistrict',
+		_type: 'goodpartyOrg_globalTemplate',
+		field_title: 'Location - District',
+		field_electionTemplateType: 'locationDistrict',
+		previewTarget: GLOBAL_TEMPLATE_PREVIEW_TARGETS.locationDistrict,
+		pageSections: { list_pageSections: tmplElectionsDistrictIndexSections },
 	},
 ] as const;
 

--- a/src/lib/renderElectionsIndexPage.tsx
+++ b/src/lib/renderElectionsIndexPage.tsx
@@ -4,6 +4,7 @@ import {
 	type ElectionsIndexPageContext,
 } from '~/lib/electionsTemplateHelpers';
 import { buildElectionsIndexTokens } from '~/lib/electionsIndexTemplates';
+import { locationTemplateTypeFromLevel } from '~/lib/electionTemplates';
 import { renderElectionTemplatePage } from '~/lib/renderElectionTemplatePage';
 
 export type ElectionsIndexTemplateContext = ElectionsIndexPageContext & {
@@ -13,7 +14,7 @@ export type ElectionsIndexTemplateContext = ElectionsIndexPageContext & {
 export async function renderElectionsIndexPage(ctx: ElectionsIndexTemplateContext) {
 	return renderElectionTemplatePage({
 		context: {
-			templateType: 'location',
+			templateType: locationTemplateTypeFromLevel(ctx.locationLevel),
 			placeSlug: ctx.placeSlug,
 		},
 		sectionOverrides: buildElectionsIndexSectionOverrides(ctx),

--- a/src/sanity/groq.ts
+++ b/src/sanity/groq.ts
@@ -327,7 +327,7 @@ export const globalElectionTemplateQuery = defineQuery(
  */
 /*language=textmate*/
 export const customElectionTemplateTargetsQuery = defineQuery(
-	`*[_type=="goodpartyOrg_customTemplate"&&field_electionTemplateType==$templateType&&field_enabled!=false] | order(field_priority asc, _updatedAt desc){_id,field_electionTemplateType,field_enabled,field_priority,_updatedAt,list_targets[]{field_electionTargetType,field_electionTargetSlug}}`,
+	`*[_type=="goodpartyOrg_customTemplate"&&field_electionTemplateType in $templateTypes&&field_enabled!=false] | order(field_priority asc, _updatedAt desc){_id,field_electionTemplateType,field_enabled,field_priority,_updatedAt,list_targets[]{field_electionTargetType,field_electionTargetSlug}}`,
 );
 
 /*language=textmate*/

--- a/src/sanity/schema/documents/goodpartyOrg_customTemplate.ts
+++ b/src/sanity/schema/documents/goodpartyOrg_customTemplate.ts
@@ -5,6 +5,8 @@ import { field_electionTemplateType } from '../fields/field_electionTemplateType
 
 const CUSTOM_INSTRUCTIONS = `Custom templates override the global template when their targets match the current page.
 
+Location templates are split by level (state, county, city, district). Choose the level that matches the pages you want to override.
+
 Matching rules (most specific wins, then lower Priority number):
 1. Candidate slug beats position slug beats place slug
 2. Longer place slug beats shorter (e.g. ny/kings/brooklyn beats ny)

--- a/src/sanity/schema/documents/goodpartyOrg_globalTemplate.ts
+++ b/src/sanity/schema/documents/goodpartyOrg_globalTemplate.ts
@@ -5,6 +5,8 @@ import { field_electionTemplateType } from '../fields/field_electionTemplateType
 
 const EDITOR_INSTRUCTIONS = `Global templates are the site-wide default for each election page family.
 
+Location pages have separate globals for state, county, city, and district index pages.
+
 If a custom template matches the current page but has an error, the site falls back to this global template.
 If this global template is missing or invalid, the site falls back to the built-in code default (same as launch).
 

--- a/src/sanity/schema/fields/field_electionTemplateType.ts
+++ b/src/sanity/schema/fields/field_electionTemplateType.ts
@@ -1,5 +1,8 @@
 export const ELECTION_TEMPLATE_TYPES = [
-	{ title: 'Location (state / county / city / district)', value: 'location' },
+	{ title: 'Location - State', value: 'locationState' },
+	{ title: 'Location - County', value: 'locationCounty' },
+	{ title: 'Location - City', value: 'locationCity' },
+	{ title: 'Location - District', value: 'locationDistrict' },
 	{ title: 'Position page', value: 'position' },
 	{ title: 'Position candidates list', value: 'positionCandidates' },
 	{ title: 'Candidate profile', value: 'candidateProfile' },

--- a/src/sanity/structure/defaultStructure.ts
+++ b/src/sanity/structure/defaultStructure.ts
@@ -73,7 +73,10 @@ export function defaultStructure(S: StructureBuilder) {
                 title: 'Global Templates',
                 icon: getIcon('Template'),
                 items: [
-                  globalTemplateItem('globalTemplate_location', 'Location'),
+                  globalTemplateItem('globalTemplate_locationState', 'Location - State'),
+                  globalTemplateItem('globalTemplate_locationCounty', 'Location - County'),
+                  globalTemplateItem('globalTemplate_locationCity', 'Location - City'),
+                  globalTemplateItem('globalTemplate_locationDistrict', 'Location - District'),
                   globalTemplateItem('globalTemplate_position', 'Position'),
                   globalTemplateItem('globalTemplate_positionCandidates', 'Position Candidates'),
                   globalTemplateItem('globalTemplate_candidateProfile', 'Candidate Profile'),


### PR DESCRIPTION
- Updated election template types to include distinct levels: state, county, city, and district.
- Modified related functions and mappings to accommodate the new structure.
- Enhanced tests to verify the correct behavior of the new location template types.
- Updated documentation to reflect changes in template structure and usage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which Sanity global/custom template resolves for every elections index page by level; incorrect CMS data or missing new globals could alter live page layouts until migration/seeds are applied.
> 
> **Overview**
> Replaces the single **location** election template type with four level-specific types (`locationState`, `locationCounty`, `locationCity`, `locationDistrict`) so state, county, city, and district index pages can have separate global defaults, code fallbacks, and CMS choices.
> 
> **Runtime:** `renderElectionsIndexPage` picks the template type from `locationLevel` via `locationTemplateTypeFromLevel`. Custom template matching and GROQ now query both the level-specific type and legacy `location`; legacy custom globals still match any location level, and missing level-specific globals fall back to the old `globalTemplate_location` doc.
> 
> **CMS & seeds:** Sanity template type field, studio structure, and global seed documents are split into four location globals (each with its own preview target and section seed). Migration/audit scripts map each legacy `tmpl_elections*Index` singleton to the matching new global id.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb3395ac3484c5c28b3947db4df4c269e77f2850. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->