### PR TITLE
Add templates documentations

### DIFF
--- a/docs/content-vs-code.md
+++ b/docs/content-vs-code.md
@@ -27,7 +27,8 @@ Studio (the CMS, served at `/studio/main`), do not open a PR:
 - Redirects (managed as content; they take effect without a deploy).
 - A/B experiment variants.
 - Election page templates: which blocks appear and the token-driven copy on the
-  global template or a per-location custom template.
+  global template or a per-location custom template. Step-by-step editor guide:
+  `docs/election-templates-manual.md`.
 
 Content published in Studio goes live without a rebuild (a webhook revalidates the
 affected pages). Some content is also written programmatically by AirOps — see

--- a/docs/election-templates-manual.md
+++ b/docs/election-templates-manual.md
@@ -1,0 +1,205 @@
+# Election templates: editor guide
+
+How to control the layout and copy on GoodParty.org election and candidate pages
+from Sanity Studio. No code or deploy is required for normal edits.
+
+Studio: [https://goodparty-marketing.sanity.studio/studio/main](https://goodparty-marketing.sanity.studio/studio/main)
+
+In the left nav: **Goodparty.org → Templates**.
+
+---
+
+## What this feature is
+
+Election and candidate pages are not built one by one. Each page family uses a
+**template**: a list of page sections (blocks) plus token-driven copy.
+
+There are two kinds:
+
+| Kind | What it does |
+| ---- | ------------ |
+| **Global Templates** | Site-wide default for one page family (all states, all counties, and so on). |
+| **Custom Templates** | Override the global for specific places, races, or candidates you target. |
+
+Page families (one Global Template each):
+
+- Location - State (example: `/elections/ny`)
+- Location - County (example: `/elections/wi/adams-county`)
+- Location - City (example: `/elections/wi/adams-county/adams`)
+- Location - District (example: `/elections/mn/minneapolis-public-school-district`)
+- Position page (example: `/elections/ny/position/governor`)
+- Position Candidates list (example: `/elections/ny/position/governor/candidates`)
+- Candidate Profile (example: `/candidate/janet-mills/us-senate-maine`)
+
+```mermaid
+flowchart TD
+  page[Election or candidate page]
+  custom[Matching Custom Template?]
+  global[Global Template for that page family]
+  fallback[Built-in default]
+  page --> custom
+  custom -->|yes| renderCustom[Use Custom]
+  custom -->|no or empty| global
+  global -->|has sections| renderGlobal[Use Global]
+  global -->|missing or empty| fallback
+```
+
+---
+
+## How pages choose a template
+
+1. If an **enabled Custom Template** matches this page (by Targets), use it.
+2. Otherwise use the **Global Template** for that page family.
+3. If that Global is missing or has no sections, use the **built-in default**.
+
+Among Custom Templates that all match, the most specific target wins. Ties use
+the lower **Priority** number (default 100).
+
+---
+
+## Editing a Global Template
+
+1. Open **Templates → Global Templates**.
+2. Open the page family you want (for example **Location - State**).
+3. Edit **Page Sections** like any other page builder: add, remove, reorder
+   blocks, and change copy.
+4. Open the **Preview** group and set **Preview Target** (see cheat sheet below).
+5. Open the site preview tab and confirm the draft looks right.
+6. **Publish**.
+
+Do not create extra Global documents for the same page family. Use the seven
+fixed entries in the Global Templates list.
+
+---
+
+## Preview Target cheat sheet
+
+Preview Target tells Studio which real URL to open in the iframe.
+
+| Template | Preview Target Type | Preview Slug example | Position Slug |
+| -------- | ------------------- | -------------------- | ------------- |
+| Location - State | Place | `ny` | (hidden) |
+| Location - County | Place | `wi/adams-county` | (hidden) |
+| Location - City | Place | `wi/adams-county/adams` | (hidden) |
+| Location - District | Place | `mn/minneapolis-public-school-district` | (hidden) |
+| Position | Place | `ny` | `governor` |
+| Position Candidates | Place | `ny` | `governor` |
+| Candidate Profile | **Candidate** | `janet-mills/us-senate-maine` | (hidden) |
+
+Rules:
+
+- Do not add leading or trailing `/`.
+- For **Candidate Profile**, choose **Candidate**, not Place. Paste the candidate
+  slug from a live profile URL after `/candidate/`.
+- **Position Slug** only appears for Position and Position Candidates templates.
+  It is the last URL segment (for example `governor`), not the full race slug.
+- If **Candidate** is missing from the list, hard-refresh Studio or confirm you
+  are on `https://goodparty-marketing.sanity.studio/studio/main`.
+
+---
+
+## Creating a Custom Template
+
+Sanity cannot change a document’s type. Do **not** duplicate a Global and try to
+turn it into a Custom.
+
+### Clone from a Global (recommended)
+
+1. Open the Global Template for the page family you want to override.
+2. Go to **Page Sections**.
+3. Open the field actions menu on **Page Sections** → **Copy field**.
+4. Go to **Templates → Custom Templates** → create a new document.
+5. Set **Title** (internal label only).
+6. Set **Template Type** to the same page family as the Global you copied.
+7. Leave **Enabled** on.
+8. Set **Priority** if needed (lower number wins ties; default 100).
+9. Paste into **Page Sections** (field actions → **Paste field**).
+10. Add at least one **Target** (see valid combinations below).
+11. Set **Preview Target** to a page that should show this custom version.
+12. Edit sections / tokens as needed.
+13. Confirm the Studio preview.
+14. **Publish**.
+
+Optional: set **Cloned from Global Template** for lineage only. It does not
+affect matching.
+
+---
+
+## Valid target combinations
+
+Custom **Targets** decide which live pages use this template.
+
+| Template Type | Use this Target Type | Slug examples |
+| ------------- | -------------------- | ------------- |
+| Location - State / County / City / District | **Place** only | `ny`, `wi/adams-county`, `wi/adams-county/adams`, `mn/minneapolis-public-school-district` |
+| Position or Position Candidates | **Place** or **Position** | Place: `ny`. Position: full race slug such as `ny/governor` (not only `governor`) |
+| Candidate Profile | **Candidate** only | `janet-mills/us-senate-maine` |
+
+Place targets match by prefix. A Place target of `ny` can match New York state
+and deeper places under New York for that template type. Prefer longer slugs when
+you only want a county or city.
+
+---
+
+## Tokens (dynamic copy)
+
+In plain text (and supported rich text) fields, use bracket tokens. The site
+replaces them per page. Unmatched known tokens are removed so raw `[token]` text
+does not show.
+
+| Token | Typical pages |
+| ----- | ------------- |
+| `[State]` | Location, position, candidates |
+| `[County]` | County / city location |
+| `[City]` | City location |
+| `[District]` | District location |
+| `[County or City]` | Position / candidates |
+| `[location]` | Position / candidates |
+| `[office]` / `[office name]` | Position / candidates / profile |
+| `[candidate name]` | Candidate profile |
+
+Example: `Upcoming elections in [State]` on a New York state page becomes
+`Upcoming elections in New York`.
+
+---
+
+## Publish checklist
+
+Use this before asking someone else to review a Custom Template:
+
+1. Draft preview in Studio looks correct on the Preview Target URL.
+2. Publish the Custom Template.
+3. Open the **target** public page and confirm your change is live.
+4. Open a **nearby non-target** page of the same family and confirm it still uses
+   the Global Template.
+5. Turn **Enabled** off, publish again, and confirm the target page returns to
+   the Global Template.
+6. Turn **Enabled** back on only when you are ready for the override to stay.
+
+Global Template edits: publish, then check one representative page for that
+family (use the Preview Target URL).
+
+---
+
+## Troubleshooting
+
+| Problem | What to try |
+| ------- | ----------- |
+| Preview is blank or wrong | Set Preview Target Type + Preview Slug (and Position Slug when shown). Click reload on the preview pane. |
+| No **Candidate** option | Hard-refresh Studio. Use the hosted Studio URL above. For Candidate Profile you must pick **Candidate**. |
+| Published change not on the site | Wait a minute and hard-refresh the public page. If it stays stale, ask engineering to check the revalidation webhook for template document types. |
+| Custom Template does nothing | Confirm Enabled is on, Template Type matches the page family, Targets use the correct type and slug format, and Page Sections is not empty. |
+| Wrong pages pick up a Custom | Place prefixes are broad (`ny` matches deep New York places for that type). Use a longer Place slug or a higher Priority number on broader templates. |
+| Position Custom never matches | Use the **full race slug** (for example `ny/governor`), not only `governor`. |
+| One block is empty | A single broken block can hide itself. Fix that block’s fields; the whole page may not switch to Global. |
+
+---
+
+## What this guide does not cover
+
+- Changing how templates behave in code, adding new block types, or new token
+  names (that needs engineering).
+- Fixing wrong candidate data on a profile (usually upstream data, not the
+  template).
+
+For “is this a Studio edit or a code change?”, see `docs/content-vs-code.md`.

--- a/docs/elections.md
+++ b/docs/elections.md
@@ -100,6 +100,9 @@ inheriting its county's statistics.
 
 ### Templates: global vs custom, and three-tier resolution
 
+Editor-facing how-to (Studio steps, preview targets, clone workflow):
+`docs/election-templates-manual.md`.
+
 `ElectionTemplateType` is one of `locationState`, `locationCounty`, `locationCity`,
 `locationDistrict`, `position`, `positionCandidates`, or `candidateProfile` (plus a
 deprecated legacy `location`). `resolveElectionTemplate` in `electionTemplates.ts`

--- a/src/lib/electionTemplatePreview.test.ts
+++ b/src/lib/electionTemplatePreview.test.ts
@@ -15,27 +15,27 @@ describe('buildElectionTemplatePreviewPath', () => {
 		expect(
 			buildElectionTemplatePreviewPath('locationCounty', {
 				field_electionTargetType: 'place',
-				field_electionTargetSlug: 'ny/kings-county',
+				field_electionTargetSlug: 'wi/adams-county',
 			}),
-		).toBe('/elections/ny/kings-county');
+		).toBe('/elections/wi/adams-county');
 	});
 
 	test('builds city location path', () => {
 		expect(
 			buildElectionTemplatePreviewPath('locationCity', {
 				field_electionTargetType: 'place',
-				field_electionTargetSlug: 'ny/kings-county/brooklyn',
+				field_electionTargetSlug: 'wi/adams-county/adams',
 			}),
-		).toBe('/elections/ny/kings-county/brooklyn');
+		).toBe('/elections/wi/adams-county/adams');
 	});
 
 	test('builds district location path', () => {
 		expect(
 			buildElectionTemplatePreviewPath('locationDistrict', {
 				field_electionTargetType: 'place',
-				field_electionTargetSlug: 'tx/congressional-district-1',
+				field_electionTargetSlug: 'mn/minneapolis-public-school-district',
 			}),
-		).toBe('/elections/tx/congressional-district-1');
+		).toBe('/elections/mn/minneapolis-public-school-district');
 	});
 
 	test('builds legacy location path', () => {

--- a/src/lib/electionsTemplateSeedSections.ts
+++ b/src/lib/electionsTemplateSeedSections.ts
@@ -487,15 +487,15 @@ const GLOBAL_TEMPLATE_PREVIEW_TARGETS = {
 	},
 	locationCounty: {
 		field_electionTargetType: 'place',
-		field_electionTargetSlug: 'ny/kings-county',
+		field_electionTargetSlug: 'wi/adams-county',
 	},
 	locationCity: {
 		field_electionTargetType: 'place',
-		field_electionTargetSlug: 'ny/kings-county/brooklyn',
+		field_electionTargetSlug: 'wi/adams-county/adams',
 	},
 	locationDistrict: {
 		field_electionTargetType: 'place',
-		field_electionTargetSlug: 'tx/congressional-district-1',
+		field_electionTargetSlug: 'mn/minneapolis-public-school-district',
 	},
 	position: {
 		field_electionTargetType: 'place',
@@ -507,6 +507,10 @@ const GLOBAL_TEMPLATE_PREVIEW_TARGETS = {
 		field_electionTargetSlug: 'ny',
 		field_positionSlug: 'governor',
 	},
+	candidateProfile: {
+		field_electionTargetType: 'candidate',
+		field_electionTargetSlug: 'janet-mills/us-senate-maine',
+	},
 } as const;
 
 export const globalElectionTemplateSeedDocuments = [
@@ -515,6 +519,7 @@ export const globalElectionTemplateSeedDocuments = [
 		_type: 'goodpartyOrg_globalTemplate',
 		field_title: 'Candidate Profile',
 		field_electionTemplateType: 'candidateProfile',
+		previewTarget: GLOBAL_TEMPLATE_PREVIEW_TARGETS.candidateProfile,
 		pageSections: { list_pageSections: tmplCandidateProfileSections },
 	},
 	{

--- a/src/sanity/schema/documents/goodpartyOrg_customTemplate.ts
+++ b/src/sanity/schema/documents/goodpartyOrg_customTemplate.ts
@@ -12,9 +12,13 @@ Matching rules (most specific wins, then lower Priority number):
 2. Longer place slug beats shorter (e.g. ny/kings-county/brooklyn beats ny)
 3. Lower Priority wins ties
 
-On any error in a custom template, the site uses the corresponding global template, then the code default.
+If a custom template is missing, disabled, or has no page sections, the site uses the matching global template, then the built-in default. A single broken block on a page may still hide itself without switching the whole template.
 
-Clone workflow: duplicate a global template document, change type to custom, add targets, and edit sections.
+Clone workflow (do not duplicate and change document type — Sanity cannot change type that way):
+1. Open the Global Template you want to start from
+2. On Page Sections, use the field menu → Copy field
+3. Create a new Custom Template
+4. Paste into Page Sections, set Template Type, add Targets, set Preview Target, then publish
 
 Supported tokens in plain text fields:
 - Location: [State], [County], [City], [District]

--- a/src/sanity/schema/documents/goodpartyOrg_globalTemplate.ts
+++ b/src/sanity/schema/documents/goodpartyOrg_globalTemplate.ts
@@ -7,15 +7,16 @@ const EDITOR_INSTRUCTIONS = `Global templates are the site-wide default for each
 
 Location pages have separate globals for state, county, city, and district index pages.
 
-If a custom template matches the current page but has an error, the site falls back to this global template.
-If this global template is missing or invalid, the site falls back to the built-in code default (same as launch).
+If a custom template is missing, disabled, or has no page sections, the site uses this global template.
+If this global template is missing or has no page sections, the site uses the built-in default (same as launch).
 
 Supported tokens in plain text fields:
 - Location: [State], [County], [City], [District]
 - Position / candidates: [office name], [State], [County or City], [office], [location]
 - Profile: [candidate name], [office name]
 
-Preview: set Preview Target to a real slug so the iframe opens an example page.`;
+Preview: set Preview Target to a real slug so the iframe opens an example page.
+For Candidate Profile, choose Candidate and a candidate slug (e.g. janet-mills/us-senate-maine).`;
 
 export const goodpartyOrg_globalTemplate = {
 	title: 'Global Election Template',

--- a/src/sanity/schema/groups/electionTemplatePreviewTarget.ts
+++ b/src/sanity/schema/groups/electionTemplatePreviewTarget.ts
@@ -1,27 +1,47 @@
 import { field_electionTargetSlug, field_electionTargetType } from '../fields/field_electionTemplateType.ts';
 
+type PreviewDoc = {
+	field_electionTemplateType?: string;
+};
+
 export const electionTemplatePreviewTarget = {
 	name: 'electionTemplatePreviewTarget',
 	title: 'Preview Target',
 	type: 'object',
 	description:
-		'Used by Studio preview to open a real page URL. Set a representative slug for the page family you are editing.',
+		'Opens a real election or candidate page in the Studio preview. For Candidate Profile templates, choose Candidate and paste a candidate slug (e.g. janet-mills/us-senate-maine). For location templates, choose Place. Position Slug is only needed for Position and Position Candidates templates.',
 	fields: [
 		{
 			...field_electionTargetType,
 			name: 'field_electionTargetType',
 			title: 'Preview Target Type',
+			description:
+				'Candidate Profile → Candidate. Location pages → Place. Position / candidates list → Place (plus Position Slug below) or leave Place with a state/county/city slug.',
+			options: {
+				list: [
+					{ title: 'Place (state, county, city, district slug)', value: 'place' },
+					{ title: 'Position (race slug)', value: 'position' },
+					{ title: 'Candidate (candidate slug)', value: 'candidate' },
+				],
+				layout: 'radio',
+			},
 		},
 		{
 			...field_electionTargetSlug,
 			name: 'field_electionTargetSlug',
 			title: 'Preview Slug',
+			description:
+				'Examples: place `ny`, `wi/adams-county`, `wi/adams-county/adams`, `mn/minneapolis-public-school-district`; candidate `janet-mills/us-senate-maine`.',
 		},
 		{
 			name: 'field_positionSlug',
 			title: 'Position Slug (optional)',
 			type: 'string',
-			description: 'Route position segment when previewing position or candidates pages, e.g. `governor`.',
+			description: 'URL position segment for Position or Position Candidates preview, e.g. `governor`.',
+			hidden: ({ document }: { document?: PreviewDoc }) => {
+				const templateType = document?.field_electionTemplateType;
+				return templateType !== 'position' && templateType !== 'positionCandidates';
+			},
 		},
 	],
 };


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation and CMS editor copy/field visibility only; seed slug changes affect Studio preview defaults, not runtime template matching.
> 
> **Overview**
> Adds **`docs/election-templates-manual.md`**, a Sanity editor guide for global/custom election templates (resolution order, preview targets, clone-via-copy-field workflow, tokens, checklist, troubleshooting). **`docs/content-vs-code.md`** and **`docs/elections.md`** now point editors to that manual.
> 
> **Studio and seeds:** Global/custom template in-schema instructions are updated to match real fallback behavior (missing/disabled/empty sections → global → built-in default; single broken blocks may hide without switching templates). The **Preview Target** object gets clearer copy, an explicit Place/Position/Candidate radio list, and **Position Slug** is hidden unless the document is a Position or Position Candidates template. Default global template **preview slugs** in `electionsTemplateSeedSections.ts` switch to WI/MN examples and **Candidate Profile** gets a seeded preview target (`janet-mills/us-senate-maine`); preview path tests use the same slugs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 078631fc376c8ce79e87902e9926eeac1ca4af35. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->