### PR TITLE
fix(people): cache people sitemap data across alphabetical shards

### DIFF
--- a/src/lib/sitemap-entries.test.ts
+++ b/src/lib/sitemap-entries.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, test } from 'bun:test';
+import { afterAll, describe, expect, test } from 'bun:test';
 import {
 	buildCountyLookups,
 	buildRaceEntries,
 	buildRaceRouteParams,
 	chunkArray,
+	fetchPeopleSitemapEntries,
 	getSitemapIds,
 	normalizeName,
 	peopleShardForSlug,
@@ -41,6 +42,57 @@ describe('people sitemap shards', () => {
 		// The set is a contiguous 0..last with no gaps or dupes (ids are emitted
 		// interleaved by band, so compare the sorted set).
 		expect([...ids].sort((a, b) => a - b)).toEqual([...Array(expectedLength).keys()]);
+	});
+});
+
+describe('fetchPeopleSitemapEntries cache', () => {
+	const originalFetch = globalThis.fetch;
+	const aliceId = 'aaaaaaaa-1111-2222-3333-444444444444';
+	const bobId = 'bbbbbbbb-1111-2222-3333-444444444444';
+
+	afterAll(() => {
+		globalThis.fetch = originalFetch;
+	});
+
+	test('shards share one gp-api + election-api round-trip', async () => {
+		const urls: string[] = [];
+		globalThis.fetch = (async (input: RequestInfo | URL) => {
+			const url = String(input);
+			urls.push(url);
+			if (url.includes('public-person-profiles/published')) {
+				return new Response(
+					JSON.stringify([
+						{ personId: aliceId, updatedAt: '2026-01-15T00:00:00.000Z' },
+						{ personId: bobId, updatedAt: '2026-02-01T00:00:00.000Z' },
+					]),
+					{ status: 200, headers: { 'content-type': 'application/json' } },
+				);
+			}
+			if (url.includes('/v1/persons')) {
+				return new Response(
+					JSON.stringify([
+						{ id: aliceId, slug: 'alice-smith' },
+						{ id: bobId, slug: 'bob-jones' },
+					]),
+					{ status: 200, headers: { 'content-type': 'application/json' } },
+				);
+			}
+			return new Response(JSON.stringify([]), { status: 200 });
+		}) as typeof fetch;
+
+		const base = 'https://goodparty.org';
+		const [aShard, bShard] = await Promise.all([
+			fetchPeopleSitemapEntries(base, 'a'),
+			fetchPeopleSitemapEntries(base, 'b'),
+		]);
+
+		const gpCalls = urls.filter((u) => u.includes('public-person-profiles/published'));
+		const personCalls = urls.filter((u) => u.includes('/v1/persons'));
+		expect(gpCalls).toHaveLength(1);
+		expect(personCalls).toHaveLength(1);
+
+		expect(aShard.map((e) => e.url)).toEqual([`${base}/people/alice-smith-aaaaaaaa`]);
+		expect(bShard.map((e) => e.url)).toEqual([`${base}/people/bob-jones-bbbbbbbb`]);
 	});
 });
 

--- a/src/lib/sitemap-entries.test.ts
+++ b/src/lib/sitemap-entries.test.ts
@@ -49,24 +49,29 @@ describe('fetchPeopleSitemapEntries cache', () => {
 	const originalFetch = globalThis.fetch;
 	const aliceId = 'aaaaaaaa-1111-2222-3333-444444444444';
 	const bobId = 'bbbbbbbb-1111-2222-3333-444444444444';
+	const base = 'https://goodparty.org';
 
 	afterAll(() => {
 		globalThis.fetch = originalFetch;
 	});
 
-	test('shards share one gp-api + election-api round-trip', async () => {
+	test('empty upstream is not poisoned; concurrent shards then share one warm fetch', async () => {
 		const urls: string[] = [];
+		let serveEmpty = true;
 		globalThis.fetch = (async (input: RequestInfo | URL) => {
 			const url = String(input);
 			urls.push(url);
 			if (url.includes('public-person-profiles/published')) {
-				return new Response(
-					JSON.stringify([
-						{ personId: aliceId, updatedAt: '2026-01-15T00:00:00.000Z' },
-						{ personId: bobId, updatedAt: '2026-02-01T00:00:00.000Z' },
-					]),
-					{ status: 200, headers: { 'content-type': 'application/json' } },
-				);
+				const body = serveEmpty
+					? []
+					: [
+							{ personId: aliceId, updatedAt: '2026-01-15T00:00:00.000Z' },
+							{ personId: bobId, updatedAt: '2026-02-01T00:00:00.000Z' },
+						];
+				return new Response(JSON.stringify(body), {
+					status: 200,
+					headers: { 'content-type': 'application/json' },
+				});
 			}
 			if (url.includes('/v1/persons')) {
 				return new Response(
@@ -80,17 +85,21 @@ describe('fetchPeopleSitemapEntries cache', () => {
 			return new Response(JSON.stringify([]), { status: 200 });
 		}) as typeof fetch;
 
-		const base = 'https://goodparty.org';
+		const empty = await fetchPeopleSitemapEntries(base, 'a');
+		expect(empty).toEqual([]);
+		expect(urls.filter((u) => u.includes('public-person-profiles/published'))).toHaveLength(1);
+		expect(urls.filter((u) => u.includes('/v1/persons'))).toHaveLength(0);
+
+		serveEmpty = false;
+		urls.length = 0;
+
 		const [aShard, bShard] = await Promise.all([
 			fetchPeopleSitemapEntries(base, 'a'),
 			fetchPeopleSitemapEntries(base, 'b'),
 		]);
 
-		const gpCalls = urls.filter((u) => u.includes('public-person-profiles/published'));
-		const personCalls = urls.filter((u) => u.includes('/v1/persons'));
-		expect(gpCalls).toHaveLength(1);
-		expect(personCalls).toHaveLength(1);
-
+		expect(urls.filter((u) => u.includes('public-person-profiles/published'))).toHaveLength(1);
+		expect(urls.filter((u) => u.includes('/v1/persons'))).toHaveLength(1);
 		expect(aShard.map((e) => e.url)).toEqual([`${base}/people/alice-smith-aaaaaaaa`]);
 		expect(bShard.map((e) => e.url)).toEqual([`${base}/people/bob-jones-bbbbbbbb`]);
 	});

--- a/src/lib/sitemap-entries.test.ts
+++ b/src/lib/sitemap-entries.test.ts
@@ -4,6 +4,7 @@ import {
 	buildRaceEntries,
 	buildRaceRouteParams,
 	chunkArray,
+	clearPeopleSitemapCache,
 	fetchPeopleSitemapEntries,
 	getSitemapIds,
 	normalizeName,
@@ -53,6 +54,7 @@ describe('fetchPeopleSitemapEntries cache', () => {
 
 	afterAll(() => {
 		globalThis.fetch = originalFetch;
+		clearPeopleSitemapCache();
 	});
 
 	test('empty upstream is not poisoned; concurrent shards then share one warm fetch', async () => {

--- a/src/lib/sitemap-entries.test.ts
+++ b/src/lib/sitemap-entries.test.ts
@@ -58,6 +58,7 @@ describe('fetchPeopleSitemapEntries cache', () => {
 	});
 
 	test('empty upstream is not poisoned; concurrent shards then share one warm fetch', async () => {
+		clearPeopleSitemapCache();
 		const urls: string[] = [];
 		let serveEmpty = true;
 		globalThis.fetch = (async (input: RequestInfo | URL) => {
@@ -104,6 +105,51 @@ describe('fetchPeopleSitemapEntries cache', () => {
 		expect(urls.filter((u) => u.includes('/v1/persons'))).toHaveLength(1);
 		expect(aShard.map((e) => e.url)).toEqual([`${base}/people/alice-smith-aaaaaaaa`]);
 		expect(bShard.map((e) => e.url)).toEqual([`${base}/people/bob-jones-bbbbbbbb`]);
+	});
+
+	test('empty election-api persons is not poisoned while published ids exist', async () => {
+		clearPeopleSitemapCache();
+		const urls: string[] = [];
+		let servePersons = false;
+		globalThis.fetch = (async (input: RequestInfo | URL) => {
+			const url = String(input);
+			urls.push(url);
+			if (url.includes('public-person-profiles/published')) {
+				return new Response(
+					JSON.stringify([
+						{ personId: aliceId, updatedAt: '2026-01-15T00:00:00.000Z' },
+						{ personId: bobId, updatedAt: '2026-02-01T00:00:00.000Z' },
+					]),
+					{ status: 200, headers: { 'content-type': 'application/json' } },
+				);
+			}
+			if (url.includes('/v1/persons')) {
+				const body = servePersons
+					? [
+							{ id: aliceId, slug: 'alice-smith' },
+							{ id: bobId, slug: 'bob-jones' },
+						]
+					: [];
+				return new Response(JSON.stringify(body), {
+					status: 200,
+					headers: { 'content-type': 'application/json' },
+				});
+			}
+			return new Response(JSON.stringify([]), { status: 200 });
+		}) as typeof fetch;
+
+		const empty = await fetchPeopleSitemapEntries(base, 'a');
+		expect(empty).toEqual([]);
+		expect(urls.filter((u) => u.includes('public-person-profiles/published'))).toHaveLength(1);
+		expect(urls.filter((u) => u.includes('/v1/persons'))).toHaveLength(1);
+
+		servePersons = true;
+		urls.length = 0;
+
+		const recovered = await fetchPeopleSitemapEntries(base, 'a');
+		expect(urls.filter((u) => u.includes('public-person-profiles/published'))).toHaveLength(1);
+		expect(urls.filter((u) => u.includes('/v1/persons'))).toHaveLength(1);
+		expect(recovered.map((e) => e.url)).toEqual([`${base}/people/alice-smith-aaaaaaaa`]);
 	});
 });
 

--- a/src/lib/sitemap-entries.ts
+++ b/src/lib/sitemap-entries.ts
@@ -602,6 +602,11 @@ type PeopleSitemapData = {
 
 let cachedPeopleSitemapData: Promise<PeopleSitemapData> | null = null;
 
+/** Clears the module-level people sitemap cache. Used by tests. */
+export function clearPeopleSitemapCache(): void {
+	cachedPeopleSitemapData = null;
+}
+
 /**
  * Shared gp-api + election-api lookup for the /people sitemap band.
  * All 27 alphabetical shards call this; the Promise is hoisted so they share

--- a/src/lib/sitemap-entries.ts
+++ b/src/lib/sitemap-entries.ts
@@ -638,7 +638,13 @@ async function getCachedPeopleSitemapData(): Promise<PeopleSitemapData> {
 			).flat();
 
 			return { updatedByPersonId, persons };
-		})();
+		})().then((result) => {
+			// If the upstream returned empty data (indistinguishable from a transient
+			// error at this layer), clear the cache so the next request retries rather
+			// than serving poisoned empty sitemaps for the process lifetime.
+			if (result.updatedByPersonId.size === 0) cachedPeopleSitemapData = null;
+			return result;
+		});
 	}
 	return cachedPeopleSitemapData;
 }

--- a/src/lib/sitemap-entries.ts
+++ b/src/lib/sitemap-entries.ts
@@ -644,10 +644,11 @@ async function getCachedPeopleSitemapData(): Promise<PeopleSitemapData> {
 
 			return { updatedByPersonId, persons };
 		})().then((result) => {
-			// If the upstream returned empty data (indistinguishable from a transient
-			// error at this layer), clear the cache so the next request retries rather
-			// than serving poisoned empty sitemaps for the process lifetime.
-			if (result.updatedByPersonId.size === 0) cachedPeopleSitemapData = null;
+			// Empty published set or empty persons (indistinguishable from a swallowed
+			// gp-api / election-api failure) must not poison the process-lifetime cache.
+			if (result.updatedByPersonId.size === 0 || result.persons.length === 0) {
+				cachedPeopleSitemapData = null;
+			}
 			return result;
 		});
 	}

--- a/src/lib/sitemap-entries.ts
+++ b/src/lib/sitemap-entries.ts
@@ -593,6 +593,56 @@ export async function fetchStateElectionSitemapEntries(
 	return dedupeByUrl(entries);
 }
 
+type PeopleSitemapPerson = { id?: string; slug?: string | null };
+
+type PeopleSitemapData = {
+	updatedByPersonId: Map<string, string | undefined>;
+	persons: PeopleSitemapPerson[];
+};
+
+let cachedPeopleSitemapData: Promise<PeopleSitemapData> | null = null;
+
+/**
+ * Shared gp-api + election-api lookup for the /people sitemap band.
+ * All 27 alphabetical shards call this; the Promise is hoisted so they share
+ * a single upstream round-trip (mirrors getCachedElectionRouteParams).
+ */
+async function getCachedPeopleSitemapData(): Promise<PeopleSitemapData> {
+	if (!cachedPeopleSitemapData) {
+		cachedPeopleSitemapData = (async () => {
+			const published = await fetchGpApiJson<{ personId?: string; updatedAt?: string }>(
+				'v1/public-person-profiles/published',
+			);
+			const updatedByPersonId = new Map<string, string | undefined>();
+			for (const row of published) {
+				if (row.personId) updatedByPersonId.set(row.personId.toLowerCase(), row.updatedAt);
+			}
+
+			if (updatedByPersonId.size === 0) {
+				return { updatedByPersonId, persons: [] };
+			}
+
+			const ids = [...updatedByPersonId.keys()];
+			// election-api caps the `ids` filter at 500 (a larger list is rejected and
+			// returns []), so batch to avoid silently dropping published people.
+			const idBatches = chunkArray(ids, 500);
+			const persons = (
+				await Promise.all(
+					idBatches.map(async (batch) =>
+						fetchElectionJson<PeopleSitemapPerson>('v1/persons', {
+							ids: batch.join(','),
+							columns: 'id,slug',
+						}),
+					),
+				)
+			).flat();
+
+			return { updatedByPersonId, persons };
+		})();
+	}
+	return cachedPeopleSitemapData;
+}
+
 /**
  * Fetches public /people profile sitemap entries.
  *
@@ -600,35 +650,14 @@ export async function fetchStateElectionSitemapEntries(
  * personIds are live), election-api owns the authoritative, unique, clean
  * `Person.slug` that is the canonical URL. Anything gp-api reports as published
  * but that has no election-api Person yet is skipped (no slug → no page).
+ *
+ * Upstream fetches are shared across shards via getCachedPeopleSitemapData.
  */
 export async function fetchPeopleSitemapEntries(
 	baseUrl: string,
 	shard?: string,
 ): Promise<MetadataRoute.Sitemap> {
-	const published = await fetchGpApiJson<{ personId?: string; updatedAt?: string }>(
-		'v1/public-person-profiles/published',
-	);
-	if (published.length === 0) return [];
-
-	const updatedByPersonId = new Map<string, string | undefined>();
-	for (const row of published) {
-		if (row.personId) updatedByPersonId.set(row.personId.toLowerCase(), row.updatedAt);
-	}
-
-	const ids = [...updatedByPersonId.keys()];
-	// election-api caps the `ids` filter at 500 (a larger list is rejected and
-	// returns []), so batch to avoid silently dropping published people.
-	const idBatches = chunkArray(ids, 500);
-	const persons = (
-		await Promise.all(
-			idBatches.map(async (batch) =>
-				fetchElectionJson<{ id?: string; slug?: string | null }>('v1/persons', {
-					ids: batch.join(','),
-					columns: 'id,slug',
-				}),
-			),
-		)
-	).flat();
+	const { updatedByPersonId, persons } = await getCachedPeopleSitemapData();
 
 	const entries: MetadataRoute.Sitemap = [];
 	for (const p of persons) {


### PR DESCRIPTION
All 27 /people sitemap shards were independently fetching the full published list from gp-api and all matching persons from `election-api`. Hoist that lookup into a module-level promise so shards share one upstream round-trip, matching  `getCachedElectionRouteParams`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only caching with unchanged shard filtering and URL output; risk is limited to process-lifetime cache staleness, which matches existing election sitemap caching.
> 
> **Overview**
> **People sitemap shards no longer each hit gp-api and election-api on their own.** The published-profile list and batched person slug lookup are moved into `getCachedPeopleSitemapData`, backed by a module-level shared `Promise` (same idea as `getCachedElectionRouteParams`). `fetchPeopleSitemapEntries` only reads that cache and applies alphabetical shard filtering.
> 
> A test stubs `fetch` and asserts that concurrent calls for shards `a` and `b` trigger **one** `public-person-profiles/published` request and **one** `/v1/persons` request while still returning the correct per-shard URLs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04bda41e9d980cafe2a75f2d550e960551062385. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->