### PR TITLE
refactor: use isomorphic layout effect for attribution capture

### DIFF
--- a/src/ui/AttributionProvider.tsx
+++ b/src/ui/AttributionProvider.tsx
@@ -5,8 +5,6 @@ import {
 	createContext,
 	Suspense,
 	useContext,
-	useEffect,
-	useLayoutEffect,
 	useState,
 	type Dispatch,
 	type ReactNode,
@@ -18,10 +16,9 @@ import {
 	decorateAppUrl,
 	readGpAttributionCookie,
 } from '~/lib/attribution';
+import useIsomorphicLayoutEffect from '~/ui/_lib/useIsomorphicLayoutEffect';
 
 const AttributionContext = createContext<AttributionData | null>(null);
-
-const useIsomorphicLayoutEffect = typeof window !== 'undefined' ? useLayoutEffect : useEffect;
 
 export function useAttribution(): AttributionData | null {
 	return useContext(AttributionContext);

--- a/src/ui/AttributionProvider.tsx
+++ b/src/ui/AttributionProvider.tsx
@@ -6,6 +6,7 @@ import {
 	Suspense,
 	useContext,
 	useEffect,
+	useLayoutEffect,
 	useState,
 	type Dispatch,
 	type ReactNode,
@@ -19,6 +20,8 @@ import {
 } from '~/lib/attribution';
 
 const AttributionContext = createContext<AttributionData | null>(null);
+
+const useIsomorphicLayoutEffect = typeof window !== 'undefined' ? useLayoutEffect : useEffect;
 
 export function useAttribution(): AttributionData | null {
 	return useContext(AttributionContext);
@@ -56,7 +59,7 @@ function AttributionCapture({ onCapture }: CaptureProps) {
 	const searchParams = useSearchParams();
 	const searchKey = searchParams.toString();
 
-	useEffect(() => {
+	useIsomorphicLayoutEffect(() => {
 		const captured =
 			captureAttributionFromSearch(searchKey ? `?${searchKey}` : '', window.location.hostname) ??
 			readGpAttributionCookie();


### PR DESCRIPTION
This update replaces the useEffect hook with a custom useIsomorphicLayoutEffect in the AttributionCapture component to ensure consistent behavior across server and client environments. This change enhances the reliability of attribution data capture from URL parameters and cookies.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small timing change in a client-only attribution provider with no API or data-model changes; main risk is subtle SSR/hydration or ordering differences versus the previous effect.
> 
> **Overview**
> **Attribution capture timing** in `AttributionCapture` moves from `useEffect` to a local `useIsomorphicLayoutEffect` (`useLayoutEffect` in the browser, `useEffect` when `window` is undefined). The capture logic is unchanged; it still reads query params via `captureAttributionFromSearch` and falls back to `readGpAttributionCookie`, then calls `onCapture`.
> 
> The goal is to populate attribution context earlier on the client so consumers like `useDecoratedAppHref` / `Anchor` are less likely to render once without attribution params and then update on the next paint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3cff6134bd5f1f8e802ef74c884df5092ab3de5d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->