### PR TITLE
Enhance Amplitude integration

### DIFF
--- a/src/RichTextContentSections/ImageCTAGroup.tsx
+++ b/src/RichTextContentSections/ImageCTAGroup.tsx
@@ -22,9 +22,9 @@ export function ImageCTAGroup(section: Extract<ArticleSections, { _type: 'imageC
 				image={section.image?.img_featuredImage}
 				showFullImage={section.image?.showFullImage}
 				label={section['overview']?.field_label}
-				title={section['overview'].field_title}
+				title={section['overview']?.field_title}
 				copy={<RichData value={section['overview']?.block_summaryText} />}
-				caption={section['overview'].field_caption}
+				caption={section['overview']?.field_caption}
 				primaryButton={transformButtons([section['primaryCTA']])?.[0]}
 				secondaryButton={transformButtons([section['secondaryCTA']])?.[0]}
 			/>

--- a/src/RichTextContentSections/InlineQuoteSectionGroup.tsx
+++ b/src/RichTextContentSections/InlineQuoteSectionGroup.tsx
@@ -14,8 +14,8 @@ export function InlineQuoteSectionGroup(section: Extract<ArticleSections, { _typ
 				/>
 				<Author
 					className='pl-9'
-					name={section.ref_quoteBy?.['personOverview'].field_personName}
-					meta={[section.ref_quoteBy?.['personOverview'].field_jobTitleOrRole]}
+					name={section.ref_quoteBy?.['personOverview']?.field_personName}
+					meta={[section.ref_quoteBy?.['personOverview']?.field_jobTitleOrRole]}
 				/>
 			</div>
 		</section>

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -33,6 +33,10 @@ function encodeAmplitudeBrowserSdk20Cookie(deviceId: string): string {
 	return btoa(encoded);
 }
 
+function isGoodPartyProductionHost(hostname: string): boolean {
+	return hostname === 'goodparty.org' || hostname.endsWith('.goodparty.org');
+}
+
 /**
  * First-time visitors have no `AMP_*` cookie yet, so SSR cannot bucket them.
  * Runs on every page route the matcher allows so experiments can be resolved
@@ -66,6 +70,9 @@ function maybeBootstrapAmplitudeDeviceCookie(request: NextRequest): NextResponse
 		maxAge: 365 * 24 * 60 * 60,
 		sameSite: 'lax',
 		secure: request.nextUrl.protocol === 'https:',
+		...(isGoodPartyProductionHost(request.nextUrl.hostname)
+			? { domain: '.goodparty.org' }
+			: {}),
 	});
 
 	return response;

--- a/src/types/amplitude.d.ts
+++ b/src/types/amplitude.d.ts
@@ -8,9 +8,15 @@ declare global {
 		amplitude?: {
 			init(apiKey: string, options?: {
 				fetchRemoteConfig?: boolean;
-				autocapture?: boolean;
+				autocapture?: boolean | {
+					attribution?: boolean | {
+						resetSessionOnNewCampaign?: boolean;
+						excludeReferrers?: (string | RegExp)[];
+					};
+				};
 				/** Prefer beacon so events survive full-page navigation / unload. */
 				transport?: 'fetch' | 'xhr' | 'beacon';
+				cookieOptions?: { domain?: string };
 			}): void;
 			add?(plugin: unknown): void;
 			track(eventName: string, eventProperties?: Record<string, unknown>): void;

--- a/src/ui/Amplitude.tsx
+++ b/src/ui/Amplitude.tsx
@@ -24,6 +24,7 @@ function markAmplitudeUnavailable(message: string) {
 }
 
 function adoptExternalAmplitude() {
+	// Externally-owned Amplitude (GTM/Segment) also needs cookieOptions.domain: '.goodparty.org' at its source to stitch across subdomains.
 	const state = getAmplitudeState();
 	if (!state || state.clientInitialized) return;
 	state.clientInitialized = true;
@@ -36,10 +37,19 @@ function bootAppAmplitude() {
 	if (!state || state.clientInitialized) return;
 	state.clientInitialized = true;
 
+	const host = window.location.hostname;
+	const onGoodPartyDomain = host === 'goodparty.org' || host.endsWith('.goodparty.org');
+
 	window.amplitude.init(AMPLITUDE_API_KEY, {
 		fetchRemoteConfig: false,
-		autocapture: true,
+		autocapture: {
+			attribution: {
+				resetSessionOnNewCampaign: false,
+				excludeReferrers: [/goodparty\.org$/],
+			},
+		},
 		transport: 'beacon',
+		...(onGoodPartyDomain ? { cookieOptions: { domain: '.goodparty.org' } } : {}),
 	});
 	markAmplitudeReady();
 }


### PR DESCRIPTION
Advanced autocapture options and cookie domain settings

- Updated amplitude types to support a more complex autocapture configuration, allowing for attribution settings.
- Added cookieOptions to specify the domain for external Amplitude instances, ensuring proper tracking across subdomains.
- Adjusted Amplitude initialization in the UI to reflect these new options based on the current domain.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes attribution and cookie scope for analytics identity; misconfiguration could skew sessions or cross-subdomain tracking, but there is no auth or data-handling impact.
> 
> **Overview**
> Tightens **Amplitude** initialization so attribution and identity behave better across **goodparty.org** subdomains.
> 
> **`bootAppAmplitude`** no longer uses plain `autocapture: true`. It enables attribution autocapture with **`resetSessionOnNewCampaign: false`** and **`excludeReferrers`** matching `goodparty.org`, so internal navigation is less likely to be treated as new campaign traffic. On hosts under **goodparty.org**, **`cookieOptions.domain: '.goodparty.org'`** is set so device/session cookies can be shared across subdomains.
> 
> Type definitions in **`amplitude.d.ts`** are expanded so **`autocapture`** and **`cookieOptions`** match these init options. A comment on **`adoptExternalAmplitude`** notes that GTM/Segment-owned Amplitude must apply the same cookie domain at its source for consistent stitching when the app does not call **`init`** itself.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bef605c60474f6ddcd1e03524418ffe22e24679b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->