### PR TITLE
Add Postalytics tracking pixel to find-your-super-voters

### DIFF
--- a/src/app/[slug]/page.tsx
+++ b/src/app/[slug]/page.tsx
@@ -15,15 +15,18 @@ import { getFaqSlugMapForPage } from '~/lib/getCachedFaqSlugMap';
 import { HeaderBlock } from '~/ui/HeaderBlock';
 import { Container } from '~/ui/Container';
 import { PageSchema } from '~/ui/PageSchema';
+import { PostalyticsPixel } from '~/ui/PostalyticsPixel';
 import { buildWebPageSchema } from '~/lib/schema';
 import { toAbsoluteUrl } from '~/lib/url';
 import { SANITY_DOC_TYPE } from '~/lib/sanity-doc-types';
+
+const POSTALYTICS_PIXEL_SLUG = 'find-your-super-voters';
 
 // SSR per request so ExperimentResolver reads the visitor's AMP_* cookie and
 // resolves the variant on the server before HTML is sent (no client flicker).
 // `generateStaticParams` is intentionally omitted: it is a build-time API for
 // static generation and the Next.js docs only sanction combining it with
-// `force-static`. Pairing it with `force-dynamic` is contradictory and causes
+ // `force-static`. Pairing it with `force-dynamic` is contradictory and causes
 // dev/prod render differences. Unknown slugs are handled by `notFound()` below
 // and the sitemap enumerates landing pages via `src/lib/sitemap-entries.ts`.
 export const dynamic = 'force-dynamic';
@@ -62,6 +65,7 @@ export default async function Page(props: any) {
 		return (
 			<>
 				<PageSchema schema={landingSchema} />
+				{slug === POSTALYTICS_PIXEL_SLUG && <PostalyticsPixel />}
 				<Suspense fallback={<PageSections pageSections={controlSections} pageSlug={slug} faqSlugMap={faqSlugMap} />}>
 					<ExperimentResolver pageId={page._id} controlSections={controlSections} pageSlug={slug} faqSlugMap={faqSlugMap} />
 				</Suspense>

--- a/src/ui/PostalyticsPixel.tsx
+++ b/src/ui/PostalyticsPixel.tsx
@@ -1,0 +1,29 @@
+import Script from 'next/script';
+
+export function PostalyticsPixel() {
+	return (
+		<Script
+			id='postalytics-pixel'
+			strategy='afterInteractive'
+			dangerouslySetInnerHTML={{
+				__html: `
+var a;
+var rc = new RegExp('_bn_d=([^;]+)');
+var rq = new RegExp('_bn_d=([^&#]*)', 'i');
+var aq = rq.exec(window.location.href);
+if (aq != null) a=aq;
+else var ac = rc.exec(document.cookie);
+if (ac != null) a=ac;
+if (a != null) {
+  var _bn_d = a[1];
+  (function() {
+var pl = document.createElement('script'); pl.type = 'text/javascript'; pl.async = true;
+pl.src = ('https:' == document.location.protocol ? 'https://app' : 'http://app') + '.postaladmin.com/plDataEmbed.js';
+var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(pl, s);
+  })();
+}
+				`,
+			}}
+		/>
+	);
+}


### PR DESCRIPTION
The Aug Election direct mail campaign QR codes land on `/find-your-super-voters`. Postalytics needs its tracking snippet on that page so post-scan visits can be attributed.

## Behavior

- Renders the Postalytics snippet only on the `find-your-super-voters` landing page (hardcoded slug gate in the Sanity `[slug]` route).
- Uses `next/script` with `afterInteractive`, matching Facebook Pixel / Segment. The ticket asked for `<head>`; Next only allows `beforeInteractive` in the root layout, which would install the pixel sitewide. Vendor behavior is unchanged: the snippet only loads `plDataEmbed.js` when `_bn_d` is present in the URL or cookie.
- Eyeball the Vercel preview on `/find-your-super-voters?_bn_d=test` (vendor script should load) and confirm the homepage HTML does not include the snippet.
