### PR TITLE
fix: update election target slugs to include 'county' for consistency

### DIFF
--- a/src/lib/electionTemplatePreview.test.ts
+++ b/src/lib/electionTemplatePreview.test.ts
@@ -15,18 +15,18 @@ describe('buildElectionTemplatePreviewPath', () => {
 		expect(
 			buildElectionTemplatePreviewPath('locationCounty', {
 				field_electionTargetType: 'place',
-				field_electionTargetSlug: 'ny/kings',
+				field_electionTargetSlug: 'ny/kings-county',
 			}),
-		).toBe('/elections/ny/kings');
+		).toBe('/elections/ny/kings-county');
 	});
 
 	test('builds city location path', () => {
 		expect(
 			buildElectionTemplatePreviewPath('locationCity', {
 				field_electionTargetType: 'place',
-				field_electionTargetSlug: 'ny/kings/brooklyn',
+				field_electionTargetSlug: 'ny/kings-county/brooklyn',
 			}),
-		).toBe('/elections/ny/kings/brooklyn');
+		).toBe('/elections/ny/kings-county/brooklyn');
 	});
 
 	test('builds district location path', () => {
@@ -42,9 +42,9 @@ describe('buildElectionTemplatePreviewPath', () => {
 		expect(
 			buildElectionTemplatePreviewPath('location', {
 				field_electionTargetType: 'place',
-				field_electionTargetSlug: 'ny/kings',
+				field_electionTargetSlug: 'ny/kings-county',
 			}),
-		).toBe('/elections/ny/kings');
+		).toBe('/elections/ny/kings-county');
 	});
 
 	test('builds position path with position slug', () => {

--- a/src/lib/electionTemplates.test.ts
+++ b/src/lib/electionTemplates.test.ts
@@ -8,7 +8,7 @@ import {
 
 const baseCtx: ElectionTemplateContext = {
 	templateType: 'locationCity',
-	placeSlug: 'ny/kings/brooklyn',
+	placeSlug: 'ny/kings-county/brooklyn',
 };
 
 describe('templateTypesForQuery', () => {
@@ -68,16 +68,16 @@ describe('pickBestCustomTemplate', () => {
 				list_targets: [{ field_electionTargetType: 'place' as const, field_electionTargetSlug: 'ny' }],
 			},
 			{
-				_id: 'ny-kings',
+				_id: 'ny-kings-county',
 				field_enabled: true,
 				field_priority: 50,
 				field_electionTemplateType: 'locationCity' as const,
 				list_targets: [
-					{ field_electionTargetType: 'place' as const, field_electionTargetSlug: 'ny/kings' },
+					{ field_electionTargetType: 'place' as const, field_electionTargetSlug: 'ny/kings-county' },
 				],
 			},
 		];
-		expect(pickBestCustomTemplate(docs, baseCtx)?._id).toBe('ny-kings');
+		expect(pickBestCustomTemplate(docs, baseCtx)?._id).toBe('ny-kings-county');
 	});
 
 	test('uses lower priority on tie', () => {
@@ -147,7 +147,7 @@ describe('pickBestCustomTemplate', () => {
 				list_targets: [{ field_electionTargetType: 'place' as const, field_electionTargetSlug: 'ny' }],
 			},
 		];
-		const ctx: ElectionTemplateContext = { templateType: 'locationCounty', placeSlug: 'ny/kings' };
+		const ctx: ElectionTemplateContext = { templateType: 'locationCounty', placeSlug: 'ny/kings-county' };
 		expect(pickBestCustomTemplate(docs, ctx)?._id).toBe('legacy-location');
 	});
 

--- a/src/lib/electionsTemplateSeedSections.ts
+++ b/src/lib/electionsTemplateSeedSections.ts
@@ -487,11 +487,11 @@ const GLOBAL_TEMPLATE_PREVIEW_TARGETS = {
 	},
 	locationCounty: {
 		field_electionTargetType: 'place',
-		field_electionTargetSlug: 'ny/kings',
+		field_electionTargetSlug: 'ny/kings-county',
 	},
 	locationCity: {
 		field_electionTargetType: 'place',
-		field_electionTargetSlug: 'ny/kings/brooklyn',
+		field_electionTargetSlug: 'ny/kings-county/brooklyn',
 	},
 	locationDistrict: {
 		field_electionTargetType: 'place',

--- a/src/sanity/schema/documents/goodpartyOrg_customTemplate.ts
+++ b/src/sanity/schema/documents/goodpartyOrg_customTemplate.ts
@@ -9,7 +9,7 @@ Location templates are split by level (state, county, city, district). Choose th
 
 Matching rules (most specific wins, then lower Priority number):
 1. Candidate slug beats position slug beats place slug
-2. Longer place slug beats shorter (e.g. ny/kings/brooklyn beats ny)
+2. Longer place slug beats shorter (e.g. ny/kings-county/brooklyn beats ny)
 3. Lower Priority wins ties
 
 On any error in a custom template, the site uses the corresponding global template, then the code default.

--- a/src/sanity/schema/fields/field_electionTemplateType.ts
+++ b/src/sanity/schema/fields/field_electionTemplateType.ts
@@ -41,6 +41,6 @@ export const field_electionTargetSlug = {
 	title: 'Target Slug',
 	type: 'string',
 	description:
-		'API slug used for matching. Examples: place `ny`, `ny/kings`, `ny/kings/brooklyn`; position race slug; candidate profile slug.',
+		'API slug used for matching. Examples: place `ny`, `ny/kings-county`, `ny/kings-county/brooklyn`; position race slug; candidate profile slug.',
 	validation: (rule: { required(): unknown }) => rule.required(),
 };


### PR DESCRIPTION
This commit modifies the election target slugs in the elections template and related tests to include 'county' in the slug for Kings County. The changes ensure that the slugs are consistent across the application, improving clarity and accuracy in the election template paths.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and documentation/seed constant updates only; custom templates in Sanity that still use `ny/kings` would need manual retargeting to match production slugs.
> 
> **Overview**
> Updates **Kings County** example and preview place slugs from `ny/kings` to **`ny/kings-county`** (and city paths to `ny/kings-county/brooklyn`) so election template matching, preview URLs, and CMS docs match the real API slug shape.
> 
> Touches **tests** (`electionTemplatePreview`, `electionTemplates`), **global template seed preview targets** in `electionsTemplateSeedSections`, and **Sanity copy** on custom template instructions and `field_electionTargetSlug` examples. No matching or routing logic changes in this diff—only slug strings and documentation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 236aa7097921179771c59bf608055e77380fb7c6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->