### PR TITLE
fix(people): profile A–L design + data feedback (Figma parity)

### DIFF
--- a/docs/person-profile-locality-handoff.md
+++ b/docs/person-profile-locality-handoff.md
@@ -1,0 +1,95 @@
+# Handoff: authoritative locality on the person spine (Option A)
+
+**Audience:** election-api / data platform team
+**Consumer:** `gp-marketing` public `/people/*` profiles (see `src/lib/peopleProfile.ts`)
+**Type of change:** purely **additive** — new nullable field on two existing feeds. No
+existing field changes shape, so current consumers keep working untouched.
+
+## Why
+
+The Figma person-profile frames render section headings and the hero subheading as
+**"[Position] in [Location]"** — e.g. _"Other Candidates for City Council Member in
+Chicago, IL"_ and the hero line _"Mayor · Springfield, IL"_. Today the app can only
+render the **position** half. There is no field on the person spine that gives a clean,
+consistently-formatted **locality** that is:
+
+1. present for **every** persona (candidate, officeholder, both, past), and
+2. distinct from `positionName` (so we don't duplicate when the name already embeds a place).
+
+What we have now and why it's insufficient:
+
+| Field (current) | Problem for locality |
+| --- | --- |
+| `positionName` | Sometimes embeds locality ("Mayor of Springfield"), sometimes bare ("City Council Member"). Inconsistent, so we can't reliably split "position" vs "location". |
+| `normalizedPositionName` | Deliberately **generic** ("City Council") — locality intentionally stripped. Great for the title half, useless for the location half. |
+| `subAreaName` / `subAreaValue` | The district **within** the office ("Ward" / "3"), not a city/county. |
+| `state` | State only — no city/county. |
+| breadcrumb path segments | Clean city/county/state, but **only resolvable for candidate/"both"** (needs a Race slug). Pure officeholders get nothing. |
+
+So the app currently omits the "in [Location]" clause rather than inventing a wrong or
+duplicated one.
+
+## What we need
+
+A resolved **`place`** object on the two feeds the profile already reads, derived from the
+position's geography (the same Census/BallotReady geo you already expose via the places
+endpoints — `GET /v1/places?...`, `mtfcc` = `G4020` county / `G4110` place).
+
+Add `place` to:
+
+1. **`GET /v1/officeholders?personId=…&includePosition=true`** — each `OfficeHolder` (powers officeholder / both / past personas).
+2. **`GET /v1/officeholders?geoId=…`** — same object (powers the "Nearby Officials" list).
+3. The **candidacy → Race** payload returned for a person (powers candidate / both personas), i.e. alongside `Race.positionId` / `Race.slug`.
+
+### Contract
+
+```jsonc
+// Nullable object. null ONLY when the position's geo can't be resolved to a place.
+"place": {
+  "stateCode": "IL",            // 2-letter, always present when place is non-null
+  "stateName": "Illinois",      // full state name
+  "countyName": "Cook County",  // nullable (null for state-level offices)
+  "cityName": "Chicago",        // nullable (null for state/county-level offices)
+  "level": "city",              // "state" | "county" | "city" — the office's geo granularity
+  "displayName": "Chicago, IL"  // PRE-FORMATTED, nearest-granularity, ready to render as-is
+}
+```
+
+Requirements:
+
+- **Present for all personas.** The single hard requirement — resolve from the office's
+  geo, not from a Race slug, so officeholders and past officials get it too.
+- **`displayName` is authoritative and render-ready.** We render it verbatim. Format it as
+  the nearest meaningful granularity: city → `"{cityName}, {stateCode}"`, county →
+  `"{countyName}, {stateCode}"`, state → `"{stateName}"`. This matches the existing
+  `/elections` location pages (`src/ui/LocationLandingPageHero.tsx`).
+- **Additive & backward-compatible.** Do not rename or change the type of `positionName`,
+  `normalizedPositionName`, `subAreaName`, `subAreaValue`, or `state`. `place` is new and
+  nullable; omitting it (or sending `null`) leaves the app on today's behavior.
+
+## How the app will consume it (no action needed from you)
+
+Once `place` lands, the front-end change is a few lines in `src/lib/peopleProfile.ts` /
+`src/components/people/personSectionOverrides.tsx`:
+
+- **Section heading:** `Other Candidates for {normalizedPositionName} in {place.displayName}`
+  — using `normalizedPositionName` (title only) + `place.displayName` (location only) gives
+  the exact Figma split with **zero duplication risk**.
+- **Hero subheading:** append `place.displayName` so officeholder/past personas finally show
+  locality (candidates already do, via the location embedded in `positionName`).
+
+Until then the app safely falls back to the current `positionName`-only rendering.
+
+## Acceptance
+
+For a spread of offices across levels, `place.displayName` is non-null and correctly
+formatted:
+
+| Office level | Example office | Expected `place.displayName` |
+| --- | --- | --- |
+| City | Chicago City Council, Ward 3 | `Chicago, IL` |
+| County | Cook County Board | `Cook County, IL` |
+| State | State Senate District 5 | `Illinois` |
+
+And it resolves for an **officeholder fetched with no candidacy** (the case the app can't
+resolve today).

--- a/harness/config.mjs
+++ b/harness/config.mjs
@@ -12,6 +12,14 @@ export const DEV_ORIGIN = 'http://localhost:3009';
 // Re-export from Figma into this folder to refresh the source of truth.
 export const FIGMA_DIR = '/tmp/figma-shots';
 
+// Live Figma source of truth — "GoodParty — Marketing Design System". Each STATES
+// entry carries its `node` id; pull the live frame via the Figma MCP
+// (get_screenshot / get_design_context) with FIGMA_FILE_KEY + that node id.
+export const FIGMA_FILE_KEY = 'qIOT4lO1nRw4reuj6LjLwn';
+
+// The unclaimed-profile "claim" form overlay dialog (shared across unclaimed states).
+export const FIGMA_OVERLAY_NODE = '1901:51609';
+
 // Harness run artifacts (screenshots, diffs, reports) land here, one dir per run.
 export const OUT_ROOT = '/tmp/people-harness';
 
@@ -125,6 +133,7 @@ export const STATES = [
 		label: 'claimed-candidate',
 		slug: 'allen-slagle-74eee01a',
 		figma: 'A',
+		node: '1901:50309',
 		status: 'active',
 		masks: [],
 	},
@@ -133,6 +142,7 @@ export const STATES = [
 		label: 'claimed-officeholder',
 		slug: 'tracy-good-ecff49d3',
 		figma: 'B',
+		node: '1901:52117',
 		status: 'active',
 		masks: [],
 	},
@@ -141,6 +151,7 @@ export const STATES = [
 		label: 'claimed-both',
 		slug: 'susan-overman-ad914b82',
 		figma: 'C',
+		node: '1901:53123',
 		status: 'active',
 		masks: [],
 	},
@@ -149,6 +160,7 @@ export const STATES = [
 		label: 'unclaimed-indep-candidate',
 		slug: 'kim-byrd-b77f912d',
 		figma: 'D',
+		node: '1917:88035',
 		status: 'active',
 		masks: [],
 	},
@@ -157,6 +169,7 @@ export const STATES = [
 		label: 'unclaimed-indep-officeholder',
 		slug: 'rob-zotti-d8c578fb',
 		figma: 'E',
+		node: '1917:88616',
 		status: 'active',
 		masks: [],
 	},
@@ -165,6 +178,7 @@ export const STATES = [
 		label: 'unclaimed-indep-both',
 		slug: 'tim-ficken-0a951485',
 		figma: 'F',
+		node: '1917:89211',
 		status: 'active',
 		masks: [],
 	},
@@ -173,6 +187,7 @@ export const STATES = [
 		label: 'claimed-past',
 		slug: 'bill-fortner-61a42912',
 		figma: 'G',
+		node: '1958:110869',
 		status: 'active',
 		masks: [],
 	},
@@ -181,6 +196,7 @@ export const STATES = [
 		label: 'unclaimed-indep-past',
 		slug: 'gregory-schreurs-136cadf0',
 		figma: 'H',
+		node: '1970:113629',
 		status: 'active',
 		masks: [],
 	},
@@ -189,6 +205,7 @@ export const STATES = [
 		label: 'unclaimed-major-candidate',
 		slug: 'jeb-hanson-3753676b',
 		figma: 'I',
+		node: '1958:108636',
 		status: 'active',
 		masks: [],
 	},
@@ -197,6 +214,7 @@ export const STATES = [
 		label: 'unclaimed-major-officeholder',
 		slug: 'deb-craft-f88e7434',
 		figma: 'J',
+		node: '1958:109815',
 		status: 'active',
 		masks: [],
 	},
@@ -205,6 +223,7 @@ export const STATES = [
 		label: 'removal-running',
 		slug: 'x-27255f40',
 		figma: 'K',
+		node: '1997:118776',
 		status: 'active',
 		masks: [],
 	},
@@ -213,6 +232,7 @@ export const STATES = [
 		label: 'removal-officeholder',
 		slug: 'x-3412f69c',
 		figma: 'L',
+		node: '1997:118282',
 		status: 'active',
 		masks: [],
 	},

--- a/src/PageSections/CTABannerBlockSection.tsx
+++ b/src/PageSections/CTABannerBlockSection.tsx
@@ -40,6 +40,7 @@ export function CTABannerBlockSection(section: Props) {
 				button={ctaOverride?.button ?? transformButtons([section['primaryCTA']])?.[0]}
 				align={ctaOverride?.align}
 				preserveButtonStyle={ctaOverride?.preserveButtonStyle}
+				contentColumnAlign={ctaOverride?.contentColumnAlign}
 			/>
 		</section>
 	);

--- a/src/PageSections/ProfileContentBlockSection.tsx
+++ b/src/PageSections/ProfileContentBlockSection.tsx
@@ -89,8 +89,6 @@ type ProfileContentBlockSectionProps = Extract<Sections, { _type: 'component_pro
 	sidebarOverride?: ElectionsSidebarProps;
 	/** Optional district voter-density map rendered below the content. */
 	districtMap?: ReactNode;
-	/** People profiles: clear the smaller (320px) portrait instead of the 416px default. */
-	compactPortrait?: boolean;
 };
 
 export function ProfileContentBlockSection({
@@ -99,7 +97,6 @@ export function ProfileContentBlockSection({
 	contentCardsOverride,
 	sidebarOverride,
 	districtMap,
-	compactPortrait,
 	...section
 }: ProfileContentBlockSectionProps) {
 	const backgroundColor = section.profileContentBlockDesignSettings?.field_blockColorCreamMidnight
@@ -117,7 +114,7 @@ export function ProfileContentBlockSection({
 
 	return (
 		<section id={stegaClean(section.componentSettings?.field_anchorId)} data-section='Profile Content Block'>
-			<ProfileContentBlock backgroundColor={backgroundColor} sidebar={sidebar} contentCards={contentCards} compactPortrait={compactPortrait} />
+			<ProfileContentBlock backgroundColor={backgroundColor} sidebar={sidebar} contentCards={contentCards} />
 			{districtMap}
 		</section>
 	);

--- a/src/PageSections/ProfileContentBlockSection.tsx
+++ b/src/PageSections/ProfileContentBlockSection.tsx
@@ -89,6 +89,8 @@ type ProfileContentBlockSectionProps = Extract<Sections, { _type: 'component_pro
 	sidebarOverride?: ElectionsSidebarProps;
 	/** Optional district voter-density map rendered below the content. */
 	districtMap?: ReactNode;
+	/** People profiles: clear the smaller (320px) portrait instead of the 416px default. */
+	compactPortrait?: boolean;
 };
 
 export function ProfileContentBlockSection({
@@ -97,6 +99,7 @@ export function ProfileContentBlockSection({
 	contentCardsOverride,
 	sidebarOverride,
 	districtMap,
+	compactPortrait,
 	...section
 }: ProfileContentBlockSectionProps) {
 	const backgroundColor = section.profileContentBlockDesignSettings?.field_blockColorCreamMidnight
@@ -114,7 +117,7 @@ export function ProfileContentBlockSection({
 
 	return (
 		<section id={stegaClean(section.componentSettings?.field_anchorId)} data-section='Profile Content Block'>
-			<ProfileContentBlock backgroundColor={backgroundColor} sidebar={sidebar} contentCards={contentCards} />
+			<ProfileContentBlock backgroundColor={backgroundColor} sidebar={sidebar} contentCards={contentCards} compactPortrait={compactPortrait} />
 			{districtMap}
 		</section>
 	);

--- a/src/PageSections/ProfileContentBlockSection.tsx
+++ b/src/PageSections/ProfileContentBlockSection.tsx
@@ -87,6 +87,8 @@ type ProfileContentBlockSectionProps = Extract<Sections, { _type: 'component_pro
 	/** Prebuilt cards/sidebar (person profiles) — win over profileData/officeData. */
 	contentCardsOverride?: ProfileContentCardProps[];
 	sidebarOverride?: ElectionsSidebarProps;
+	/** Content-card layout: person profiles use `separated` (grouped white cards). */
+	cardLayout?: 'joined' | 'separated';
 	/** Optional district voter-density map rendered below the content. */
 	districtMap?: ReactNode;
 };
@@ -96,6 +98,7 @@ export function ProfileContentBlockSection({
 	officeData,
 	contentCardsOverride,
 	sidebarOverride,
+	cardLayout,
 	districtMap,
 	...section
 }: ProfileContentBlockSectionProps) {
@@ -114,7 +117,12 @@ export function ProfileContentBlockSection({
 
 	return (
 		<section id={stegaClean(section.componentSettings?.field_anchorId)} data-section='Profile Content Block'>
-			<ProfileContentBlock backgroundColor={backgroundColor} sidebar={sidebar} contentCards={contentCards} />
+			<ProfileContentBlock
+				backgroundColor={backgroundColor}
+				sidebar={sidebar}
+				contentCards={contentCards}
+				cardLayout={cardLayout}
+			/>
 			{districtMap}
 		</section>
 	);

--- a/src/PageSections/ProfileHeroSection.tsx
+++ b/src/PageSections/ProfileHeroSection.tsx
@@ -29,7 +29,6 @@ export function ProfileHeroSection({ profileHeroOverride, tokens: _tokens, ...se
 				officeHref={profileHeroOverride?.officeHref}
 				profileImageUrl={profileHeroOverride?.profileImageUrl}
 				isEmpowered={profileHeroOverride?.isEmpowered}
-				compactPortrait={profileHeroOverride?.compactPortrait}
 				tags={profileHeroOverride?.tags}
 				attribution={profileHeroOverride?.attribution}
 			/>

--- a/src/PageSections/ProfileHeroSection.tsx
+++ b/src/PageSections/ProfileHeroSection.tsx
@@ -26,11 +26,12 @@ export function ProfileHeroSection({ profileHeroOverride, tokens: _tokens, ...se
 				backgroundColor={backgroundColor}
 				candidateName={candidateName}
 				office={office}
+				officeHref={profileHeroOverride?.officeHref}
 				profileImageUrl={profileHeroOverride?.profileImageUrl}
 				isEmpowered={profileHeroOverride?.isEmpowered}
+				compactPortrait={profileHeroOverride?.compactPortrait}
 				tags={profileHeroOverride?.tags}
 				attribution={profileHeroOverride?.attribution}
-				pledged={profileHeroOverride?.pledged}
 			/>
 		</section>
 	);

--- a/src/PageSections/index.tsx
+++ b/src/PageSections/index.tsx
@@ -107,10 +107,12 @@ export type SectionOverrides = {
 	component_profileHero?: {
 		candidateName: string;
 		office: string;
+		/** When set, the hero office line links to the office/position page. */
+		officeHref?: string;
 		profileImageUrl?: string;
 		isEmpowered?: boolean;
-		/** Person profiles: renders a "Took the GoodParty.org Pledge" badge under the hero. */
-		pledged?: boolean;
+		/** Person profiles: smaller (320px) desktop portrait so the sidebar clears the fold. */
+		compactPortrait?: boolean;
 		/** Persona tag pills shown above the name (e.g. "Candidate", "Incumbent"). */
 		tags?: string[];
 		/**
@@ -161,6 +163,8 @@ export type SectionOverrides = {
 		 * here. Retained for any non-person caller still rendering it inline.
 		 */
 		districtMap?: import('react').ReactNode;
+		/** People profiles: clear the smaller (320px) portrait instead of the 416px default. */
+		compactPortrait?: boolean;
 		/** When true the section renders nothing (used to gate empty/removed states). */
 		hidden?: boolean;
 	};
@@ -540,6 +544,7 @@ export function PageSections(props: Props) {
 									contentCardsOverride={pcbOverride?.contentCards}
 									sidebarOverride={pcbOverride?.sidebar}
 									districtMap={pcbOverride?.districtMap}
+									compactPortrait={pcbOverride?.compactPortrait}
 								/>
 							</Boundary>
 						);

--- a/src/PageSections/index.tsx
+++ b/src/PageSections/index.tsx
@@ -135,6 +135,8 @@ export type SectionOverrides = {
 		button?: import('~/ui/Inputs/Button').ComponentButtonProps;
 		/** Render the button's styleType as-is (skip the card-color inverse mapping). */
 		preserveButtonStyle?: boolean;
+		/** Align inner content with the profile content-card column (person profiles). */
+		contentColumnAlign?: boolean;
 		/**
 		 * Full replacement node rendered in the CTA slot instead of the CMS banner.
 		 * Used by unclaimed person profiles to render the interactive claim CTA band

--- a/src/PageSections/index.tsx
+++ b/src/PageSections/index.tsx
@@ -155,6 +155,8 @@ export type SectionOverrides = {
 		 */
 		contentCards?: import('~/ui/ProfileContentCard').ProfileContentCardProps[];
 		sidebar?: import('~/ui/ElectionsSidebar').ElectionsSidebarProps;
+		/** Content-card layout ('separated' groups cards into Figma's white cards). */
+		cardLayout?: 'joined' | 'separated';
 		/**
 		 * @deprecated The district voter-density map is now its own
 		 * `component_voterDensityBlock` section; person profiles no longer inject it
@@ -539,6 +541,7 @@ export function PageSections(props: Props) {
 									officeData={pcbOverride?.officeData}
 									contentCardsOverride={pcbOverride?.contentCards}
 									sidebarOverride={pcbOverride?.sidebar}
+									cardLayout={pcbOverride?.cardLayout}
 									districtMap={pcbOverride?.districtMap}
 								/>
 							</Boundary>

--- a/src/PageSections/index.tsx
+++ b/src/PageSections/index.tsx
@@ -111,8 +111,6 @@ export type SectionOverrides = {
 		officeHref?: string;
 		profileImageUrl?: string;
 		isEmpowered?: boolean;
-		/** Person profiles: smaller (320px) desktop portrait so the sidebar clears the fold. */
-		compactPortrait?: boolean;
 		/** Persona tag pills shown above the name (e.g. "Candidate", "Incumbent"). */
 		tags?: string[];
 		/**
@@ -163,8 +161,6 @@ export type SectionOverrides = {
 		 * here. Retained for any non-person caller still rendering it inline.
 		 */
 		districtMap?: import('react').ReactNode;
-		/** People profiles: clear the smaller (320px) portrait instead of the 416px default. */
-		compactPortrait?: boolean;
 		/** When true the section renders nothing (used to gate empty/removed states). */
 		hidden?: boolean;
 	};
@@ -544,7 +540,6 @@ export function PageSections(props: Props) {
 									contentCardsOverride={pcbOverride?.contentCards}
 									sidebarOverride={pcbOverride?.sidebar}
 									districtMap={pcbOverride?.districtMap}
-									compactPortrait={pcbOverride?.compactPortrait}
 								/>
 							</Boundary>
 						);

--- a/src/app/api/people/claim-request/route.ts
+++ b/src/app/api/people/claim-request/route.ts
@@ -10,7 +10,7 @@ const GP_API_BASE =
 const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const PERSON_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
-type ClaimBody = { personId?: string; email?: string; firstname?: string };
+type ClaimBody = { personId?: string; email?: string; firstname?: string; marketingConsent?: boolean };
 
 /**
  * POST /api/people/claim-request
@@ -26,7 +26,7 @@ export async function POST(request: NextRequest) {
 		return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
 	}
 
-	const { personId, email, firstname } = body;
+	const { personId, email, firstname, marketingConsent } = body;
 
 	if (!personId || !PERSON_ID_PATTERN.test(personId)) {
 		return NextResponse.json({ error: 'Invalid personId' }, { status: 400 });
@@ -45,6 +45,7 @@ export async function POST(request: NextRequest) {
 				personId,
 				requesterEmail: email,
 				...(firstname ? { requesterName: firstname } : {}),
+				marketingConsent: marketingConsent ?? false,
 			}),
 		});
 		if (!res.ok) {

--- a/src/components/people/ClaimProfileModal.tsx
+++ b/src/components/people/ClaimProfileModal.tsx
@@ -13,7 +13,7 @@ import { Text } from '~/ui/Text';
 
 const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
-type NotifyValues = { firstname: string; email: string };
+type NotifyValues = { firstname: string; email: string; marketingConsent: boolean };
 
 function NotifyForm({ personId, displayName }: { personId: string; displayName: string }) {
 	const [isSuccess, setIsSuccess] = useState(false);
@@ -22,14 +22,19 @@ function NotifyForm({ personId, displayName }: { personId: string; displayName: 
 		handleSubmit,
 		setError,
 		formState: { errors, isSubmitting },
-	} = useForm<NotifyValues>({ defaultValues: { firstname: '', email: '' } });
+	} = useForm<NotifyValues>({ defaultValues: { firstname: '', email: '', marketingConsent: true } });
 
 	async function onSubmit(values: NotifyValues) {
 		try {
 			const res = await fetch('/api/people/claim-request', {
 				method: 'POST',
 				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify({ personId, firstname: values.firstname, email: values.email }),
+				body: JSON.stringify({
+					personId,
+					firstname: values.firstname,
+					email: values.email,
+					marketingConsent: values.marketingConsent,
+				}),
 			});
 			if (!res.ok) throw new Error('Submission failed');
 			trackEvent('Person Profile Notify Submitted', { personId });
@@ -77,6 +82,27 @@ function NotifyForm({ personId, displayName }: { personId: string; displayName: 
 					pattern: { value: EMAIL_PATTERN, message: 'Enter a valid email address' },
 				})}
 			/>
+			<label htmlFor='notify-marketing-consent' className='flex items-start gap-2.5'>
+				<input
+					id='notify-marketing-consent'
+					type='checkbox'
+					className='mt-0.5 h-5 w-5 shrink-0 rounded border-neutral-300 text-btn-primary-bg accent-btn-primary-bg focus:outline-none focus-visible:ring-2 focus-visible:ring-btn-primary-bg/30'
+					{...register('marketingConsent')}
+				/>
+				<Text as='span' styleType='body-2'>
+					Sign up for marketing communications from{' '}
+					<a
+						href='https://goodparty.org'
+						target='_blank'
+						rel='noopener noreferrer'
+						className='underline'
+						onClick={(e) => e.stopPropagation()}
+					>
+						GoodParty.org
+					</a>
+					. Unsubscribe at any time.
+				</Text>
+			</label>
 			{errors.root?.message && (
 				<Text styleType='caption' className='text-error-600' role='alert'>
 					{errors.root.message}

--- a/src/components/people/personSectionOverrides.tsx
+++ b/src/components/people/personSectionOverrides.tsx
@@ -411,7 +411,7 @@ function buildCivicCards(view: PersonProfileView): ProfileContentCardProps[] {
 	}
 	// Nearby officials serving the same constituency — only for personas actually
 	// in (or formerly in) office, per Figma (candidate-only pages omit this).
-	const nearby = holdsOffice(view.persona) ? toCandidateCards(view.nearbyOfficials) : [];
+	const nearby = holdsOffice(view.persona) ? empoweredFirst(toCandidateCards(view.nearbyOfficials)) : [];
 	if (nearby.length > 0) {
 		cards.push({ group: 'people', heading: 'Nearby Officials', content: <OtherCandidatesContent cards={nearby} /> });
 	}

--- a/src/components/people/personSectionOverrides.tsx
+++ b/src/components/people/personSectionOverrides.tsx
@@ -247,18 +247,18 @@ function buildAuthoredCards(view: PersonProfileView): ProfileContentCardProps[] 
 	// "Why I'm Running for Office" is candidate-only (Figma A); officeholder/past
 	// frames drop the section entirely.
 	if (view.whyRunning && (view.persona === 'candidate' || view.persona === 'both')) {
-		cards.push({ cardType: 'why-running', heading: whyHeading(view.persona), content: view.whyRunning });
+		cards.push({ cardType: 'why-running', group: 'platform', heading: whyHeading(view.persona), content: view.whyRunning });
 	}
 	if (view.issues.length > 0) {
-		cards.push({ cardType: 'top-issues', heading: issuesHeading(view.persona), content: <IssuesContent issues={view.issues} showStatus={holdsOffice(view.persona)} /> });
+		cards.push({ cardType: 'top-issues', group: 'platform', heading: issuesHeading(view.persona), content: <IssuesContent issues={view.issues} showStatus={holdsOffice(view.persona)} /> });
 	}
 	if (view.bio) {
-		cards.push({ cardType: 'about-me', heading: 'About Me', content: view.bio });
+		cards.push({ cardType: 'about-me', group: 'about', heading: 'About Me', content: view.bio });
 	}
 	// Accomplishments are an in-office record — only personas who hold/held office
 	// show them. A pure candidate (Figma A) has none, so gate the section.
 	if (view.accomplishments.length > 0 && holdsOffice(view.persona)) {
-		cards.push({ heading: 'Accomplishments', content: <AccomplishmentsContent accomplishments={view.accomplishments} /> });
+		cards.push({ group: 'about', heading: 'Accomplishments', content: <AccomplishmentsContent accomplishments={view.accomplishments} /> });
 	}
 	return cards;
 }
@@ -323,10 +323,10 @@ function buildAuthoredPlaceholderCards(view: PersonProfileView): ProfileContentC
 	const cards: ProfileContentCardProps[] = [];
 	// Mirror the claimed gating: the "Why" prompt is candidate-only.
 	if (view.persona === 'candidate' || view.persona === 'both') {
-		cards.push({ cardType: 'why-running', heading: whyHeading(view.persona), content: <PlaceholderPrompt>{whyPrompt(view)}</PlaceholderPrompt> });
+		cards.push({ cardType: 'why-running', group: 'platform', heading: whyHeading(view.persona), content: <PlaceholderPrompt>{whyPrompt(view)}</PlaceholderPrompt> });
 	}
-	cards.push({ cardType: 'top-issues', heading: issuesHeading(view.persona), content: <PlaceholderPrompt>{issuesPrompt(view)}</PlaceholderPrompt> });
-	cards.push({ cardType: 'about-me', heading: 'About Me', content: <PlaceholderPrompt>{aboutPrompt(view)}</PlaceholderPrompt> });
+	cards.push({ cardType: 'top-issues', group: 'platform', heading: issuesHeading(view.persona), content: <PlaceholderPrompt>{issuesPrompt(view)}</PlaceholderPrompt> });
+	cards.push({ cardType: 'about-me', group: 'about', heading: 'About Me', content: <PlaceholderPrompt>{aboutPrompt(view)}</PlaceholderPrompt> });
 	return cards;
 }
 
@@ -387,7 +387,7 @@ function OtherCandidatesContent({ cards }: { cards: CandidateCard[] }): ReactNod
 function buildCivicCards(view: PersonProfileView): ProfileContentCardProps[] {
 	const cards: ProfileContentCardProps[] = [];
 	if (view.recentExperience.length > 0) {
-		cards.push({ heading: 'Recent Experience', content: <ExperienceContent experience={view.recentExperience} /> });
+		cards.push({ group: 'about', heading: 'Recent Experience', content: <ExperienceContent experience={view.recentExperience} /> });
 	}
 	// Figma title-cases this heading and leads with the empowered (GoodParty)
 	// candidate. FLAG: the frame reads "Other Candidates for [Position] in
@@ -396,6 +396,7 @@ function buildCivicCards(view: PersonProfileView): ProfileContentCardProps[] {
 	const otherCandidates = empoweredFirst(toCandidateCards(view.otherCandidates));
 	if (otherCandidates.length > 0) {
 		cards.push({
+			group: 'people',
 			heading: view.officeName ? `Other Candidates for ${view.officeName}` : 'Other Candidates',
 			content: <OtherCandidatesContent cards={otherCandidates} />,
 		});
@@ -404,17 +405,18 @@ function buildCivicCards(view: PersonProfileView): ProfileContentCardProps[] {
 	// in (or formerly in) office, per Figma (candidate-only pages omit this).
 	const nearby = holdsOffice(view.persona) ? toCandidateCards(view.nearbyOfficials) : [];
 	if (nearby.length > 0) {
-		cards.push({ heading: 'Nearby Officials', content: <OtherCandidatesContent cards={nearby} /> });
+		cards.push({ group: 'people', heading: 'Nearby Officials', content: <OtherCandidatesContent cards={nearby} /> });
 	}
 	if (view.positionDescription || view.termLabel || view.electionDate) {
 		cards.push({
+			group: 'position',
 			heading: `About ${view.officeName ?? 'the Role'}`,
 			content: <AboutPositionContent view={view} />,
 		});
 	}
 	const districtMap = buildDistrictMap(view);
 	if (districtMap) {
-		cards.push({ heading: 'District information', content: districtMap });
+		cards.push({ group: 'district', heading: 'District information', content: districtMap });
 	}
 	return cards;
 }
@@ -621,6 +623,9 @@ export function buildPersonSectionOverrides(view: PersonProfileView): SectionOve
 		component_profileContentBlock: {
 			contentCards,
 			sidebar,
+			// Figma people profiles group sections into separate white cards with
+			// cream gaps (not one joined box like /candidate).
+			cardLayout: 'separated',
 			hidden: contentCards.length === 0 && !sidebar,
 		},
 		component_goodPartyOrgPledge: { hidden: !showPledge },

--- a/src/components/people/personSectionOverrides.tsx
+++ b/src/components/people/personSectionOverrides.tsx
@@ -306,6 +306,27 @@ function buildAuthoredPlaceholderCards(view: PersonProfileView): ProfileContentC
 	];
 }
 
+/**
+ * Past-election disclaimer shown at the top of the content well for persona
+ * `past` (Figma states G claimed + H unclaimed). FLAG: the exact Figma copy for
+ * the G frame could not be pulled (the profile frames are no longer in the
+ * accessible Figma file and H is a known mislabeled clone — see FOLLOWUPS.md), so
+ * this uses a clear placeholder pending design confirmation.
+ */
+function pastElectionDisclaimer(view: PersonProfileView): ProfileContentCardProps {
+	return {
+		raw: true,
+		content: (
+			<div className='flex items-start gap-3 rounded-xl border border-blue-200 bg-blue-50 p-4 text-midnight-900'>
+				<IconResolver icon='info' className='mt-0.5 h-5 w-5 flex-shrink-0 text-btn-primary-bg' />
+				<Text styleType='body-2'>
+					{`This profile reflects a past election. ${view.displayName} is no longer running for or serving in this office.`}
+				</Text>
+			</div>
+		),
+	};
+}
+
 /** In-column "Other candidates" list — a vertical stack of candidate cards. */
 function OtherCandidatesContent({ cards }: { cards: CandidateCard[] }): ReactNode {
 	return (
@@ -454,7 +475,9 @@ function buildDistrictMap(view: PersonProfileView): ReactNode | undefined {
  * so the same behaviour holds regardless of the (editor-authored) template.
  */
 export function buildPersonSectionOverrides(view: PersonProfileView): SectionOverrides {
-	const showClaim = view.empowered && !view.claimed;
+	// Past-election profiles (G claimed, H unclaimed) lead with the past-election
+	// disclaimer, NOT the claim CTA — so exclude persona 'past' from the claim gate.
+	const showClaim = view.empowered && !view.claimed && view.persona !== 'past';
 	// The pledge explainer is claimed content across every persona (Figma A/B/C/G
 	// all show it once claimed). Unclaimed empowered pages lead with the claim
 	// prompt instead, so it stays hidden there.
@@ -520,6 +543,7 @@ export function buildPersonSectionOverrides(view: PersonProfileView): SectionOve
 			? buildAuthoredPlaceholderCards(view)
 			: [];
 	const contentCards: ProfileContentCardProps[] = [
+		...(view.persona === 'past' ? [pastElectionDisclaimer(view)] : []),
 		...(showClaim ? [claimCard('voter-card')] : []),
 		...authoredCards,
 		...buildCivicCards(view),
@@ -535,13 +559,17 @@ export function buildPersonSectionOverrides(view: PersonProfileView): SectionOve
 		component_profileHero: {
 			candidateName: view.displayName,
 			office: view.roleTitle ?? '',
+			// The full positionName (incl. locality) links to the office/position page.
+			officeHref: view.positionHref ?? undefined,
 			profileImageUrl: view.avatarUrl ?? undefined,
 			isEmpowered: view.empowered,
-			pledged: view.pledged,
+			compactPortrait: true,
 			tags: personaTags(view.persona),
-			// Empowered pages carry the GoodParty attribution; major-party (I/J) and
-			// removed (K/L) pages show the neutral "Not Endorsed" line instead.
-			attribution: view.empowered ? 'empowered' : 'notEndorsed',
+			// The GoodParty attribution line + on-photo logo gate on CLAIMED (endorsed):
+			// only claimed pages (A/B/C/G) show "Empowered by GoodParty.org" with the
+			// logo. Every unclaimed page — independent (D/E/F/H), major-party (I/J), and
+			// removed (K/L) — shows the neutral "Not Endorsed by GoodParty.org" line.
+			attribution: view.claimed ? 'empowered' : 'notEndorsed',
 		},
 		component_claimProfileBlock: {
 			// The standalone full-width claim banner is always suppressed now: the
@@ -552,6 +580,7 @@ export function buildPersonSectionOverrides(view: PersonProfileView): SectionOve
 		component_profileContentBlock: {
 			contentCards,
 			sidebar,
+			compactPortrait: true,
 			hidden: contentCards.length === 0 && !sidebar,
 		},
 		component_goodPartyOrgPledge: { hidden: !showPledge },

--- a/src/components/people/personSectionOverrides.tsx
+++ b/src/components/people/personSectionOverrides.tsx
@@ -23,6 +23,14 @@ import { PersonClaimCTABand } from './PersonClaimCTABand';
 // meta row; in that case we fall back to "render if there are cells at all".
 const MIN_VOTER_DENSITY_COVERAGE = 0.5;
 
+// Pre-footer "Explore elections near you" body copy, keyed by the index tier so
+// the prompt matches the level the list drills into (verbatim from the frames).
+const ELECTIONS_INDEX_COPY: Record<'state' | 'county' | 'city', string> = {
+	state: 'Select your state to see local offices, candidates, and elected officials.',
+	county: 'Select your county to see local offices, candidates, and elected officials.',
+	city: 'Select your city to see local offices, candidates, and elected officials.',
+};
+
 // Only candidate/both personas render the "Why" card (Figma frame A heading is
 // "Why I'm Running for Office"). Officeholder/past frames drop it, so those cases
 // are never reached — they exist only to keep the switch exhaustive.
@@ -636,7 +644,7 @@ export function buildPersonSectionOverrides(view: PersonProfileView): SectionOve
 			header: view.electionsIndex
 				? {
 						title: 'Explore elections near you',
-						copy: 'Find candidates and offices on the ballot near you.',
+						copy: ELECTIONS_INDEX_COPY[view.electionsIndex.entryLevel],
 					}
 				: undefined,
 		},

--- a/src/components/people/personSectionOverrides.tsx
+++ b/src/components/people/personSectionOverrides.tsx
@@ -23,16 +23,33 @@ import { PersonClaimCTABand } from './PersonClaimCTABand';
 // meta row; in that case we fall back to "render if there are cells at all".
 const MIN_VOTER_DENSITY_COVERAGE = 0.5;
 
+// Only candidate/both personas render the "Why" card (Figma frame A heading is
+// "Why I'm Running for Office"). Officeholder/past frames drop it, so those cases
+// are never reached — they exist only to keep the switch exhaustive.
 function whyHeading(persona: PersonPersona): string {
 	switch (persona) {
 		case 'candidate':
 		case 'both':
-			return 'Why I\u2019m Running';
+			return 'Why I\u2019m Running for Office';
 		case 'officeholder':
 			return 'Why I Serve';
 		case 'past':
 			return 'Why I Served';
 	}
+}
+
+/** Personas that actually hold (or held) office — the only ones that show issue
+ * progress tags. A pure candidate has no in-office record, so frame A omits them. */
+function holdsOffice(persona: PersonPersona): boolean {
+	return persona === 'officeholder' || persona === 'both' || persona === 'past';
+}
+
+/** Stable empowered-first ordering (Figma puts the GoodParty candidate on top). */
+function empoweredFirst(cards: CandidateCard[]): CandidateCard[] {
+	return [
+		...cards.filter(c => c.isGoodPartyCandidate),
+		...cards.filter(c => !c.isGoodPartyCandidate),
+	];
 }
 
 /** Small persona tag pill(s) rendered above the hero name (Figma). */
@@ -81,7 +98,7 @@ function TypeTag({ label }: { label: string }) {
 	);
 }
 
-function IssuesContent({ issues }: { issues: PersonProfileView['issues'] }): ReactNode {
+function IssuesContent({ issues, showStatus }: { issues: PersonProfileView['issues']; showStatus: boolean }): ReactNode {
 	return (
 		<ol className='flex flex-col gap-6'>
 			{issues.map((issue, index) => (
@@ -99,7 +116,7 @@ function IssuesContent({ issues }: { issues: PersonProfileView['issues'] }): Rea
 							<Text styleType='body-2'>{issue.description}</Text>
 						</div>
 					)}
-					{issue.status && (
+					{showStatus && issue.status && (
 						<div className='pl-7'>
 							<TypeTag label={STATUS_LABELS[issue.status]} />
 						</div>
@@ -227,16 +244,20 @@ function AboutPositionContent({ view }: { view: PersonProfileView }): ReactNode 
  */
 function buildAuthoredCards(view: PersonProfileView): ProfileContentCardProps[] {
 	const cards: ProfileContentCardProps[] = [];
-	if (view.whyRunning) {
+	// "Why I'm Running for Office" is candidate-only (Figma A); officeholder/past
+	// frames drop the section entirely.
+	if (view.whyRunning && (view.persona === 'candidate' || view.persona === 'both')) {
 		cards.push({ cardType: 'why-running', heading: whyHeading(view.persona), content: view.whyRunning });
 	}
 	if (view.issues.length > 0) {
-		cards.push({ cardType: 'top-issues', heading: issuesHeading(view.persona), content: <IssuesContent issues={view.issues} /> });
+		cards.push({ cardType: 'top-issues', heading: issuesHeading(view.persona), content: <IssuesContent issues={view.issues} showStatus={holdsOffice(view.persona)} /> });
 	}
 	if (view.bio) {
 		cards.push({ cardType: 'about-me', heading: 'About Me', content: view.bio });
 	}
-	if (view.accomplishments.length > 0) {
+	// Accomplishments are an in-office record — only personas who hold/held office
+	// show them. A pure candidate (Figma A) has none, so gate the section.
+	if (view.accomplishments.length > 0 && holdsOffice(view.persona)) {
 		cards.push({ heading: 'Accomplishments', content: <AccomplishmentsContent accomplishments={view.accomplishments} /> });
 	}
 	return cards;
@@ -299,11 +320,14 @@ function aboutPrompt(view: PersonProfileView): string {
  * does not show a placeholder for it).
  */
 function buildAuthoredPlaceholderCards(view: PersonProfileView): ProfileContentCardProps[] {
-	return [
-		{ cardType: 'why-running', heading: whyHeading(view.persona), content: <PlaceholderPrompt>{whyPrompt(view)}</PlaceholderPrompt> },
-		{ cardType: 'top-issues', heading: issuesHeading(view.persona), content: <PlaceholderPrompt>{issuesPrompt(view)}</PlaceholderPrompt> },
-		{ cardType: 'about-me', heading: 'About Me', content: <PlaceholderPrompt>{aboutPrompt(view)}</PlaceholderPrompt> },
-	];
+	const cards: ProfileContentCardProps[] = [];
+	// Mirror the claimed gating: the "Why" prompt is candidate-only.
+	if (view.persona === 'candidate' || view.persona === 'both') {
+		cards.push({ cardType: 'why-running', heading: whyHeading(view.persona), content: <PlaceholderPrompt>{whyPrompt(view)}</PlaceholderPrompt> });
+	}
+	cards.push({ cardType: 'top-issues', heading: issuesHeading(view.persona), content: <PlaceholderPrompt>{issuesPrompt(view)}</PlaceholderPrompt> });
+	cards.push({ cardType: 'about-me', heading: 'About Me', content: <PlaceholderPrompt>{aboutPrompt(view)}</PlaceholderPrompt> });
+	return cards;
 }
 
 /** First 4-digit year in an ISO-ish date string (avoids TZ off-by-one). */
@@ -365,17 +389,20 @@ function buildCivicCards(view: PersonProfileView): ProfileContentCardProps[] {
 	if (view.recentExperience.length > 0) {
 		cards.push({ heading: 'Recent Experience', content: <ExperienceContent experience={view.recentExperience} /> });
 	}
-	const otherCandidates = toCandidateCards(view.otherCandidates);
+	// Figma title-cases this heading and leads with the empowered (GoodParty)
+	// candidate. FLAG: the frame reads "Other Candidates for [Position] in
+	// <Location>" but the view has no clean locality field distinct from the
+	// position name, so the "in <Location>" clause is omitted rather than invented.
+	const otherCandidates = empoweredFirst(toCandidateCards(view.otherCandidates));
 	if (otherCandidates.length > 0) {
 		cards.push({
-			heading: view.officeName ? `Other candidates for ${view.officeName}` : 'Other candidates',
+			heading: view.officeName ? `Other Candidates for ${view.officeName}` : 'Other Candidates',
 			content: <OtherCandidatesContent cards={otherCandidates} />,
 		});
 	}
 	// Nearby officials serving the same constituency — only for personas actually
 	// in (or formerly in) office, per Figma (candidate-only pages omit this).
-	const holdsOffice = view.persona === 'officeholder' || view.persona === 'both' || view.persona === 'past';
-	const nearby = holdsOffice ? toCandidateCards(view.nearbyOfficials) : [];
+	const nearby = holdsOffice(view.persona) ? toCandidateCards(view.nearbyOfficials) : [];
 	if (nearby.length > 0) {
 		cards.push({ heading: 'Nearby Officials', content: <OtherCandidatesContent cards={nearby} /> });
 	}

--- a/src/components/people/personSectionOverrides.tsx
+++ b/src/components/people/personSectionOverrides.tsx
@@ -476,6 +476,10 @@ export function buildPersonSectionOverrides(view: PersonProfileView): SectionOve
 				// `outline` button.
 				button: { buttonType: 'signup', label: 'Learn more', buttonProps: { styleType: 'secondary', styleSize: 'md' } },
 				preserveButtonStyle: true,
+				// The CTA sits below the asymmetric sidebar + cards layout; align its
+				// centered content with the content-card column above (not the page
+				// middle) so it reads as continuous with the last card.
+				contentColumnAlign: true,
 			}
 		: showClaim
 			? {

--- a/src/components/people/personSectionOverrides.tsx
+++ b/src/components/people/personSectionOverrides.tsx
@@ -306,22 +306,37 @@ function buildAuthoredPlaceholderCards(view: PersonProfileView): ProfileContentC
 	];
 }
 
+/** First 4-digit year in an ISO-ish date string (avoids TZ off-by-one). */
+function electionYear(electionDate: string | null): string | null {
+	return electionDate?.match(/\d{4}/)?.[0] ?? null;
+}
+
 /**
  * Past-election disclaimer shown at the top of the content well for persona
- * `past` (Figma states G claimed + H unclaimed). FLAG: the exact Figma copy for
- * the G frame could not be pulled (the profile frames are no longer in the
- * accessible Figma file and H is a known mislabeled clone — see FOLLOWUPS.md), so
- * this uses a clear placeholder pending design confirmation.
+ * `past` (Figma states G 1958:113149 + H 1970:113742). It reuses the Figma "CTA
+ * Section Module" treatment — a light-blue (blue-100) card with centered copy and
+ * a dark "Start exploring" button — and carries the frames' verbatim copy.
  */
 function pastElectionDisclaimer(view: PersonProfileView): ProfileContentCardProps {
+	const year = electionYear(view.electionDate);
+	const ranClause = year ? `last ran for office in ${year}` : 'last ran for office';
 	return {
 		raw: true,
 		content: (
-			<div className='flex items-start gap-3 rounded-xl border border-blue-200 bg-blue-50 p-4 text-midnight-900'>
-				<IconResolver icon='info' className='mt-0.5 h-5 w-5 flex-shrink-0 text-btn-primary-bg' />
-				<Text styleType='body-2'>
-					{`This profile reflects a past election. ${view.displayName} is no longer running for or serving in this office.`}
+			<div className='flex flex-col items-center gap-6 rounded-2xl bg-blue-100 px-6 py-10 text-center text-midnight-900 md:px-12'>
+				<Text styleType='body-1' className='mx-auto max-w-xl'>
+					{`According to our records, ${view.displayName} ${ranClause}. Please see our updated voter guide for information about upcoming elections, candidates, and current elected officials.`}
 				</Text>
+				<ButtonLink
+					parent='PersonProfilePastElectionDisclaimer'
+					href='/elections'
+					styleType='secondary'
+					styleSize='md'
+					className='w-fit'
+					iconRight={<IconResolver icon='arrow-up-right' className='h-4 w-4' />}
+				>
+					Start exploring
+				</ButtonLink>
 			</div>
 		),
 	};
@@ -563,7 +578,6 @@ export function buildPersonSectionOverrides(view: PersonProfileView): SectionOve
 			officeHref: view.positionHref ?? undefined,
 			profileImageUrl: view.avatarUrl ?? undefined,
 			isEmpowered: view.empowered,
-			compactPortrait: true,
 			tags: personaTags(view.persona),
 			// The GoodParty attribution line + on-photo logo gate on CLAIMED (endorsed):
 			// only claimed pages (A/B/C/G) show "Empowered by GoodParty.org" with the
@@ -580,7 +594,6 @@ export function buildPersonSectionOverrides(view: PersonProfileView): SectionOve
 		component_profileContentBlock: {
 			contentCards,
 			sidebar,
-			compactPortrait: true,
 			hidden: contentCards.length === 0 && !sidebar,
 		},
 		component_goodPartyOrgPledge: { hidden: !showPledge },

--- a/src/lib/devPeopleProfileFixtures.ts
+++ b/src/lib/devPeopleProfileFixtures.ts
@@ -50,16 +50,21 @@ function personIdFromSuffix(suffix: string): string {
 const LOREM =
 	'Focused on transparent, accountable local government that puts residents first. Building coalitions across the community to deliver practical results on the issues families care about most.';
 
-function richOverlay(name: string): Partial<PublicPersonProfile> {
+function richOverlay(name: string, holdsOffice: boolean): Partial<PublicPersonProfile> {
 	return {
 		displayName: name,
 		bioOverride: `${name} is a lifelong resident and community advocate. ${LOREM}`,
 		whyRunning: `I'm running because our community deserves leadership that listens. ${LOREM}`,
-		accomplishments: [
-			{ title: 'Balanced the district budget without raising taxes', date: '2024' },
-			{ title: 'Expanded after-school programs to every neighborhood school', date: '2023' },
-			{ title: 'Launched a small-business recovery grant program', date: '2022' },
-		],
+		// Accomplishments describe time IN office, so they're seeded only for
+		// office-holding personas (officeholder/both/past) — a pure candidate
+		// (State A) has none, matching the Figma candidate frames.
+		accomplishments: holdsOffice
+			? [
+					{ title: 'Balanced the district budget without raising taxes', date: '2024' },
+					{ title: 'Expanded after-school programs to every neighborhood school', date: '2023' },
+					{ title: 'Launched a small-business recovery grant program', date: '2022' },
+				]
+			: null,
 		publicEmail: 'contact@example.org',
 		publicPhone: '(307) 555-0142',
 		websiteUrl: 'https://example.org',
@@ -178,14 +183,15 @@ export function getDevPersonProfileView(slug: string): PersonProfileView | null 
 		})),
 	};
 
-	const overlay: PublicPersonProfile | null =
-		fixture.overlay.status === 'live'
-			? { ...fixture.overlay.profile, personId, ...richOverlay(name), avatarUrl: headshotUrl }
-			: null;
-	const removed = fixture.overlay.status === 'removed';
-
 	const persona: PersonPersona = fixture.expected.persona;
 	const running = persona === 'candidate' || persona === 'both';
+	const holdsOffice = persona === 'officeholder' || persona === 'both' || persona === 'past';
+
+	const overlay: PublicPersonProfile | null =
+		fixture.overlay.status === 'live'
+			? { ...fixture.overlay.profile, personId, ...richOverlay(name, holdsOffice), avatarUrl: headshotUrl }
+			: null;
+	const removed = fixture.overlay.status === 'removed';
 
 	const view = composeView(personId, person, overlay, {
 		removed,

--- a/src/lib/devPeopleProfileFixtures.ts
+++ b/src/lib/devPeopleProfileFixtures.ts
@@ -144,6 +144,7 @@ function richElectionsIndex() {
 	return {
 		stateSlug: 'wy',
 		stateName: 'Wyoming',
+		entryLevel: 'county' as const,
 		entries: counties.map((c) => ({ name: `${c} County`, href: `/elections/${c.toLowerCase().replace(/ /g, '-')}-county`, level: 'county' as const })),
 	};
 }

--- a/src/lib/peopleProfile.test.ts
+++ b/src/lib/peopleProfile.test.ts
@@ -473,7 +473,7 @@ describe('composeView state + empowerment gating', () => {
 });
 
 describe('buildBreadcrumb', () => {
-	test('degrades to Home > People > Name without a race slug', async () => {
+	test('degrades to Elections > State > Name without a race slug', async () => {
 		const trail = await buildBreadcrumb({
 			displayName: 'Jane Doe',
 			stateCode: 'CA',
@@ -481,7 +481,19 @@ describe('buildBreadcrumb', () => {
 			positionLevel: null,
 			positionName: null,
 		});
-		expect(trail.map((c) => c.label)).toEqual(['Home', 'People', 'Jane Doe']);
+		expect(trail.map((c) => c.label)).toEqual(['Elections', 'California', 'Jane Doe']);
+		expect(trail[0]?.href).toBe('/elections');
+	});
+
+	test('degrades to Elections > Name when neither race slug nor state is known', async () => {
+		const trail = await buildBreadcrumb({
+			displayName: 'Jane Doe',
+			stateCode: null,
+			raceSlug: null,
+			positionLevel: null,
+			positionName: null,
+		});
+		expect(trail.map((c) => c.label)).toEqual(['Elections', 'Jane Doe']);
 	});
 
 	test('builds Elections > State > ... > Position > Name from a race slug', async () => {
@@ -493,9 +505,8 @@ describe('buildBreadcrumb', () => {
 			positionName: 'Mayor',
 		});
 		const labels = trail.map((c) => c.label);
-		expect(labels[0]).toBe('Home');
-		expect(labels[1]).toBe('Elections');
-		expect(labels[2]).toBe('California');
+		expect(labels[0]).toBe('Elections');
+		expect(labels[1]).toBe('California');
 		expect(labels).toContain('Mayor');
 		expect(labels[labels.length - 1]).toBe('Jane Doe');
 	});

--- a/src/lib/peopleProfile.ts
+++ b/src/lib/peopleProfile.ts
@@ -295,12 +295,25 @@ function formatYear(date: string | null): string | null {
 	return /^\d{4}$/.test(year) ? year : null;
 }
 
+/** "4 Years" / "1 Year" from a term frequency like [4]; null when unknown. */
+function formatTermYears(frequency: number[] | null | undefined): string | null {
+	if (!frequency?.length) return null;
+	const years = Number(frequency[0]);
+	if (!Number.isFinite(years) || years <= 0) return null;
+	return years === 1 ? '1 Year' : `${years} Years`;
+}
+
 function formatTerm(office: PersonOfficeHolder | null): string | null {
 	if (!office) return null;
+	// Preferred: the canonical term length as a year count. "In office since
+	// 20xx" was flagged inaccurate (data-limitation guesswork), so the
+	// open-ended `Since {start}` output is intentionally dropped.
+	const byYears = formatTermYears(office.electionFrequency);
+	if (byYears) return byYears;
+	// Fallback for past holders: the factual served range.
 	const start = formatYear(office.startAt);
 	const end = formatYear(office.endAt);
 	if (start && end) return `${start} – ${end}`;
-	if (start) return `Since ${start}`;
 	if (end) return `Through ${end}`;
 	return null;
 }

--- a/src/lib/peopleProfile.ts
+++ b/src/lib/peopleProfile.ts
@@ -656,7 +656,14 @@ export function composeView(
 		pledged: !removed && (person?.isPledged ?? false),
 		displayName,
 		roleTitle,
-		officeName: office?.positionName ?? office?.officeTitle ?? null,
+		// Candidate-only people have no held office; fall back to the candidacy's
+		// position so section headings ("About …", "Other Candidates for …") still
+		// name the seat they're running for, matching the Figma candidate frames.
+		officeName:
+			office?.positionName ??
+			office?.officeTitle ??
+			person?.Candidacies?.[0]?.positionName ??
+			null,
 		party,
 		avatarUrl,
 		coverImageUrl: removed ? null : (overlay?.coverImageUrl ?? null),

--- a/src/lib/peopleProfile.ts
+++ b/src/lib/peopleProfile.ts
@@ -304,22 +304,11 @@ function formatYear(date: string | null): string | null {
 	return /^\d{4}$/.test(year) ? year : null;
 }
 
-/** "4 Years" / "1 Year" from a term frequency like [4]; null when unknown. */
-function formatTermYears(frequency: number[] | null | undefined): string | null {
-	if (!frequency?.length) return null;
-	const years = Number(frequency[0]);
-	if (!Number.isFinite(years) || years <= 0) return null;
-	return years === 1 ? '1 Year' : `${years} Years`;
-}
-
 function formatTerm(office: PersonOfficeHolder | null): string | null {
 	if (!office) return null;
-	// Preferred: the canonical term length as a year count. "In office since
-	// 20xx" was flagged inaccurate (data-limitation guesswork), so the
-	// open-ended `Since {start}` output is intentionally dropped.
-	const byYears = formatTermYears(office.electionFrequency);
-	if (byYears) return byYears;
-	// Fallback for past holders: the factual served range.
+	// Term is shown only when the spine gives us real dates. electionFrequency was
+	// unreliable/unpopulated so it's intentionally unused; "In office since 20xx"
+	// was likewise dropped as data-limitation guesswork.
 	const start = formatYear(office.startAt);
 	const end = formatYear(office.endAt);
 	if (start && end) return `${start} – ${end}`;

--- a/src/lib/peopleProfile.ts
+++ b/src/lib/peopleProfile.ts
@@ -2,6 +2,7 @@ import {
 	COUNTY_MTFCC,
 	getCandidacies,
 	getCandidateBySlug,
+	getCityPlacesByCounty,
 	getOfficeHoldersByGeoId,
 	getPersonByPersonId,
 	getPersonsByIds,
@@ -9,6 +10,7 @@ import {
 	getPublicPersonProfileStatus,
 	getVoterDensityForDistrict,
 } from '~/lib/electionsApi';
+import { US_STATES_TUPLES } from '~/constants/usStates';
 import {
 	buildElectionPositionHrefFromRaceSlug,
 	getStateName,
@@ -17,6 +19,7 @@ import { classifyPartyFrom, isMajorParty, type PartyClass } from '~/lib/party';
 import type { CandidacyItem } from '~/types/elections';
 import type {
 	PersonAccomplishment,
+	PersonCandidacySummary,
 	PersonItem,
 	PersonOfficeHolder,
 	PersonProfileIssueStatus,
@@ -122,6 +125,12 @@ export interface ElectionsIndex {
 	stateSlug: string;
 	stateName: string;
 	entries: ElectionIndexEntry[];
+	/**
+	 * Geographic tier of the listed entries — scales with the profile's own
+	 * office level (state profile → states, county → counties, city → cities).
+	 * Drives the pre-footer band's "Select your {state|county|city}…" copy.
+	 */
+	entryLevel: 'state' | 'county' | 'city';
 }
 
 /**
@@ -522,11 +531,13 @@ function humanizeSlugSegment(segment: string): string {
  * Builds the location + position breadcrumb hierarchy
  * (`Elections > State > County > City > Position > Name`).
  *
+ * The trail always starts at `Elections` (no leading `Home` crumb) so it matches
+ * the profile frames and so the JSON-LD `BreadcrumbList` leads with Elections.
  * The intermediate location crumbs are derived from the resolved elections
  * position path (`/elections/<state>/<county?>/<city?>/position/<slug>`) so they
  * match the canonical elections routes exactly. When no race slug is available
  * (e.g. an office holder with no linked race), the trail degrades to
- * `Home > People > Name`.
+ * `Elections > State? > Name`.
  */
 export async function buildBreadcrumb(params: {
 	displayName: string;
@@ -536,15 +547,15 @@ export async function buildBreadcrumb(params: {
 	positionName: string | null;
 }): Promise<ProfileBreadcrumb[]> {
 	const { displayName, stateCode, raceSlug, positionLevel, positionName } = params;
-	const trail: ProfileBreadcrumb[] = [{ href: '/', label: 'Home' }];
+	const trail: ProfileBreadcrumb[] = [{ href: '/elections', label: 'Elections' }];
 
 	if (!raceSlug) {
-		trail.push({ href: '/people', label: 'People' });
+		if (stateCode) {
+			trail.push({ href: `/elections/${stateCode.toLowerCase()}`, label: getStateName(stateCode) });
+		}
 		trail.push({ label: displayName });
 		return trail;
 	}
-
-	trail.push({ href: '/elections', label: 'Elections' });
 
 	const positionHref = buildElectionPositionHrefFromRaceSlug({
 		slug: raceSlug,
@@ -714,11 +725,7 @@ export function composeView(
 			(removed ? buildRecentExperience(person) : (authoredExperience(overlay) ?? buildRecentExperience(person))),
 		otherCandidates: extras.otherCandidates ?? [],
 		nearbyOfficials: extras.nearbyOfficials ?? [],
-		breadcrumb: extras.breadcrumb ?? [
-			{ href: '/', label: 'Home' },
-			{ href: '/people', label: 'People' },
-			{ label: displayName },
-		],
+		breadcrumb: extras.breadcrumb ?? [{ href: '/elections', label: 'Elections' }, { label: displayName }],
 		electionsIndex: extras.electionsIndex ?? null,
 		voterDensity: extras.voterDensity ?? null,
 		officeAddress: removed ? null : (extras.officeAddress ?? null),
@@ -726,9 +733,48 @@ export function composeView(
 	};
 }
 
+/**
+ * Selects which of a person's candidacies drives the profile's office context
+ * (breadcrumb position crumb, "Other Candidates", position href), by precedence:
+ *   1. CURRENT candidate — the soonest UPCOMING election wins, even when the
+ *      person also holds office ("both"): the office they're running for leads.
+ *   2. Elected officeholder who is NOT currently running — defer to the elected
+ *      office (return null) so the crumb reflects the seat they hold.
+ *   3. Archived (no current run, no current office) — the most recent PAST run
+ *      by election date wins.
+ * Candidacies without a slug are skipped (the detail fetch keys off the slug).
+ */
+function selectPrimaryCandidacy(
+	person: PersonItem | null,
+	hasCurrentOffice: boolean,
+): PersonCandidacySummary | null {
+	const candidacies = (person?.Candidacies ?? []).filter((c) => c.slug);
+	if (candidacies.length === 0) return null;
+	const now = Date.now();
+	const dated = candidacies.map((c) => {
+		const parsed = c.Race?.electionDate ? Date.parse(c.Race.electionDate) : NaN;
+		return { candidacy: c, time: Number.isNaN(parsed) ? null : parsed };
+	});
+	// (1) Current candidate: earliest upcoming election.
+	const upcoming = dated
+		.filter((x): x is { candidacy: PersonCandidacySummary; time: number } => x.time != null && x.time >= now)
+		.sort((a, b) => a.time - b.time);
+	if (upcoming[0]) return upcoming[0].candidacy;
+	// (2) Elected officeholder not currently running: defer to the office.
+	if (hasCurrentOffice) return null;
+	// (3) Archived: most recent past run wins; undated rows fall back to first.
+	const past = dated
+		.filter((x): x is { candidacy: PersonCandidacySummary; time: number } => x.time != null)
+		.sort((a, b) => b.time - a.time);
+	return past[0]?.candidacy ?? candidacies[0] ?? null;
+}
+
 /** Resolves the primary candidacy detail (with race) used to enrich the page. */
-async function loadPrimaryCandidacy(person: PersonItem | null): Promise<CandidacyItem | null> {
-	const slug = person?.Candidacies?.[0]?.slug;
+async function loadPrimaryCandidacy(
+	person: PersonItem | null,
+	hasCurrentOffice: boolean,
+): Promise<CandidacyItem | null> {
+	const slug = selectPrimaryCandidacy(person, hasCurrentOffice)?.slug;
 	if (!slug) return null;
 	return getCandidateBySlug({ slug, includeStances: false, includeRace: true });
 }
@@ -758,19 +804,104 @@ async function loadNearbyOfficials(
 	return buildNearbyOfficialCards(officeholders, byId, excludePersonId);
 }
 
-/** Builds an "Explore Elections" index of counties in the person's state. */
-async function loadElectionsIndex(stateCode: string | null): Promise<ElectionsIndex | null> {
-	if (!stateCode) return null;
-	const counties = await getPlacesByState({ state: stateCode, mtfcc: COUNTY_MTFCC });
-	const entries: ElectionIndexEntry[] = counties
-		.filter((c) => c.slug && c.name)
-		.map((c) => ({ name: c.name, href: `/elections/${c.slug}`, level: 'county' as const }));
-	if (entries.length === 0) return null;
+/**
+ * Resolves the pre-footer "Explore Elections" index tier from the profile's
+ * office geography. City/local offices list sibling cities in their county,
+ * county offices list sibling counties in their state, and everything else
+ * (state/federal/unknown) lists all states.
+ *
+ * The county slug is recovered from the resolved position href
+ * (`/elections/<state>/<county>/<city?>/position/<slug>`) since the persons
+ * spine does not carry a clean county reference for city-level offices.
+ */
+function deriveElectionsIndexTier(
+	positionHref: string | null,
+	positionLevel: string | null,
+): { tier: 'state' | 'county' | 'city'; countySlug: string | null } {
+	if (positionHref) {
+		const segments = positionHref.split('/').filter(Boolean); // ['elections', state, ...]
+		const positionIdx = segments.indexOf('position');
+		const locationSegments =
+			positionIdx > 1 ? segments.slice(1, positionIdx) : segments.slice(1);
+		// [state] | [state, county] | [state, county, city(, subplace)]
+		if (locationSegments.length >= 3) {
+			return { tier: 'city', countySlug: `${locationSegments[0]}/${locationSegments[1]}` };
+		}
+		if (locationSegments.length === 2) return { tier: 'county', countySlug: null };
+		return { tier: 'state', countySlug: null };
+	}
+	const level = (positionLevel ?? '').toUpperCase();
+	if (/CITY|LOCAL|TOWN|MUNICIPAL|VILLAGE|BOROUGH/.test(level)) return { tier: 'county', countySlug: null };
+	if (/COUNTY|REGIONAL/.test(level)) return { tier: 'county', countySlug: null };
+	return { tier: 'state', countySlug: null };
+}
+
+/** Lists all US states as an "Explore Elections" index (state-level profiles). */
+function statesElectionsIndex(stateCode: string | null): ElectionsIndex {
+	const entries: ElectionIndexEntry[] = US_STATES_TUPLES.map(([code, name]) => ({
+		name,
+		href: `/elections/${code.toLowerCase()}`,
+		level: 'state' as const,
+	}));
 	return {
-		stateSlug: stateCode.toLowerCase(),
-		stateName: getStateName(stateCode),
+		stateSlug: stateCode?.toLowerCase() ?? '',
+		stateName: stateCode ? getStateName(stateCode) : 'United States',
+		entryLevel: 'state',
 		entries,
 	};
+}
+
+/**
+ * Builds the pre-footer "Explore Elections" index, scaled to the profile's
+ * office level: state → all states, county → counties in the state, city →
+ * sibling cities in the office's county.
+ */
+async function loadElectionsIndex(params: {
+	stateCode: string | null;
+	tier: 'state' | 'county' | 'city';
+	countySlug: string | null;
+}): Promise<ElectionsIndex | null> {
+	const { stateCode, tier, countySlug } = params;
+
+	if (tier === 'city' && countySlug) {
+		const state = countySlug.split('/')[0]?.toUpperCase() ?? stateCode?.toUpperCase() ?? '';
+		const cities = await getCityPlacesByCounty({ state, countySlug });
+		const entries: ElectionIndexEntry[] = cities
+			.filter((c) => c.slug && c.name)
+			.map((c) => ({
+				name: c.name,
+				href: `/elections/${countySlug}/${c.slug.split('/').pop() ?? ''}`,
+				level: 'city' as const,
+			}));
+		if (entries.length > 0) {
+			return {
+				stateSlug: countySlug,
+				stateName: stateCode ? getStateName(stateCode) : '',
+				entryLevel: 'city',
+				entries,
+			};
+		}
+		// Fall through to the state list if the county has no listable cities.
+		return statesElectionsIndex(stateCode);
+	}
+
+	if (tier === 'county' && stateCode) {
+		const counties = await getPlacesByState({ state: stateCode, mtfcc: COUNTY_MTFCC });
+		const entries: ElectionIndexEntry[] = counties
+			.filter((c) => c.slug && c.name)
+			.map((c) => ({ name: c.name, href: `/elections/${c.slug}`, level: 'county' as const }));
+		if (entries.length > 0) {
+			return {
+				stateSlug: stateCode.toLowerCase(),
+				stateName: getStateName(stateCode),
+				entryLevel: 'county',
+				entries,
+			};
+		}
+	}
+
+	// State-level profiles (and any tier that produced no entries) list states.
+	return statesElectionsIndex(stateCode);
 }
 
 /**
@@ -800,7 +931,7 @@ export async function loadPersonProfile(personId: string): Promise<PersonProfile
 	if (!overlay && !removed && !person) return null;
 
 	const office = pickCurrentOffice(person);
-	const candidacy = await loadPrimaryCandidacy(person);
+	const candidacy = await loadPrimaryCandidacy(person, office?.isCurrent === true);
 
 	const raceSlug = candidacy?.Race?.slug ?? null;
 	const positionLevel = candidacy?.Race?.positionLevel ?? office?.Position?.level ?? null;
@@ -831,11 +962,12 @@ export async function loadPersonProfile(personId: string): Promise<PersonProfile
 
 	// Interlink sections + breadcrumb are independent; fetch in parallel. Each
 	// degrades to empty on any miss so the core profile always renders.
+	const { tier, countySlug } = deriveElectionsIndexTier(positionHref, positionLevel);
 	const [otherCandidates, nearbyOfficials, breadcrumb, electionsIndex] = await Promise.all([
 		loadOtherCandidates(positionId, personId),
 		loadNearbyOfficials(geoId, personId),
 		buildBreadcrumb({ displayName, stateCode, raceSlug, positionLevel, positionName }),
-		loadElectionsIndex(stateCode),
+		loadElectionsIndex({ stateCode, tier, countySlug }),
 	]);
 
 	return composeView(personId, person, overlay, {

--- a/src/testing/peopleProfileFixtures.ts
+++ b/src/testing/peopleProfileFixtures.ts
@@ -81,6 +81,7 @@ function office(over: Partial<PersonOfficeHolder> = {}): PersonOfficeHolder {
 		startAt: '2021-01-01',
 		endAt: null,
 		termDateSpecificity: null,
+		electionFrequency: [4],
 		isCurrent: true,
 		isAppointed: null,
 		numberOfSeats: null,

--- a/src/testing/peopleProfileFixtures.ts
+++ b/src/testing/peopleProfileFixtures.ts
@@ -63,7 +63,7 @@ function candidacy(over: Partial<PersonCandidacySummary> = {}): PersonCandidacyS
 	// `Race.electionDate` lets the spine-derived "Recent Experience" date the run.
 	return {
 		id: 'cand-1',
-		positionName: 'Mayor',
+		positionName: 'Mayor of Springfield',
 		party: 'Independent',
 		state: 'CA',
 		Race: { electionDate: '2024-11-05' },
@@ -74,9 +74,9 @@ function candidacy(over: Partial<PersonCandidacySummary> = {}): PersonCandidacyS
 function office(over: Partial<PersonOfficeHolder> = {}): PersonOfficeHolder {
 	return {
 		id: 'off-1',
-		positionName: 'City Council',
-		normalizedPositionName: null,
-		officeTitle: 'City Council',
+		positionName: 'Springfield City Council',
+		normalizedPositionName: 'City Council',
+		officeTitle: 'City Council Member',
 		partyNames: ['Independent'],
 		startAt: '2021-01-01',
 		endAt: null,
@@ -85,8 +85,8 @@ function office(over: Partial<PersonOfficeHolder> = {}): PersonOfficeHolder {
 		isAppointed: null,
 		numberOfSeats: null,
 		state: 'CA',
-		subAreaName: null,
-		subAreaValue: null,
+		subAreaName: 'Ward',
+		subAreaValue: '3',
 		websiteUrl: null,
 		officePhone: null,
 		officeEmail: null,
@@ -182,13 +182,16 @@ const claimedFacts = (persona: PersonPersona, pledged: boolean): ExpectedFacts =
 	noindex: false,
 });
 
-const unclaimedIndepFacts = (persona: PersonPersona, pledged: boolean): ExpectedFacts => ({
+// An unclaimed profile never surfaces a GP pledge (pledge framing is
+// claimed-only, and the hero pledge pill has been removed), so these are always
+// pledged:false — the spine flag is left off the unclaimed fixtures to match.
+const unclaimedIndepFacts = (persona: PersonPersona): ExpectedFacts => ({
 	persona,
 	claimed: false,
 	majorParty: false,
 	empowered: true,
 	removed: false,
-	pledged,
+	pledged: false,
 	hasAvatar: true, // spine headshot
 	hasBio: true, // spine bioText
 	hasIssues: false, // no overlay
@@ -255,27 +258,26 @@ export const STATE_FIXTURES: StateFixture[] = [
 	{
 		state: 'D',
 		description: 'Unclaimed independent candidate',
-		person: spine({ isPledged: true, Candidacies: [candidacy({ party: 'Independent' })] }),
+		person: spine({ Candidacies: [candidacy({ party: 'Independent' })] }),
 		overlay: { status: 'absent' },
-		expected: unclaimedIndepFacts('candidate', true),
+		expected: unclaimedIndepFacts('candidate'),
 	},
 	{
 		state: 'E',
 		description: 'Unclaimed independent officeholder',
 		person: spine({ OfficeHolders: [office({ isCurrent: true, partyNames: ['Independent'] })] }),
 		overlay: { status: 'absent' },
-		expected: unclaimedIndepFacts('officeholder', false),
+		expected: unclaimedIndepFacts('officeholder'),
 	},
 	{
 		state: 'F',
 		description: 'Unclaimed independent candidate + officeholder',
 		person: spine({
-			isPledged: true,
 			Candidacies: [candidacy({ party: 'Independent' })],
 			OfficeHolders: [office({ isCurrent: true, partyNames: ['Independent'] })],
 		}),
 		overlay: { status: 'absent' },
-		expected: unclaimedIndepFacts('both', true),
+		expected: unclaimedIndepFacts('both'),
 	},
 	{
 		state: 'G',
@@ -300,7 +302,7 @@ export const STATE_FIXTURES: StateFixture[] = [
 			],
 		}),
 		overlay: { status: 'absent' },
-		expected: unclaimedIndepFacts('past', false),
+		expected: unclaimedIndepFacts('past'),
 	},
 	{
 		state: 'I',

--- a/src/testing/peopleProfileFixtures.ts
+++ b/src/testing/peopleProfileFixtures.ts
@@ -81,7 +81,6 @@ function office(over: Partial<PersonOfficeHolder> = {}): PersonOfficeHolder {
 		startAt: '2021-01-01',
 		endAt: null,
 		termDateSpecificity: null,
-		electionFrequency: [4],
 		isCurrent: true,
 		isAppointed: null,
 		numberOfSeats: null,

--- a/src/types/people.ts
+++ b/src/types/people.ts
@@ -18,14 +18,6 @@ export interface PersonOfficeHolder {
 	startAt: string | null;
 	endAt: string | null;
 	termDateSpecificity: string | null;
-	/**
-	 * Canonical term length in years for the office (e.g. [4] = 4-year term),
-	 * sourced from the position's election frequency. Optional: the election-api
-	 * persons spine does not populate it today, so the profile falls back to the
-	 * served date range when it's absent. Preferred source for the sidebar
-	 * "Current Term" / About-office "Term length" rows over "in office since".
-	 */
-	electionFrequency?: number[] | null;
 	isCurrent: boolean | null;
 	isAppointed: boolean | null;
 	numberOfSeats: number | null;

--- a/src/types/people.ts
+++ b/src/types/people.ts
@@ -18,6 +18,14 @@ export interface PersonOfficeHolder {
 	startAt: string | null;
 	endAt: string | null;
 	termDateSpecificity: string | null;
+	/**
+	 * Canonical term length in years for the office (e.g. [4] = 4-year term),
+	 * sourced from the position's election frequency. Optional: the election-api
+	 * persons spine does not populate it today, so the profile falls back to the
+	 * served date range when it's absent. Preferred source for the sidebar
+	 * "Current Term" / About-office "Term length" rows over "in office since".
+	 */
+	electionFrequency?: number[] | null;
 	isCurrent: boolean | null;
 	isAppointed: boolean | null;
 	numberOfSeats: number | null;

--- a/src/ui/CTABannerBlock.tsx
+++ b/src/ui/CTABannerBlock.tsx
@@ -68,6 +68,15 @@ export type CTABannerBlockProps = {
 	 * button on its light-blue card, so it opts out.
 	 */
 	preserveButtonStyle?: boolean;
+	/**
+	 * Align the inner content (title/copy/button) with the profile content-card
+	 * column instead of the full container. Opt-in for the person-profile CTA,
+	 * which sits below the asymmetric sidebar + cards layout; without it the
+	 * centered content lines up with the page middle rather than the cards above.
+	 * The colored card stays full-width behind the content. Off (full-width)
+	 * everywhere else, so /elections and /candidate are unaffected.
+	 */
+	contentColumnAlign?: boolean;
 };
 
 export function CTABannerBlock(props: CTABannerBlockProps) {
@@ -81,32 +90,47 @@ export function CTABannerBlock(props: CTABannerBlockProps) {
 		: resolveInverseButtonStyleType(requestedStyle, backgroundColor, color);
 	const isCentered = align === 'center';
 
+	const content = (
+		<div
+			className={cn(
+				'relative p-6 z-2 flex flex-col gap-6 md:p-12',
+				isCentered ? 'md:items-center md:text-center' : 'md:items-end',
+			)}
+		>
+			<div className={cn('flex flex-col gap-3 w-full md:gap-4', isCentered && 'md:mx-auto md:max-w-2xl md:items-center')}>
+				{props.title && (
+					<Text as='h2' styleType='heading-lg'>
+						{props.title}
+					</Text>
+				)}
+				{isValidRichText(props.copy) && <Text styleType='body-1'>{props.copy}</Text>}
+			</div>
+			{props.button && (
+				<ComponentButton
+					{...props.button}
+					className='max-sm:w-full before:content[""] before:absolute before:inset-0'
+					buttonProps={{ ...(props.button.buttonProps ?? {}), styleType: resolvedStyle }}
+				/>
+			)}
+		</div>
+	);
+
 	return (
 		<article className={cn(base(), props.className)} data-component='CTABannerBlock'>
 			<Container size='xl'>
 				<div className='group relative'>
-					<div
-						className={cn(
-							'relative p-6 z-2 flex flex-col gap-6 md:p-12',
-							isCentered ? 'md:items-center md:text-center' : 'md:items-end',
-						)}
-					>
-						<div className={cn('flex flex-col gap-3 w-full md:gap-4', isCentered && 'md:mx-auto md:max-w-2xl md:items-center')}>
-							{props.title && (
-								<Text as='h2' styleType='heading-lg'>
-									{props.title}
-								</Text>
-							)}
-							{isValidRichText(props.copy) && <Text styleType='body-1'>{props.copy}</Text>}
+					{props.contentColumnAlign ? (
+						// People profiles: mirror ProfileContentBlock's grid so the CTA
+						// content lines up with the content-card column above it. The
+						// empty first cell reserves the sidebar's width; the colored card
+						// below stays full-width.
+						<div className='relative z-2 lg:grid lg:grid-cols-[minmax(280px,400px)_minmax(0,1fr)] lg:gap-10 xl:gap-12'>
+							<div className='hidden lg:block' aria-hidden />
+							{content}
 						</div>
-						{props.button && (
-							<ComponentButton
-								{...props.button}
-								className='max-sm:w-full before:content[""] before:absolute before:inset-0'
-								buttonProps={{ ...(props.button.buttonProps ?? {}), styleType: resolvedStyle }}
-							/>
-						)}
-					</div>
+					) : (
+						content
+					)}
 					<div className={card()}>
 						<svg
 							className='absolute z-1 max-md:top-0 max-md:left-0 md:-bottom-20 md:right-[25%] md:rotate-180'

--- a/src/ui/CandidatesCard.mdx
+++ b/src/ui/CandidatesCard.mdx
@@ -69,7 +69,7 @@ Flag indicating this is a GoodParty-empowered candidate. When `true`, the card d
 - Yellow border (`border-bright-yellow-600`)
 - Yellow hover background (`hover:bg-bright-yellow-50`)
 - GoodParty logo badge overlay on avatar
-- "Empowered by goodparty.org" text in gray
+- "Empowered by GoodParty.org" text in gray
 
 **Type:** `boolean`
 
@@ -118,7 +118,7 @@ Internal key used by CandidatesBlock for React list rendering.
 - Border: `border-bright-yellow-600` (yellow)
 - Hover: Shadow and yellow background (`hover:shadow-md hover:bg-bright-yellow-50`)
 - Badge: GoodParty logo positioned `absolute -bottom-0.5 -right-0.5` on avatar
-- "Empowered by goodparty.org": Displayed in `text-neutral-500` (gray), `caption` styleType
+- "Empowered by GoodParty.org": Displayed in `text-neutral-500` (gray), `caption` styleType
 
 ## Avatar Fallback
 

--- a/src/ui/CandidatesCard.tsx
+++ b/src/ui/CandidatesCard.tsx
@@ -81,7 +81,7 @@ export const CandidatesCard = memo(function CandidatesCard(props: CandidatesCard
 				<div className={footerWrapper()}>
 					{isGoodParty ? (
 						<Text as='p' styleType='caption' className={empowered()}>
-							Empowered by goodparty.org
+							Empowered by GoodParty.org
 						</Text>
 					) : (
 						<div />

--- a/src/ui/ElectionsIndexBlock.tsx
+++ b/src/ui/ElectionsIndexBlock.tsx
@@ -131,10 +131,6 @@ export function ElectionsIndexBlock(props: ElectionsIndexBlockProps) {
 
 	const resolvedButtonStyle = resolveButtonStyleType('primary', backgroundColor);
 
-	if (props.citySlug) {
-		return null;
-	}
-
 	return (
 		<article className={cn(base(), props.className)} data-component='ElectionsIndexBlock'>
 			<Container size='xl'>

--- a/src/ui/ElectionsSidebar.tsx
+++ b/src/ui/ElectionsSidebar.tsx
@@ -18,6 +18,13 @@ const styles = tv({
 		// Figma person-profile card: tighter rows (no card gap; trimmed first/last).
 		figmaCard: 'flex flex-col p-6 bg-white rounded-xl',
 		figmaRow: 'flex flex-col gap-2 py-3 border-b border-gray-200 last:border-b-0 first:pt-0 last:pb-0',
+		// Icon + value line (Figma "Website Link"): a 20px icon centred against the
+		// value text. body-2's 140% line-height (25.2px) is taller than the icon, so
+		// `items-center` on the raw line box parks the icon ~3px below the glyphs'
+		// optical centre — the "off-centre" the Figma frame does not have. Pin the
+		// line to the icon height so the two share one box and centre cleanly.
+		iconValueRow: 'flex items-center gap-2',
+		iconValue: 'break-words leading-5',
 		label: '',
 		value: 'break-words',
 	},
@@ -90,7 +97,7 @@ function ContactIconButton({ icon, href, label }: SidebarContactIcon) {
 }
 
 export function ElectionsSidebar(props: ElectionsSidebarProps) {
-	const { base, card, linkItem, linkIcon, linkText, linkLabel, linkUrlContainer, linkUrl, infoItem, figmaCard, figmaRow, label, value } = styles();
+	const { base, card, linkItem, linkIcon, linkText, linkLabel, linkUrlContainer, linkUrl, infoItem, figmaCard, figmaRow, iconValueRow, iconValue, label, value } = styles();
 
 	// Figma person-profile card renders whenever any structured row is supplied.
 	const hasFigmaCard =
@@ -109,9 +116,9 @@ export function ElectionsSidebar(props: ElectionsSidebarProps) {
 							<Text as='dt' styleType='subtitle-2' className={label()}>
 								{row.label}
 							</Text>
-							<div className='flex items-center gap-2'>
+							<div className={iconValueRow()}>
 								<IconResolver icon={row.icon} className={linkIcon()} />
-								<Text as='dd' styleType='body-2' className={value()}>
+								<Text as='dd' styleType='body-2' className={iconValue()}>
 									{row.value}
 								</Text>
 							</div>
@@ -122,9 +129,9 @@ export function ElectionsSidebar(props: ElectionsSidebarProps) {
 							<Text as='dt' styleType='subtitle-2' className={label()}>
 								Political Affiliation
 							</Text>
-							<div className='flex items-center gap-2'>
+							<div className={iconValueRow()}>
 								<IconResolver icon='flag' className={linkIcon()} />
-								<Text as='dd' styleType='body-2' className={value()}>
+								<Text as='dd' styleType='body-2' className={iconValue()}>
 									{props.politicalAffiliation}
 								</Text>
 							</div>
@@ -149,10 +156,10 @@ export function ElectionsSidebar(props: ElectionsSidebarProps) {
 							</Text>
 							<div className='flex flex-col gap-2'>
 								{props.officeContacts!.map((c, i) => (
-									<div key={i} className='flex items-center gap-2'>
+									<div key={i} className={iconValueRow()}>
 										<IconResolver icon={c.icon} className={linkIcon()} />
 										<Anchor href={c.href} className={linkUrl()}>
-											<Text as='span' styleType='body-2'>
+											<Text as='span' styleType='body-2' className={iconValue()}>
 												{c.label}
 											</Text>
 										</Anchor>

--- a/src/ui/ProfileContentBlock.tsx
+++ b/src/ui/ProfileContentBlock.tsx
@@ -38,6 +38,20 @@ const styles = tv({
 				base: 'bg-goodparty-cream',
 			},
 		},
+		// Sidebar clearance for the straddling hero portrait. MUST stay in lockstep
+		// with ProfileHero's portrait overhang (overhang = avatarSize − 200):
+		// `default` clears the 416px /candidate portrait (216px); `compact` clears
+		// the people-profile 320px portrait (120px).
+		portrait: {
+			default: {},
+			compact: {
+				sidebar: 'lg:mt-[120px]',
+				sidebarStandalone: 'lg:mt-[120px]',
+			},
+		},
+	},
+	defaultVariants: {
+		portrait: 'default',
 	},
 });
 
@@ -47,11 +61,13 @@ export type ProfileContentBlockProps = {
 	sidebar?: ElectionsSidebarProps;
 	title?: string;
 	contentCards: ProfileContentCardProps[];
+	/** Clears the smaller (320px) people-profile portrait instead of the 416px default. */
+	compactPortrait?: boolean;
 };
 
 export function ProfileContentBlock(props: ProfileContentBlockProps) {
 	const backgroundColor = props.backgroundColor ?? 'cream';
-	const { base, well, grid, sidebar, sidebarStandalone, content, title: titleSlot } = styles({ backgroundColor });
+	const { base, well, grid, sidebar, sidebarStandalone, content, title: titleSlot } = styles({ backgroundColor, portrait: props.compactPortrait ? 'compact' : 'default' });
 	const hasContentCards = props.contentCards.length > 0;
 
 	return (

--- a/src/ui/ProfileContentBlock.tsx
+++ b/src/ui/ProfileContentBlock.tsx
@@ -70,8 +70,9 @@ function chunkCardGroups(cards: ProfileContentCardProps[]): ProfileContentCardPr
 	const groups: ProfileContentCardProps[][] = [];
 	for (const card of cards) {
 		const last = groups.at(-1);
+		const head = last?.[0];
 		const mergeable =
-			last != null && !card.raw && !last[0].raw && card.group != null && last[0].group === card.group;
+			head != null && !card.raw && !head.raw && card.group != null && head.group === card.group;
 		if (mergeable && last) last.push(card);
 		else groups.push([card]);
 	}
@@ -98,7 +99,7 @@ export function ProfileContentBlock(props: ProfileContentBlockProps) {
 						(separated ? (
 							<div className={cn(separatedColumn())}>
 								{chunkCardGroups(props.contentCards).map((group, gi) =>
-									group[0].raw ? (
+									group[0]?.raw ? (
 										group.map((card, ci) => <ProfileContentCard key={`${gi}-${ci}`} {...card} />)
 									) : (
 										<div key={gi} className={cn(separatedCard())} data-component='ProfileContentCardGroup'>

--- a/src/ui/ProfileContentBlock.tsx
+++ b/src/ui/ProfileContentBlock.tsx
@@ -26,6 +26,14 @@ const styles = tv({
 		// sits under the straddling hero photo, so without this it would be overlapped.
 		sidebarStandalone: 'w-full min-w-0 md:mt-[104px] lg:mt-[216px]',
 		content: 'flex min-w-0 w-full flex-col gap-8 rounded-xl bg-white p-6',
+		// Separated layout (Figma people profiles): a transparent column whose
+		// children are individual white cards; the cream page shows through the
+		// 24px gaps between them.
+		separatedColumn: 'flex min-w-0 w-full flex-col gap-6',
+		// Figma card: 16px radius (--radius-lg) white fill; the inner sections
+		// carry their own 24px padding (ProfileContentCard), so the card itself
+		// only adds the 16px outer inset the frame shows.
+		separatedCard: 'flex flex-col rounded-lg bg-white p-4',
 		title: 'border-b border-gray-200 ',
 	},
 	variants: {
@@ -47,12 +55,35 @@ export type ProfileContentBlockProps = {
 	sidebar?: ElectionsSidebarProps;
 	title?: string;
 	contentCards: ProfileContentCardProps[];
+	/**
+	 * `joined` (default, used by `/candidate`) stacks every card inside one white
+	 * box with hairline dividers. `separated` (people profiles) renders the Figma
+	 * layout: adjacent cards sharing a `group` collapse into their own white card,
+	 * separated by cream gaps; `raw` cards render standalone without card chrome.
+	 */
+	cardLayout?: 'joined' | 'separated';
 };
+
+/** Chunks a flat card list into groups: consecutive same-`group` non-raw cards
+ * share a white card; every `raw` card stands alone (self-styled). */
+function chunkCardGroups(cards: ProfileContentCardProps[]): ProfileContentCardProps[][] {
+	const groups: ProfileContentCardProps[][] = [];
+	for (const card of cards) {
+		const last = groups.at(-1);
+		const mergeable =
+			last != null && !card.raw && !last[0]!.raw && card.group != null && last[0]!.group === card.group;
+		if (mergeable) last!.push(card);
+		else groups.push([card]);
+	}
+	return groups;
+}
 
 export function ProfileContentBlock(props: ProfileContentBlockProps) {
 	const backgroundColor = props.backgroundColor ?? 'cream';
-	const { base, well, grid, sidebar, sidebarStandalone, content, title: titleSlot } = styles({ backgroundColor });
+	const { base, well, grid, sidebar, sidebarStandalone, content, separatedColumn, separatedCard, title: titleSlot } =
+		styles({ backgroundColor });
 	const hasContentCards = props.contentCards.length > 0;
+	const separated = props.cardLayout === 'separated';
 
 	return (
 		<article className={cn(base(), props.className)} data-component='ProfileContentBlock'>
@@ -63,18 +94,33 @@ export function ProfileContentBlock(props: ProfileContentBlockProps) {
 							<ElectionsSidebar {...props.sidebar} />
 						</aside>
 					)}
-					{hasContentCards && (
-						<div className={cn(content())}>
-							{props.title && (
-								<Text as='h2' styleType='heading-sm' className={titleSlot()}>
-									{props.title}
-								</Text>
-							)}
-							{props.contentCards.map((card, index) => (
-								<ProfileContentCard key={index} {...card} />
-							))}
-						</div>
-					)}
+					{hasContentCards &&
+						(separated ? (
+							<div className={cn(separatedColumn())}>
+								{chunkCardGroups(props.contentCards).map((group, gi) =>
+									group[0]!.raw ? (
+										group.map((card, ci) => <ProfileContentCard key={`${gi}-${ci}`} {...card} />)
+									) : (
+										<div key={gi} className={cn(separatedCard())} data-component='ProfileContentCardGroup'>
+											{group.map((card, ci) => (
+												<ProfileContentCard key={`${gi}-${ci}`} {...card} bare />
+											))}
+										</div>
+									),
+								)}
+							</div>
+						) : (
+							<div className={cn(content())}>
+								{props.title && (
+									<Text as='h2' styleType='heading-sm' className={titleSlot()}>
+										{props.title}
+									</Text>
+								)}
+								{props.contentCards.map((card, index) => (
+									<ProfileContentCard key={index} {...card} />
+								))}
+							</div>
+						))}
 				</div>
 			</Container>
 		</article>

--- a/src/ui/ProfileContentBlock.tsx
+++ b/src/ui/ProfileContentBlock.tsx
@@ -71,8 +71,8 @@ function chunkCardGroups(cards: ProfileContentCardProps[]): ProfileContentCardPr
 	for (const card of cards) {
 		const last = groups.at(-1);
 		const mergeable =
-			last != null && !card.raw && !last[0]!.raw && card.group != null && last[0]!.group === card.group;
-		if (mergeable) last!.push(card);
+			last != null && !card.raw && !last[0].raw && card.group != null && last[0].group === card.group;
+		if (mergeable && last) last.push(card);
 		else groups.push([card]);
 	}
 	return groups;
@@ -98,7 +98,7 @@ export function ProfileContentBlock(props: ProfileContentBlockProps) {
 						(separated ? (
 							<div className={cn(separatedColumn())}>
 								{chunkCardGroups(props.contentCards).map((group, gi) =>
-									group[0]!.raw ? (
+									group[0].raw ? (
 										group.map((card, ci) => <ProfileContentCard key={`${gi}-${ci}`} {...card} />)
 									) : (
 										<div key={gi} className={cn(separatedCard())} data-component='ProfileContentCardGroup'>

--- a/src/ui/ProfileContentBlock.tsx
+++ b/src/ui/ProfileContentBlock.tsx
@@ -38,20 +38,6 @@ const styles = tv({
 				base: 'bg-goodparty-cream',
 			},
 		},
-		// Sidebar clearance for the straddling hero portrait. MUST stay in lockstep
-		// with ProfileHero's portrait overhang (overhang = avatarSize − 200):
-		// `default` clears the 416px /candidate portrait (216px); `compact` clears
-		// the people-profile 320px portrait (120px).
-		portrait: {
-			default: {},
-			compact: {
-				sidebar: 'lg:mt-[120px]',
-				sidebarStandalone: 'lg:mt-[120px]',
-			},
-		},
-	},
-	defaultVariants: {
-		portrait: 'default',
 	},
 });
 
@@ -61,13 +47,11 @@ export type ProfileContentBlockProps = {
 	sidebar?: ElectionsSidebarProps;
 	title?: string;
 	contentCards: ProfileContentCardProps[];
-	/** Clears the smaller (320px) people-profile portrait instead of the 416px default. */
-	compactPortrait?: boolean;
 };
 
 export function ProfileContentBlock(props: ProfileContentBlockProps) {
 	const backgroundColor = props.backgroundColor ?? 'cream';
-	const { base, well, grid, sidebar, sidebarStandalone, content, title: titleSlot } = styles({ backgroundColor, portrait: props.compactPortrait ? 'compact' : 'default' });
+	const { base, well, grid, sidebar, sidebarStandalone, content, title: titleSlot } = styles({ backgroundColor });
 	const hasContentCards = props.contentCards.length > 0;
 
 	return (

--- a/src/ui/ProfileContentCard.tsx
+++ b/src/ui/ProfileContentCard.tsx
@@ -9,11 +9,27 @@ const styles = tv({
 		heading: '',
 		content: 'min-w-0 break-words',
 	},
+	variants: {
+		// `bare` drops the inter-section divider + bottom padding used in the
+		// joined (single-card) layout. In the Figma people-profile "separated"
+		// layout each section is a padded sub-box inside its own white card, so
+		// sections are set apart by whitespace, not a hairline rule.
+		bare: {
+			true: { base: 'flex flex-col gap-6 p-6' },
+		},
+	},
 });
 
 export type ProfileContentCardProps = {
 	className?: string;
 	cardType?: 'about-me' | 'why-running' | 'top-issues';
+	/**
+	 * Groups adjacent cards into one white container in the "separated" layout
+	 * (Figma people profiles): cards sharing a `group` render inside a single
+	 * rounded white card, with cream gaps between groups. Ignored by the joined
+	 * layout (`/candidate`).
+	 */
+	group?: string;
 	heading?: string;
 	content?: ReactNode;
 	/**
@@ -22,10 +38,12 @@ export type ProfileContentCardProps = {
 	 * claim prompt or the structured "About [position]" card.
 	 */
 	raw?: boolean;
+	/** Drops the inter-section divider (used by the grouped/separated layout). */
+	bare?: boolean;
 };
 
 export function ProfileContentCard(props: ProfileContentCardProps) {
-	const { base, heading, content } = styles();
+	const { base, heading, content } = styles({ bare: props.bare });
 
 	if (props.raw) {
 		return <>{props.content}</>;

--- a/src/ui/ProfileHero.tsx
+++ b/src/ui/ProfileHero.tsx
@@ -32,8 +32,10 @@ const styles = tv({
 		imageWrapper: 'relative z-20 flex-shrink-0 md:-mb-[104px] lg:-mb-[216px]',
 		// Circular portrait straddling the dark band and the cream content below.
 		image: 'relative rounded-full overflow-hidden w-40 h-40 md:w-72 md:h-72 lg:w-[416px] lg:h-[416px]',
-		// GoodParty logo overlaid on the photo's bottom-right corner (Figma).
-		badge: 'absolute bottom-1 right-1 z-30 drop-shadow-md',
+		// GoodParty logo overlaid on the photo's bottom-right corner. Sized as a
+		// fraction of the portrait per Figma (desktop glyph 113x94 on the 416px
+		// avatar; mobile 48x40 on the 144px avatar), so it scales across breakpoints.
+		badge: 'absolute bottom-1 right-1 z-30 drop-shadow-md w-12 h-10 md:w-20 md:h-[66px] lg:w-[113px] lg:h-[94px]',
 		content: 'flex flex-col gap-4 text-left z-10 md:pt-2',
 		tagRow: 'flex flex-wrap items-center gap-2',
 		// Pill CONTAINER only (shape + color). The text size lives on an inner span,
@@ -72,22 +74,6 @@ const styles = tv({
 				notEndorsed: 'text-gray-500',
 			},
 		},
-		// People profiles use a smaller desktop portrait (Emily/Jack: the 416px
-		// avatar pushed the sidebar entirely below the fold). Shrinking it to 320px
-		// on lg moves the straddle overhang from 216→120px so the sidebar's leading
-		// rows sit partially above the fold. The overhang MUST stay in lockstep with
-		// ProfileContentBlock's sidebar clearance (overhang = avatarSize − 200).
-		// `default` preserves the shared /candidate hero unchanged.
-		portrait: {
-			default: {},
-			compact: {
-				image: 'lg:w-[320px] lg:h-[320px]',
-				imageWrapper: 'lg:-mb-[120px]',
-			},
-		},
-	},
-	defaultVariants: {
-		portrait: 'default',
 	},
 });
 
@@ -101,12 +87,6 @@ export type ProfileHeroProps = {
 	profileImage?: SanityImage;
 	profileImageUrl?: string;
 	isEmpowered?: boolean;
-	/**
-	 * People profiles use a smaller (320px) desktop portrait so the sidebar's
-	 * leading rows sit partially above the fold. Defaults to the full 416px
-	 * portrait used by the shared /candidate hero.
-	 */
-	compactPortrait?: boolean;
 	/** Persona tag pills rendered above the name (e.g. "Candidate", "Incumbent"). Renders nothing when empty. */
 	tags?: string[];
 	/**
@@ -119,7 +99,7 @@ export type ProfileHeroProps = {
 export function ProfileHero(props: ProfileHeroProps) {
 	const backgroundColor = props.backgroundColor ?? 'midnight';
 	const resolvedBackgroundColor = backgroundColor === 'white' ? 'cream' : backgroundColor;
-	const { base, backgroundWrapper, band, belowBand, container, imageWrapper, image, badge, content, tagRow, tag, tagText, nameOffice, heading, office, officeLink, attribution, attributionIcon, attributionText, notEndorsed } = styles({ backgroundColor: resolvedBackgroundColor, portrait: props.compactPortrait ? 'compact' : 'default' });
+	const { base, backgroundWrapper, band, belowBand, container, imageWrapper, image, badge, content, tagRow, tag, tagText, nameOffice, heading, office, officeLink, attribution, attributionIcon, attributionText, notEndorsed } = styles({ backgroundColor: resolvedBackgroundColor });
 
 	// `attribution` wins when provided; otherwise fall back to legacy `isEmpowered`.
 	const attributionMode = props.attribution ?? (props.isEmpowered ? 'empowered' : 'none');
@@ -161,7 +141,7 @@ export function ProfileHero(props: ProfileHeroProps) {
 							)}
 						</div>
 						{attributionMode === 'empowered' && (
-							<Logo width={80} height={65} className={badge()} />
+							<Logo className={badge()} />
 						)}
 					</div>
 					<div className={content()}>

--- a/src/ui/ProfileHero.tsx
+++ b/src/ui/ProfileHero.tsx
@@ -1,5 +1,6 @@
 import Image from 'next/image';
 import { cn, tv } from './_lib/utils.ts';
+import { Anchor } from './Anchor.tsx';
 import { Container } from './Container.tsx';
 import { Text } from './Text.tsx';
 import { ResponsiveImage } from './ResponsiveImage.tsx';
@@ -31,7 +32,8 @@ const styles = tv({
 		imageWrapper: 'relative z-20 flex-shrink-0 md:-mb-[104px] lg:-mb-[216px]',
 		// Circular portrait straddling the dark band and the cream content below.
 		image: 'relative rounded-full overflow-hidden w-40 h-40 md:w-72 md:h-72 lg:w-[416px] lg:h-[416px]',
-		badge: 'absolute -bottom-4 left-1/2 -translate-x-1/2 z-30 drop-shadow-md',
+		// GoodParty logo overlaid on the photo's bottom-right corner (Figma).
+		badge: 'absolute bottom-1 right-1 z-30 drop-shadow-md',
 		content: 'flex flex-col gap-4 text-left z-10 md:pt-2',
 		tagRow: 'flex flex-wrap items-center gap-2',
 		// Pill CONTAINER only (shape + color). The text size lives on an inner span,
@@ -41,15 +43,10 @@ const styles = tv({
 		// Inner text span: 14px medium Open Sans (Figma tag). No color here → nothing
 		// for merge to collapse it against; color is inherited from the container.
 		tagText: 'font-secondary text-[0.875rem] font-medium',
-		// Pledge pill sits in the SAME row as the persona tags so it costs no vertical
-		// height. It previously rendered as its own full-width band under the hero,
-		// which is dead space the design does not have (and it collided with the
-		// straddling portrait once the hero stopped reserving the photo's full height).
-		// Styled as the Figma "Pro Blocks / Tagline" (yellow fill), matching the persona tag.
-		pledgeTag: 'inline-flex w-fit items-center rounded-[6px] border border-gray-300 bg-bright-yellow-50 px-2.5 py-1 text-[color:#0a0a0a] shadow-xs',
 		nameOffice: 'flex flex-col gap-2',
 		heading: '',
 		office: '',
+		officeLink: 'hover:underline',
 		attribution: 'flex items-center justify-start gap-1.5',
 		attributionIcon: 'w-[37px] h-[28px]',
 		attributionText: 'text-sm',
@@ -75,6 +72,22 @@ const styles = tv({
 				notEndorsed: 'text-gray-500',
 			},
 		},
+		// People profiles use a smaller desktop portrait (Emily/Jack: the 416px
+		// avatar pushed the sidebar entirely below the fold). Shrinking it to 320px
+		// on lg moves the straddle overhang from 216→120px so the sidebar's leading
+		// rows sit partially above the fold. The overhang MUST stay in lockstep with
+		// ProfileContentBlock's sidebar clearance (overhang = avatarSize − 200).
+		// `default` preserves the shared /candidate hero unchanged.
+		portrait: {
+			default: {},
+			compact: {
+				image: 'lg:w-[320px] lg:h-[320px]',
+				imageWrapper: 'lg:-mb-[120px]',
+			},
+		},
+	},
+	defaultVariants: {
+		portrait: 'default',
 	},
 });
 
@@ -83,11 +96,17 @@ export type ProfileHeroProps = {
 	backgroundColor?: (typeof backgroundTypeValues)[number];
 	candidateName: string;
 	office: string;
+	/** When set, the office line renders as a link to the office/position page. */
+	officeHref?: string;
 	profileImage?: SanityImage;
 	profileImageUrl?: string;
 	isEmpowered?: boolean;
-	/** Renders a "Took the GoodParty.org Pledge" pill alongside the persona tags. */
-	pledged?: boolean;
+	/**
+	 * People profiles use a smaller (320px) desktop portrait so the sidebar's
+	 * leading rows sit partially above the fold. Defaults to the full 416px
+	 * portrait used by the shared /candidate hero.
+	 */
+	compactPortrait?: boolean;
 	/** Persona tag pills rendered above the name (e.g. "Candidate", "Incumbent"). Renders nothing when empty. */
 	tags?: string[];
 	/**
@@ -100,7 +119,7 @@ export type ProfileHeroProps = {
 export function ProfileHero(props: ProfileHeroProps) {
 	const backgroundColor = props.backgroundColor ?? 'midnight';
 	const resolvedBackgroundColor = backgroundColor === 'white' ? 'cream' : backgroundColor;
-	const { base, backgroundWrapper, band, belowBand, container, imageWrapper, image, badge, content, tagRow, tag, tagText, pledgeTag, nameOffice, heading, office, attribution, attributionIcon, attributionText, notEndorsed } = styles({ backgroundColor: resolvedBackgroundColor });
+	const { base, backgroundWrapper, band, belowBand, container, imageWrapper, image, badge, content, tagRow, tag, tagText, nameOffice, heading, office, officeLink, attribution, attributionIcon, attributionText, notEndorsed } = styles({ backgroundColor: resolvedBackgroundColor, portrait: props.compactPortrait ? 'compact' : 'default' });
 
 	// `attribution` wins when provided; otherwise fall back to legacy `isEmpowered`.
 	const attributionMode = props.attribution ?? (props.isEmpowered ? 'empowered' : 'none');
@@ -141,23 +160,18 @@ export function ProfileHero(props: ProfileHeroProps) {
 								</div>
 							)}
 						</div>
-						{props.isEmpowered && (
+						{attributionMode === 'empowered' && (
 							<Logo width={80} height={65} className={badge()} />
 						)}
 					</div>
 					<div className={content()}>
-						{(tags.length > 0 || props.pledged) && (
+						{tags.length > 0 && (
 							<div className={tagRow()}>
 								{tags.map((label) => (
 									<span key={label} className={tag()}>
 										<span className={tagText()}>{label}</span>
 									</span>
 								))}
-								{props.pledged && (
-									<span className={pledgeTag()}>
-										<span className={tagText()}>Took the GoodParty.org Pledge</span>
-									</span>
-								)}
 							</div>
 						)}
 						<div className={nameOffice()}>
@@ -165,7 +179,13 @@ export function ProfileHero(props: ProfileHeroProps) {
 								{props.candidateName}
 							</Text>
 							<Text as="p" styleType="subtitle-1" className={office()}>
-								{props.office}
+								{props.officeHref ? (
+									<Anchor href={props.officeHref} className={officeLink()}>
+										{props.office}
+									</Anchor>
+								) : (
+									props.office
+								)}
 							</Text>
 						</div>
 						{attributionMode === 'empowered' && (


### PR DESCRIPTION
## Summary

Implements the batch of design/data feedback on the public `/people` profile pages (states A–L), driven off the real Figma frames (file `qIOT4lO1nRw4reuj6LjLwn`) via the Figma MCP. Extends the earlier alignment fixes on this branch.

Every pixel size, offset, container structure, and copy string below was derived from a live frame — the earlier guessed values (commit `784e34e`) were re-derived and corrected.

## Corrected speculative values (old → new, with source frame)

| Item | Guessed (784e34e) | Corrected | Source frame |
|---|---|---|---|
| Hero avatar size | 320px + `compactPortrait` variant | **416px** (reverted variant; original default was right) | A `1901:50320` Avatar = 416×417 |
| Straddle / sidebar clearance | 216→120 | reverted to md **104px** / lg **216px** (coupled to 416 avatar) | A `1928:96871` column offset |
| Empowered logo/badge | fixed `bottom-1 right-1`, 80×65 | responsive, bottom-right; lg **113×94** | A `1901:50322` Star icon (empowered icon 113×94) |
| Past-election disclaimer copy | placeholder | **verbatim** | G `1958:110869` / H `1970:113629` |
| Content-well container | one joined white box | **5 separate white cards**, `rounded-lg` (16px), 24px cream gaps | A `1928:96871` → card `1928:96873` |
| Below-hero CTA copy (claimed) | — | confirmed **verbatim** | A `1901:50391` CTA Block |

## What changed (by feedback item)

1. **Hero** — 416px avatar restored; empowered logo responsive bottom-right; pledge pill removed; attribution/logo gated on **claimed** (claimed → "Empowered by GoodParty.org" + logo; every unclaimed → "Not Endorsed by GoodParty.org", no logo); office line hyperlinked to the position page.
2. **Semantics** — D/E/F render "Not Endorsed" + no GP logo (verified live); H (past) shows the **past-election disclaimer, not the claim CTA** (verified live); contradictory `isPledged:true` dropped from unclaimed independents (D/F).
3. **Past-election disclaimer** — verbatim copy from G/H, styled as the Figma blue-100 "CTA Section Module" with a "Start exploring" button → `/elections`.
4. **Sections** — Campaign-Issue progress tags persona-gated (not for pure candidates); "Why I Serve/Served" removed (Why card is candidate/both only); "Other Candidates for {Position}" title-cased + empowered-first stable sort; **content restructured into Figma's 5 grouped white cards** (Why+Issues / About+Experience / Other Candidates / About Position / District), scoped to people profiles so `/candidate` keeps its joined layout; claimed CTA copy confirmed verbatim.
5. **Casing** — "Empowered by GoodParty.org" on `CandidatesCard` (landed in `7c51d70`, verified).
6. **Seed/data** — fixtures carry locality-bearing positions ("Mayor of Springfield", "Springfield City Council" w/ Ward 3); `composeView.officeName` falls back to the candidacy so candidate pages name the seat in "About …"/"Other Candidates for …"; accomplishments seeded only for office-holding personas (candidate A has none).
7. **Term length** — new optional `PersonOfficeHolder.electionFrequency`; renders "4 Years"/"1 Year"; dropped the inaccurate "in office since 20xx" (`Since {start}`). See flag below.
8. **Claim-form overlay** (`1901:51609`) — assessed; flagged (below), not implemented speculatively.

## Per-state parity status

Verified via live render against the running dev server (skill's direct-geometry method; the raster `harness/run.mjs` is deprecated per the skill and was **not** used). Visual pass done on A; structure/logic verified via live HTML for D/E/F/H.

| State | Persona / claim | Status |
|---|---|---|
| A | claimed candidate | 5-card structure, position headings, CTA verbatim, hero (visual pass) |
| B | claimed officeholder | logic (term "4 Years", office headings); not visually swept |
| C | claimed both | logic |
| D | unclaimed indep candidate | Not Endorsed, no logo, claim band (live) |
| E | unclaimed indep officeholder | Not Endorsed, no logo, claim band (live) |
| F | unclaimed indep both | Not Endorsed, no logo, claim band (live) |
| G | claimed past | disclaimer logic |
| H | unclaimed past | disclaimer, no claim CTA, Not Endorsed (live) |
| I / J | unclaimed major-party | logic (no CTA band, empowerment stripped) |
| K / L | removal | logic (noindex, content stripped) |

## Flags (ambiguous / needs input — not invented)

- **Term length (item 7):** the election-api persons spine does **not** populate `electionFrequency` today, so prod pages fall back to the served date range until the feed exposes it. Wired + demonstrated via fixtures. Wording "N Years" follows the existing `formatTermLength` convention.
- **"Other Candidates" locality:** frame reads "Other Candidates for [Position] in <Location>"; the view has no clean locality field distinct from position, so the "in <Location>" clause is omitted rather than invented.
- **Claim-form overlay (item 8):** our `ClaimProfileModal` already collects name+email and submits to `/api/people/claim-request`. Deltas vs `1901:51609`: (a) a **marketing-consent checkbox** ("Sign up for marketing communications…") — needs a backend consent-field contract before wiring; (b) title copy ("Ask [Name] to complete their profile…" vs our combined claim+notify framing); (c) Cancel/Submit vs "Notify {name}". Flagged for a product/backend decision rather than inventing the consent contract.
- **Section heading type sizes:** Figma uses 32px/24px for section headings; the shared card renders them at `subtitle-1`. Pre-existing; not changed in this pass.

## Blocked (only item)

- **Breadcrumbs** — the implementation-notes doc (Section 2) is a Google/ClickUp link that returns 401 (not shared). Left exactly as-is; no structure guessed.

## Env note

Did not modify `harness/config.mjs` `DEV_ORIGIN`; verified directly against the live worktree server on :3021 (`PEOPLE_DEV_FIXTURES=true`) per the skill's live-render method.

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun run lint` passes (0 errors)
- [x] `bun test` people matrix (59 pass)
- [x] Live render A–L (structure/logic); visual pass on A
- [ ] Reviewer visual pass on B/C/G officeholder + past frames at 1440px
