### PR TITLE
feat: component generator + new-component skill

### DIFF
--- a/.claude/skills/new-component/SKILL.md
+++ b/.claude/skills/new-component/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: new-component
+description: Add a new Sanity page-builder block (a reusable section the marketing team can drag onto pages). Use when the user wants a new component, block, or section type on the marketing site that does not already exist. Runs the scaffolding generator so no wiring is missed, then customizes and verifies it.
+---
+
+# Add a new page-builder block
+
+Use this when the marketing site needs a new kind of block that does not exist yet
+(a new section a marketer can drop onto a page in Studio). If the request is really
+about content, styling an existing block, or a new field on an existing block, this
+is the wrong tool — check `docs/content-vs-code.md` first.
+
+The person you are helping is usually not an engineer. Gather what they want in
+plain language, do the technical work yourself, and verify before you open a PR.
+Full background: `docs/adding-a-component.md`.
+
+## Why use the generator
+
+Adding a block by hand means editing five files that must all agree, and if you miss
+one the block half-works silently (renders nothing, or has no data, or never appears
+in the editor menu). The generator does all that wiring in one step so it cannot be
+missed. Your job is then the parts that need judgment: the fields, the data mapping,
+and the styling.
+
+## Steps
+
+1. **Understand what the block should be.** Ask the person, in plain terms, what it
+   should show and roughly how it should look. Pick a PascalCase name (for example
+   `PromoBanner`) and, if you know it, which add-block menu group it belongs in
+   (`hero`, `form`, `text`, `image`, `quote`, `cards`, `grid`, `stats`, `pricing`,
+   `features`, `cta`, `blog`; default is `text`).
+
+2. **Scaffold it:**
+
+   ```bash
+   bun run new:component PromoBanner --group text
+   ```
+
+   This creates the schema, the PageSection wrapper, and the UI component, and wires
+   the block into `componentSchema.ts`, `list_pageSections.ts`, `groq.ts`, and
+   `PageSections/index.tsx`. The scaffold is a working placeholder with a heading and
+   a body field.
+
+3. **Regenerate types:**
+
+   ```bash
+   bun run sanity:extract && bun run sanity:generate
+   ```
+
+4. **Customize the three generated files** for what the person actually asked for:
+   - `src/sanity/schema/components/component_<name>.ts` — the editable fields.
+   - `src/PageSections/<Name>Section.tsx` — maps the Sanity fields to the UI props.
+   - `src/ui/<Name>.tsx` — the actual markup and styling. Follow the design system
+     (reuse existing components, design tokens, and CSS custom properties; see
+     `.cursor/BUGBOT.md`).
+   - If you add fields with nested references, buttons, or rich text, you also need a
+     GROQ projection — see the GROQ section in `docs/adding-a-component.md`. If you
+     add or change fields, regenerate types again (step 3).
+
+5. **Verify (required — this repo fails quietly):**
+   - `rm -f node_modules/.tsbuildinfo && bun run typecheck` (must be clean)
+   - `bun run test`
+   - `bun run dev`, add the block to the `/all` page in Studio, and open
+     `http://localhost:3009/all` to confirm it renders with your content and looks
+     right. Visual confirmation is the only thing that catches a wiring or data gap,
+     because none of those are type errors.
+
+6. **Ship it** with the `ship-pr` skill. Tell the person, in plain language, what the
+   new block does and that it will show up in the page builder once the PR merges.
+
+## If the generator errors
+
+It edits real files by matching anchors in them. If it reports it "could not find an
+anchor," those files have changed shape since the generator was written. Do not force
+it — fall back to the manual recipe in `docs/adding-a-component.md` and update
+`scripts/new-component.ts` so the next run works.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,7 @@ bun run typecheck           # tsc --noEmit  (the ONLY way to catch type errors; 
 bun run lint                # eslint (next lint)
 bun run test                # full test suite (splits .ts unit tests and .tsx DOM tests, see docs)
 bun run sanity:extract && bun run sanity:generate   # regenerate Sanity types after any schema change
+bun run new:component <PascalName> [--group text]   # scaffold + fully wire a new page-builder block
 ```
 
 The `/all` route (http://localhost:3009/all) renders every block in the real
@@ -79,7 +80,8 @@ Read the nearest relevant doc rather than loading everything.
 | ------------------------------------------- | ----------------------------------- |
 | Deciding if a request needs code at all     | `docs/content-vs-code.md`           |
 | Understanding the system / how pages render | `docs/architecture.md`              |
-| Adding or changing a page-builder block     | `docs/adding-a-component.md`        |
+| Adding a page-builder block                 | the `new-component` skill           |
+| Changing an existing page-builder block     | `docs/adding-a-component.md`        |
 | Anything about election or candidate pages  | `docs/elections.md`                 |
 | How AirOps writes content into Sanity       | `docs/airops-sanity-integration.md` |
 | Opening a PR and getting it approved        | the `ship-pr` skill                 |

--- a/docs/adding-a-component.md
+++ b/docs/adding-a-component.md
@@ -8,6 +8,18 @@ A block is a reusable section that a marketer can drag onto a page in the editor
 
 Adding a new block is a code change. It touches several files that must all agree with each other. This is the important thing to understand: the block only works if every file is edited. If you skip one of the edits, the block can still deploy without any error, and it will half-work in a way that is easy to miss. It might not appear in the editor's add-block menu, or it might appear but render nothing, or it might render but pull in no data. So follow every step, and then verify visually (see the verification loop at the end).
 
+## Fastest path: the generator
+
+You usually should not do the wiring by hand. Run the generator, which creates all three new files and edits all the registration points in one step, so none can be missed:
+
+```bash
+bun run new:component PromoBanner --group text
+```
+
+Use a PascalCase name. The `--group` is the add-block menu section it appears under (`hero`, `form`, `text`, `image`, `quote`, `cards`, `grid`, `stats`, `pricing`, `features`, `cta`, `blog`; defaults to `text`). Then regenerate types (`bun run sanity:extract && bun run sanity:generate`), customize the three generated files for your fields, mapping, and styling, and verify (see the verification loop at the end). The `new-component` skill walks through this.
+
+The manual recipe below documents exactly what the generator does, and is what you follow to customize the generated files or when the generator cannot run.
+
 Why it fails silently: type and lint errors are caught (CI and the build enforce `typecheck` and `lint`), but most ways to half-wire a block are not type errors. An unknown block type renders as nothing instead of crashing (the render switch just logs a warning), the error boundary swallows render errors, and a missing GROQ projection or a missing add-block-menu entry is perfectly valid TypeScript. So `typecheck`, `lint`, and `test` will pass on a broken block. Verifying visually on `/all` is the only safety net for wiring gaps.
 
 If you are an agent doing this work for a non-technical user, explain what you did and whether it worked in plain language. No jargon. Short sentences. If something needs an engineer (see the last section), say so plainly.

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "sb:dev": "storybook dev -p 6006 --disable-telemetry --no-version-updates",
     "sb:build": "storybook build",
     "sb:deploy": "chromatic",
+    "new:component": "bun run scripts/new-component.ts",
     "sanity:dev": "sanity dev",
     "sanity:extract": "sanity schema extract",
     "sanity:generate": "sanity typegen generate",

--- a/scripts/new-component.ts
+++ b/scripts/new-component.ts
@@ -44,7 +44,7 @@ const reactName = rawName!;
 const camel = reactName.charAt(0).toLowerCase() + reactName.slice(1);
 const componentType = `component_${camel}`;
 const sectionName = `${reactName}Section`;
-const title = reactName.replace(/([a-z0-9])([A-Z])/g, '$1 $2');
+const title = reactName.replace(/([A-Z]+)([A-Z][a-z])/g, '$1 $2').replace(/([a-z0-9])([A-Z])/g, '$1 $2');
 
 const schemaPath = join(root, 'src/sanity/schema/components', `${componentType}.ts`);
 if (existsSync(schemaPath)) {

--- a/scripts/new-component.ts
+++ b/scripts/new-component.ts
@@ -1,0 +1,249 @@
+/**
+ * Scaffolds a new Sanity page-builder block and wires it into every place the
+ * rendering pipeline needs it, so the block cannot half-work silently. Run:
+ *
+ *   bun run new:component <PascalCaseName> [--group <menuGroup>]
+ *
+ * Example: bun run new:component PromoBanner --group text
+ *
+ * It creates the schema, the PageSection wrapper, and the UI component, then edits
+ * componentSchema.ts, list_pageSections.ts, groq.ts, and PageSections/index.tsx.
+ * After it runs, regenerate types (bun run sanity:extract && bun run sanity:generate)
+ * and verify the block on http://localhost:3009/all. See docs/adding-a-component.md.
+ */
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const MENU_GROUPS = ['hero', 'form', 'text', 'image', 'quote', 'cards', 'grid', 'stats', 'pricing', 'features', 'cta', 'blog'];
+const DEFAULT_GROUP = 'text';
+
+const root = join(import.meta.dir, '..');
+
+const fail = (message: string): never => {
+	console.error(`\n  new:component: ${message}\n`);
+	process.exit(1);
+};
+
+const args = process.argv.slice(2);
+const groupFlagIndex = args.findIndex(a => a === '--group');
+const menuGroup = groupFlagIndex >= 0 ? args[groupFlagIndex + 1] : DEFAULT_GROUP;
+const rawName = args.find((a, i) => !a.startsWith('--') && (groupFlagIndex < 0 || i !== groupFlagIndex + 1));
+
+if (!rawName) {
+	fail('missing name. Usage: bun run new:component <PascalCaseName> [--group text]');
+}
+if (!/^[A-Z][A-Za-z0-9]+$/.test(rawName!)) {
+	fail(`name must be PascalCase letters/numbers (got "${rawName}"). Example: PromoBanner`);
+}
+if (!MENU_GROUPS.includes(menuGroup!)) {
+	fail(`--group must be one of: ${MENU_GROUPS.join(', ')}`);
+}
+
+// Naming: PromoBanner -> component_promoBanner, PromoBannerSection, ui/PromoBanner, "Promo Banner"
+const reactName = rawName!;
+const camel = reactName.charAt(0).toLowerCase() + reactName.slice(1);
+const componentType = `component_${camel}`;
+const sectionName = `${reactName}Section`;
+const title = reactName.replace(/([a-z0-9])([A-Z])/g, '$1 $2');
+
+const schemaPath = join(root, 'src/sanity/schema/components', `${componentType}.ts`);
+if (existsSync(schemaPath)) {
+	fail(`a block named ${componentType} already exists (${schemaPath}). Pick a different name.`);
+}
+
+// --- Anchored edit helper: replaces exactly once, or fails loudly if the anchor moved.
+const edit = (relPath: string, anchor: string, replacement: string): void => {
+	const path = join(root, relPath);
+	const src = readFileSync(path, 'utf8');
+	if (!src.includes(anchor)) {
+		fail(`could not find the expected anchor in ${relPath}. The file may have changed shape; update scripts/new-component.ts.`);
+	}
+	writeFileSync(path, src.replace(anchor, replacement));
+};
+
+const write = (path: string, contents: string): void => writeFileSync(path, contents);
+
+// --- New file: schema
+write(
+	schemaPath,
+	`import { resolveValue } from '../../utils/resolveValue.ts';
+import { handleReplacements } from '../../utils/handleReplacements.ts';
+import { getIcon } from '../../utils/getIcon.tsx';
+
+export const ${componentType} = {
+	title: '${title}',
+	name: '${componentType}',
+	type: 'object',
+	icon: getIcon('Development'),
+	fields: [
+		{
+			title: 'Heading',
+			name: 'field_heading',
+			type: 'string',
+		},
+		{
+			title: 'Body',
+			name: 'field_body',
+			type: 'text',
+			rows: 4,
+		},
+		{
+			title: 'Settings',
+			name: 'componentSettings',
+			type: 'componentSettings',
+			group: 'componentSettings',
+		},
+	],
+	preview: {
+		select: {
+			title: 'field_heading',
+		},
+		prepare: (x: any) => {
+			const infer = {
+				singletonTitle: null,
+				icon: getIcon('Development'),
+				fallback: {
+					title: '${title}',
+				},
+			};
+			const title = resolveValue('title', ${componentType}.preview.select, x);
+			const subtitle = resolveValue('subtitle', ${componentType}.preview.select, x);
+			const media = resolveValue('media', ${componentType}.preview.select, x);
+			return handleReplacements(
+				{
+					title: infer.singletonTitle || title || undefined,
+					subtitle: subtitle ? subtitle : infer.fallback['title'],
+					media: media || infer.icon,
+				},
+				x,
+				infer.fallback,
+			);
+		},
+	},
+	groups: [
+		{
+			title: 'Settings',
+			name: 'componentSettings',
+			icon: getIcon('Settings'),
+		},
+	],
+};
+`,
+);
+
+// --- New file: PageSection wrapper
+write(
+	join(root, 'src/PageSections', `${sectionName}.tsx`),
+	`import { stegaClean } from 'next-sanity';
+
+import type { Sections } from '~/PageSections';
+import { ${reactName} } from '~/ui/${reactName}';
+
+export function ${sectionName}(section: Extract<Sections, { _type: '${componentType}' }>) {
+	return (
+		<section id={stegaClean(section.componentSettings?.field_anchorId)} data-section='${title}'>
+			<${reactName} heading={section.field_heading ?? ''} body={section.field_body ?? ''} />
+		</section>
+	);
+}
+`,
+);
+
+// --- New file: UI component (a plain scaffold; restyle it to match the design system)
+write(
+	join(root, 'src/ui', `${reactName}.tsx`),
+	`import { Container } from '~/ui/Container.tsx';
+import { Text } from '~/ui/Text.tsx';
+
+export type ${reactName}Props = {
+	heading?: string;
+	body?: string;
+};
+
+export const ${reactName} = (props: ${reactName}Props) => {
+	return (
+		<section className='py-(--container-padding)'>
+			<Container>
+				<Text as='h2' styleType='heading-lg'>
+					{props.heading}
+				</Text>
+				<Text as='p' styleType='body-1'>
+					{props.body}
+				</Text>
+			</Container>
+		</section>
+	);
+};
+`,
+);
+
+// --- Edit: componentSchema.ts (import + array entry)
+edit(
+	'src/sanity/schema/components/componentSchema.ts',
+	'\nexport const componentSchema = [',
+	`\nimport { ${componentType} } from './${componentType}.ts';\n\nexport const componentSchema = [\n\t${componentType},`,
+);
+
+// --- Edit: list_pageSections.ts (top-level page-sections array + insert-menu group)
+edit(
+	'src/sanity/schema/lists/list_pageSections.ts',
+	"type: 'array',\n  of: [\n",
+	`type: 'array',\n  of: [\n    { title: '${title}', type: '${componentType}' },\n`,
+);
+{
+	const path = join(root, 'src/sanity/schema/lists/list_pageSections.ts');
+	const src = readFileSync(path, 'utf8');
+	const groupsStart = src.indexOf('groups: [');
+	const nameIdx = groupsStart >= 0 ? src.indexOf(`name: '${menuGroup}',`, groupsStart) : -1;
+	const ofIdx = nameIdx >= 0 ? src.indexOf('of: [', nameIdx) : -1;
+	if (ofIdx < 0) {
+		fail(`could not find the '${menuGroup}' insert-menu group in list_pageSections.ts.`);
+	}
+	const insertAt = ofIdx + 'of: ['.length;
+	writeFileSync(path, `${src.slice(0, insertAt)}\n            '${componentType}',${src.slice(insertAt)}`);
+}
+
+// --- Edit: groq.ts (projection + append to sectionsGroq before its closing backtick)
+edit(
+	'src/sanity/groq.ts',
+	'export const sectionsGroq = `_key,_type,',
+	`export const ${componentType} = \`_type=="${componentType}"=>{...,componentSettings}\`;\n/*language=textmate*/\nexport const sectionsGroq = \`_key,_type,`,
+);
+{
+	const path = join(root, 'src/sanity/groq.ts');
+	const src = readFileSync(path, 'utf8');
+	const lineStart = src.indexOf('export const sectionsGroq = `');
+	const lineEnd = src.indexOf('`;', lineStart);
+	if (lineStart < 0 || lineEnd < 0) {
+		fail('could not find the sectionsGroq template literal in src/sanity/groq.ts.');
+	}
+	writeFileSync(path, `${src.slice(0, lineEnd)},\${${componentType}}${src.slice(lineEnd)}`);
+}
+
+// --- Edit: PageSections/index.tsx (import + switch case)
+edit(
+	'src/PageSections/index.tsx',
+	'export type Sections = ',
+	`import { ${sectionName} } from '~/PageSections/${sectionName}';\n\nexport type Sections = `,
+);
+edit(
+	'src/PageSections/index.tsx',
+	'\t\t\t\tdefault:',
+	`\t\t\t\tcase '${componentType}':\n\t\t\t\t\treturn (\n\t\t\t\t\t\t<ComponentErrorBoundary key={section._key} componentName='${title}'>\n\t\t\t\t\t\t\t<${sectionName} {...section} />\n\t\t\t\t\t\t</ComponentErrorBoundary>\n\t\t\t\t\t);\n\t\t\t\tdefault:`,
+);
+
+console.log(`
+  Scaffolded ${componentType} ("${title}") and wired it in.
+
+  Created:
+    src/sanity/schema/components/${componentType}.ts
+    src/PageSections/${sectionName}.tsx
+    src/ui/${reactName}.tsx
+  Wired into: componentSchema.ts, list_pageSections.ts (page-sections + '${menuGroup}' menu group), groq.ts, PageSections/index.tsx
+
+  Next:
+    1. bun run sanity:extract && bun run sanity:generate   # regenerate types
+    2. bun run typecheck
+    3. bun run dev  ->  add the block to the /all page in Studio  ->  open http://localhost:3009/all
+    4. Customize the fields (schema), the mapping (${sectionName}), and the styling (ui/${reactName}) for what you need.
+`);


### PR DESCRIPTION
## Why

Adding a new page-builder block is the main "code" task the marketing team will want,
and by hand it is exactly the kind of change a non-technical person cannot safely make:
it touches five files that all have to agree, and if you miss one the block half-works
silently. It renders nothing, or fetches no data, or never shows up in the editor's
add-block menu. None of those are type errors, so typecheck, lint, and tests all pass
on a broken block. That silent-failure class is the single biggest blocker to letting
a marketer add a block with an agent.

This adds a generator that does the wiring so it cannot be missed, and a skill that
drives the whole workflow.

## What is here

- `scripts/new-component.ts` + a `new:component` npm script:
  `bun run new:component PromoBanner --group text`. It creates the schema, the
  PageSection wrapper, and the UI component, and inserts the registration points in
  `componentSchema.ts`, `list_pageSections.ts` (the page-sections array and the chosen
  insert-menu group), `groq.ts` (the projection and the `sectionsGroq` append), and
  `PageSections/index.tsx` (import and switch case). The scaffold is a working
  heading + body placeholder. Anchor lookups fail loudly if a target file changes
  shape, rather than producing a subtly broken block.
- A `new-component` skill that wraps it for a non-technical operator: gather intent in
  plain language, scaffold, regenerate types, customize fields / mapping / styling,
  verify on `/all`, and ship with `ship-pr`.
- `docs/adding-a-component.md` now leads with the generator; the manual recipe stays as
  the reference for customizing the generated files or when the generator cannot run.

Verified end to end on a throwaway block: the generated output typechecks and lints
clean and wires all four registration points. The throwaway block was reverted, so
this PR is only the tooling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Developer tooling and documentation only; no runtime or production pipeline behavior changes in this PR.
> 
> **Overview**
> Adds **`bun run new:component <PascalName> [--group text]`** (`scripts/new-component.ts`) so new Sanity page-builder blocks get scaffolded and wired in one step: schema, PageSection wrapper, UI placeholder, plus registration in `componentSchema.ts`, `list_pageSections.ts` (sections list and insert-menu group), `groq.ts`, and `PageSections/index.tsx`. Anchor-based edits **fail loudly** if those files drift.
> 
> Introduces the **`new-component` Claude skill** for non-engineers (intent → scaffold → typegen → customize → verify on `/all` → ship). **`docs/adding-a-component.md`** and **`CLAUDE.md`** now point new blocks at the generator/skill; the manual recipe remains for customization or when the generator breaks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e95a076e72f582dc20b653f40d20e48b3e73785. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->