### PR TITLE
refactor: simplify layout structure and enhance attribution handling

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from 'next';
 import Script from 'next/script';
 import { draftMode } from 'next/headers';
 import { VisualEditing } from 'next-sanity/visual-editing';
-import { Suspense, type ReactNode } from 'react';
+import { type ReactNode } from 'react';
 import '~/ui/_styles/globals.css';
 import { Amplitude } from '~/ui/Amplitude';
 import { AttributionProvider } from '~/ui/AttributionProvider';
@@ -94,22 +94,20 @@ export default async function RootLayout({ children }: Props) {
 				<Amplitude />
 				<ScrollDepthTracker />
 				{(await draftMode()).isEnabled && <VisualEditing />}
-				<Suspense fallback={null}>
-					<AttributionProvider>
-						<ComponentErrorBoundary componentName='Header'>
-							<PageHeader className='shrink-0' isDraftMode={(await draftMode()).isEnabled} />
-						</ComponentErrorBoundary>
-						<main
-							role='main'
-							className={`bg-goodparty-cream flex-1 basis-0 ${(await draftMode()).isEnabled ? 'pt-[calc(var(--header-height)+var(--preview-header-height))]' : 'pt-(--header-height)'}`}
-						>
-							{children}
-						</main>
-						<ComponentErrorBoundary componentName='Footer'>
-							<PageFooter className='shrink-0' />
-						</ComponentErrorBoundary>
-					</AttributionProvider>
-				</Suspense>
+				<AttributionProvider>
+					<ComponentErrorBoundary componentName='Header'>
+						<PageHeader className='shrink-0' isDraftMode={(await draftMode()).isEnabled} />
+					</ComponentErrorBoundary>
+					<main
+						role='main'
+						className={`bg-goodparty-cream flex-1 basis-0 ${(await draftMode()).isEnabled ? 'pt-[calc(var(--header-height)+var(--preview-header-height))]' : 'pt-(--header-height)'}`}
+					>
+						{children}
+					</main>
+					<ComponentErrorBoundary componentName='Footer'>
+						<PageFooter className='shrink-0' />
+					</ComponentErrorBoundary>
+				</AttributionProvider>
 				<Script id='hubspot-forms' src='//js.hsforms.net/forms/embed/v2.js' strategy='beforeInteractive' />
 				<Script id='hs-script-loader' src='//js.hs-scripts.com/21589597.js' strategy='afterInteractive' />
 			</body>

--- a/src/lib/attribution.test.ts
+++ b/src/lib/attribution.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import {
 	ATTRIBUTION_PARAM_KEYS,
+	captureAttributionFromSearch,
 	decorateAppUrl,
 	GP_ATTRIBUTION_COOKIE,
 	isAppGoodPartyUrl,
@@ -8,7 +9,40 @@ import {
 	parseAttributionFromSearch,
 	readGpAttributionCookie,
 	serializeGpAttributionCookie,
+	writeGpAttributionCookie,
 } from './attribution';
+
+type CookieDocument = { cookie: string };
+type ProtocolWindow = { location: { protocol: string } };
+type MutableGlobals = {
+	document?: CookieDocument;
+	window?: ProtocolWindow;
+};
+
+const testGlobal = globalThis as unknown as MutableGlobals;
+const originalDocument = testGlobal.document;
+const originalWindow = testGlobal.window;
+
+function installBrowserGlobals() {
+	testGlobal.document = { cookie: '' };
+	testGlobal.window = { location: { protocol: 'https:' } };
+}
+
+function restoreBrowserGlobals() {
+	testGlobal.document = originalDocument;
+	testGlobal.window = originalWindow;
+}
+
+function getDocumentCookie(): string {
+	return testGlobal.document?.cookie ?? '';
+}
+
+function setDocumentCookie(value: string) {
+	if (!testGlobal.document) {
+		throw new Error('document stub missing');
+	}
+	testGlobal.document.cookie = value;
+}
 
 describe('parseAttributionFromSearch', () => {
 	test('captures only allowlisted params', () => {
@@ -145,6 +179,83 @@ describe('decorateAppUrl', () => {
 	test('returns href unchanged when attribution is null', () => {
 		const href = 'https://app.goodparty.org/sign-up';
 		expect(decorateAppUrl(href, null)).toBe(href);
+	});
+});
+
+describe('captureAttributionFromSearch', () => {
+	beforeEach(installBrowserGlobals);
+	afterEach(restoreBrowserGlobals);
+
+	test('writes cookie and returns merged data when incoming params are present', () => {
+		const now = 1_700_000_000_000;
+		const originalNow = Date.now;
+		Date.now = () => now;
+		try {
+			const captured = captureAttributionFromSearch('?fbclid=abc&utm_source=meta', 'localhost');
+
+			expect(captured).toEqual({ fbclid: 'abc', utm_source: 'meta', _ts: now });
+			expect(getDocumentCookie()).toContain(`${GP_ATTRIBUTION_COOKIE}=`);
+			expect(readGpAttributionCookie(getDocumentCookie())).toEqual(captured);
+		} finally {
+			Date.now = originalNow;
+		}
+	});
+
+	test('returns existing cookie without writing when no incoming params', () => {
+		const existing = { fbclid: 'abc', _ts: 1_000, utm_source: 'meta' };
+		setDocumentCookie(`${GP_ATTRIBUTION_COOKIE}=${serializeGpAttributionCookie(existing)}`);
+		const cookieBefore = getDocumentCookie();
+
+		const captured = captureAttributionFromSearch('?foo=bar', 'localhost');
+
+		expect(captured).toEqual(existing);
+		expect(getDocumentCookie()).toBe(cookieBefore);
+	});
+
+	test('merges incoming params with existing cookie and writes updated value', () => {
+		const existing = { fbclid: 'abc', _ts: 1_000, utm_source: 'meta' };
+		setDocumentCookie(`${GP_ATTRIBUTION_COOKIE}=${serializeGpAttributionCookie(existing)}`);
+
+		const captured = captureAttributionFromSearch('?utm_campaign=spring', 'localhost');
+
+		expect(captured).toEqual({
+			fbclid: 'abc',
+			_ts: 1_000,
+			utm_source: 'meta',
+			utm_campaign: 'spring',
+		});
+		expect(readGpAttributionCookie(getDocumentCookie())).toEqual(captured);
+	});
+});
+
+describe('writeGpAttributionCookie', () => {
+	beforeEach(installBrowserGlobals);
+	afterEach(restoreBrowserGlobals);
+
+	test('writes host-only cookie on non-production hostname', () => {
+		writeGpAttributionCookie({ fbclid: 'abc' }, 'localhost');
+
+		const cookie = getDocumentCookie();
+		expect(cookie).toContain(`${GP_ATTRIBUTION_COOKIE}=`);
+		expect(cookie).toContain('path=/');
+		expect(cookie).toContain('max-age=7776000');
+		expect(cookie).toContain('SameSite=Lax');
+		expect(cookie).not.toContain('domain=');
+		expect(cookie).not.toContain('Secure');
+	});
+
+	test('writes domain-scoped Secure cookie on production hostname over https', () => {
+		writeGpAttributionCookie({ fbclid: 'abc' }, 'www.goodparty.org');
+
+		const cookie = getDocumentCookie();
+		expect(cookie).toContain('domain=.goodparty.org');
+		expect(cookie).toContain('Secure');
+	});
+
+	test('returns without writing when document is undefined', () => {
+		testGlobal.document = undefined;
+
+		expect(() => writeGpAttributionCookie({ fbclid: 'abc' }, 'localhost')).not.toThrow();
 	});
 });
 

--- a/src/ui/AttributionProvider.tsx
+++ b/src/ui/AttributionProvider.tsx
@@ -1,7 +1,16 @@
 'use client';
 
 import { usePathname, useSearchParams } from 'next/navigation';
-import { createContext, useContext, useEffect, useState, type ReactNode } from 'react';
+import {
+	createContext,
+	Suspense,
+	useContext,
+	useEffect,
+	useState,
+	type Dispatch,
+	type ReactNode,
+	type SetStateAction,
+} from 'react';
 import {
 	type AttributionData,
 	captureAttributionFromSearch,
@@ -26,17 +35,33 @@ type Props = {
 };
 
 export function AttributionProvider({ children }: Props) {
+	const [attribution, setAttribution] = useState<AttributionData | null>(null);
+
+	return (
+		<AttributionContext.Provider value={attribution}>
+			<Suspense fallback={null}>
+				<AttributionCapture onCapture={setAttribution} />
+			</Suspense>
+			{children}
+		</AttributionContext.Provider>
+	);
+}
+
+type CaptureProps = {
+	onCapture: Dispatch<SetStateAction<AttributionData | null>>;
+};
+
+function AttributionCapture({ onCapture }: CaptureProps) {
 	const pathname = usePathname();
 	const searchParams = useSearchParams();
 	const searchKey = searchParams.toString();
-	const [attribution, setAttribution] = useState<AttributionData | null>(null);
 
 	useEffect(() => {
 		const captured =
 			captureAttributionFromSearch(searchKey ? `?${searchKey}` : '', window.location.hostname) ??
 			readGpAttributionCookie();
-		setAttribution(captured);
-	}, [pathname, searchKey]);
+		onCapture(captured);
+	}, [pathname, searchKey, onCapture]);
 
-	return <AttributionContext.Provider value={attribution}>{children}</AttributionContext.Provider>;
+	return null;
 }


### PR DESCRIPTION
This update refactors the RootLayout component by removing the Suspense wrapper around the AttributionProvider, streamlining the layout structure. Additionally, the AttributionProvider is enhanced to manage attribution data more effectively, utilizing a new AttributionCapture component for capturing data from URL parameters and cookies. The attribution tests are also expanded to cover new functionality.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Layout and attribution wiring refactor with expanded tests; marketing attribution behavior should stay the same with a smaller suspense scope.
> 
> **Overview**
> Moves the **`Suspense`** boundary out of the root layout and into **`AttributionProvider`**, so only URL/search-param capture is deferred instead of the entire header, main, and footer tree.
> 
> **`AttributionProvider`** now keeps context state at the provider level and runs capture in a separate **`AttributionCapture`** child (using **`useSearchParams`** / **`usePathname`**) that reports results via **`onCapture`**. Children render outside that suspense boundary, so the shell is no longer blocked on search params.
> 
> Adds unit tests for **`captureAttributionFromSearch`** and **`writeGpAttributionCookie`** (cookie merge/write behavior, prod vs localhost cookie flags, SSR-safe no-op).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ba51c3cf29e2dcbab79b3d61973719a10a2d02a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->