### PR TITLE
chore: add ClickUp MCP server config

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "clickup": {
+      "type": "http",
+      "url": "https://mcp.clickup.com/mcp"
+    }
+  }
+}


### PR DESCRIPTION
The marketing team files its site requests as ClickUp tickets, so an agent working in this repo should be able to read and act on them directly. This adds the hosted ClickUp MCP server (same config as omni's `.mcp.json`). It authorizes via OAuth on first use, so no secret is committed. Config-only change; no source, so typecheck, lint, and tests are unaffected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only addition with no runtime code or secrets; OAuth is handled outside the committed file.
> 
> **Overview**
> Adds a new **`.mcp.json`** at the repo root so MCP-capable agents can reach ClickUp without leaving the editor.
> 
> The file registers one HTTP MCP server pointing at **`https://mcp.clickup.com/mcp`**, matching the pattern used elsewhere (e.g. omni). **OAuth on first use** handles auth—no API tokens in the repo. This is config-only; application source, tests, and build tooling are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf60c4c910fe8f1697ecb826efef9e5492fa1fc3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->