### PR TITLE
Load plain Amplitude SDK instead of the replay-bundling script build

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -108,7 +108,9 @@ domain model, data sources, and what is and is not fixable in this repo:
 - **Amplitude** — product analytics plus A/B experiments. `src/middleware.ts`
   bootstraps an Amplitude device cookie on page routes so experiments can be resolved
   server-side. Experiment variants are also modeled as Sanity content
-  (`experiment_variant`).
+  (`experiment_variant`). The client loads the plain Amplitude SDK plus the
+  experiment-only script — never the all-in-one `script/<key>.js` build, which
+  bundles session replay capture (see `src/ui/Amplitude.tsx`).
 - **AirOps -> Sanity** — AirOps writes content (articles, glossary, landing pages,
   policy) into Sanity via the Editor API, then a Sanity webhook hits
   `POST /api/revalidate` to make it live. Details, auth, and troubleshooting:

--- a/src/ui/Amplitude.tsx
+++ b/src/ui/Amplitude.tsx
@@ -6,6 +6,12 @@ const AMPLITUDE_API_KEY = process.env['NEXT_PUBLIC_AMPLITUDE_API_KEY'];
 const EXTERNAL_AMPLITUDE_WAIT_MS = 1_500;
 const AMPLITUDE_CDN_WAIT_MS = 10_000;
 
+// Never load the all-in-one cdn.amplitude.com/script/<key>.js build: it bundles the session
+// replay plugin, whose sample rate is remote-controlled (overriding any local sampleRate) and
+// burned the entire monthly replay quota on anonymous marketing sessions (ENG-10831). The plain
+// SDK plus the experiment-only build below cover everything this site uses, with no replay.
+const AMPLITUDE_SDK_SRC = 'https://cdn.amplitude.com/libs/analytics-browser-2.42.4-min.js.gz';
+
 function getAmplitudeState() {
 	if (typeof window === 'undefined') return undefined;
 	window.__goodpartyAmplitude ??= { clientInitialized: false, scriptInjected: false };
@@ -55,8 +61,21 @@ function bootAppAmplitude() {
 }
 
 function findInjectedAmplitudeScript(apiKey: string) {
-	const suffix = `/script/${apiKey}.js`;
-	return [...document.scripts].find((s) => s.src.endsWith(suffix));
+	// GTM may inject either the legacy all-in-one build or the plain SDK.
+	const legacySuffix = `/script/${apiKey}.js`;
+	return [...document.scripts].find((s) => s.src.endsWith(legacySuffix) || s.src === AMPLITUDE_SDK_SRC);
+}
+
+// window.experiment used to come from the all-in-one build; with the plain SDK it needs the
+// experiment-only build, which contains no session replay code.
+function ensureExperimentScript() {
+	if (window.experiment || !AMPLITUDE_API_KEY) return;
+	const src = `https://cdn.amplitude.com/script/${AMPLITUDE_API_KEY}.experiment.js`;
+	if ([...document.scripts].some((s) => s.src === src)) return;
+	const script = document.createElement('script');
+	script.src = src;
+	script.async = true;
+	document.head.appendChild(script);
 }
 
 /**
@@ -137,12 +156,15 @@ export function Amplitude() {
 
 		// GTM/Segment may already own Amplitude. Do not re-init an externally-owned SDK.
 		if (window.amplitude) {
+			ensureExperimentScript();
 			adoptExternalAmplitude();
 			return;
 		}
 
 		const waitForExternalTags = window.setTimeout(() => {
 			if (cancelled || state.clientInitialized) return;
+
+			ensureExperimentScript();
 
 			if (window.amplitude) {
 				adoptExternalAmplitude();
@@ -161,7 +183,7 @@ export function Amplitude() {
 
 			state.scriptInjected = true;
 			const script = document.createElement('script');
-			script.src = `https://cdn.amplitude.com/script/${AMPLITUDE_API_KEY}.js`;
+			script.src = AMPLITUDE_SDK_SRC;
 			script.async = true;
 			document.head.appendChild(script);
 			stopWaitingForScript = whenAmplitudeScriptProvidesGlobal(


### PR DESCRIPTION
## Why

Our monthly Amplitude session replay quota (10k sessions) has been getting fully consumed within the first days of each month by short, anonymous marketing-site sessions (ENG-10831). The capture comes from the all-in-one `cdn.amplitude.com/script/<key>.js` build, which always bundles the session replay plugin. The plugin's sample rate is remote-controlled by the project-level Session Replay setting, so it cannot be disabled from page code (local `sampleRate: 0` is overridden), and Amplitude offers no way to remove the plugin from that build.

This swaps the fallback script this site injects (used when GTM does not load Amplitude first) from the all-in-one build to:
- the plain analytics SDK (`libs/analytics-browser-2.42.4-min.js.gz`), pinned to the same version the all-in-one build ships today, and
- the experiment-only build (`script/<key>.experiment.js`), which keeps Web Experiment support and contains no replay code.

The experiment script is now also ensured on the adopt-external path, so Web Experiment keeps working once the GTM tag is likewise switched off the all-in-one build (tracked separately, same ticket).

Behavior parity notes:
- `window.amplitude` init, event tracking, and autocapture attribution config are unchanged.
- Verified locally with GTM/Segment blocked: both scripts load, `window.amplitude` boots, events flow to api2.amplitude.com, and no session replay plugin or sr-client-cfg requests occur.
- Pre-existing, unchanged: `window.experiment?.exposure()` in `ExperimentExposureTracker` has always been a no-op. Neither the old nor the new build defines `window.experiment` (the tag exposes `window.webExperiment`). Left as is; can be a follow-up.

No visual changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches client analytics bootstrap and experiment loading; behavior is intended to stay the same for events/init, but GTM coexistence and experiment globals depend on the new script split.
> 
> **Overview**
> Stops the marketing site from loading Amplitude’s all-in-one `script/<key>.js` bundle, which always includes session replay and was exhausting the monthly replay quota on anonymous traffic (ENG-10831).
> 
> **`Amplitude.tsx`** now injects the pinned plain analytics SDK (`analytics-browser-2.42.4-min.js.gz`) when the app owns the load, and adds **`ensureExperimentScript()`** to load `script/<key>.experiment.js` on both the self-inject and GTM-adopt paths so experiments still work without replay. Script detection treats either the legacy all-in-one URL or the plain SDK as an existing inject.
> 
> **`docs/architecture.md`** documents that the client must use the plain SDK plus experiment-only script, not the all-in-one build.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c99cd1b5ea10c22eabf59a6aff298f1c406f676e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->