### PR TITLE
feat(people): integrate clearPeopleSitemapCache in revalidate-person …

### DIFF
--- a/src/app/api/revalidate-person/route.ts
+++ b/src/app/api/revalidate-person/route.ts
@@ -3,6 +3,7 @@ import { revalidateTag } from 'next/cache';
 import { type NextRequest, NextResponse } from 'next/server';
 import { personRevalidateSecret } from '~/lib/env';
 import { personCacheTag } from '~/lib/electionsApi';
+import { clearPeopleSitemapCache } from '~/lib/sitemap-entries';
 
 const SECRET_HEADER = 'x-revalidate-secret';
 const HMAC_KEY = 'personRevalidate';
@@ -48,6 +49,7 @@ export async function POST(req: NextRequest) {
 	try {
 		const tag = personCacheTag(personId);
 		revalidateTag(tag);
+		clearPeopleSitemapCache();
 		return NextResponse.json({ revalidated: true, tag });
 	} catch (err) {
 		// Log the detail server-side; don't echo the raw error text to the caller.

--- a/src/app/api/revalidate-person/route.ts
+++ b/src/app/api/revalidate-person/route.ts
@@ -3,7 +3,7 @@ import { revalidateTag } from 'next/cache';
 import { type NextRequest, NextResponse } from 'next/server';
 import { personRevalidateSecret } from '~/lib/env';
 import { personCacheTag } from '~/lib/electionsApi';
-import { clearPeopleSitemapCache } from '~/lib/sitemap-entries';
+import { clearPeopleSitemapCache, PEOPLE_SITEMAP_CACHE_TAG } from '~/lib/sitemap-entries';
 
 const SECRET_HEADER = 'x-revalidate-secret';
 const HMAC_KEY = 'personRevalidate';
@@ -49,6 +49,10 @@ export async function POST(req: NextRequest) {
 	try {
 		const tag = personCacheTag(personId);
 		revalidateTag(tag);
+		// Bust the Next.js data cache for people-sitemap upstream fetches across
+		// all instances, then drop this instance's in-memory Promise so shards
+		// re-seed from the freshly invalidated cache.
+		revalidateTag(PEOPLE_SITEMAP_CACHE_TAG);
 		clearPeopleSitemapCache();
 		return NextResponse.json({ revalidated: true, tag });
 	} catch (err) {

--- a/src/lib/sitemap-entries.ts
+++ b/src/lib/sitemap-entries.ts
@@ -602,7 +602,7 @@ type PeopleSitemapData = {
 
 let cachedPeopleSitemapData: Promise<PeopleSitemapData> | null = null;
 
-/** Clears the module-level people sitemap cache. Used by tests. */
+/** Clears the module-level people sitemap cache. Used by revalidate-person and tests. */
 export function clearPeopleSitemapCache(): void {
 	cachedPeopleSitemapData = null;
 }

--- a/src/lib/sitemap-entries.ts
+++ b/src/lib/sitemap-entries.ts
@@ -66,6 +66,16 @@ const GP_API_BASE =
 
 const CACHE_1H: RequestInit = { next: { revalidate: 3600 } };
 
+/** Next.js data-cache tag for the /people sitemap upstream fetches. Bust via revalidateTag. */
+export const PEOPLE_SITEMAP_CACHE_TAG = 'people-sitemap';
+
+function cacheInit(tags?: readonly string[]): RequestInit {
+	if (tags && tags.length > 0) {
+		return { next: { revalidate: 3600, tags: [...tags] } };
+	}
+	return CACHE_1H;
+}
+
 export type CountyPlace = { slug?: string; name?: string; mtfcc?: string };
 export type CityPlace = { slug?: string; countyName?: string };
 export type RaceEntry = { slug?: string; positionLevel?: string };
@@ -404,10 +414,10 @@ export async function getCachedElectionRouteParams(): Promise<{
 	return cachedElectionRouteParams;
 }
 
-async function fetchGpApiJson<T>(path: string): Promise<T[]> {
+async function fetchGpApiJson<T>(path: string, tags?: readonly string[]): Promise<T[]> {
 	const url = `${GP_API_BASE.replace(/\/$/, '')}/${path.replace(/^\//, '')}`;
 	try {
-		const res = await fetch(url, CACHE_1H);
+		const res = await fetch(url, cacheInit(tags));
 		if (!res.ok) {
 			console.error(`[sitemap] gp-api ${res.status} ${url}`);
 			return [];
@@ -420,11 +430,15 @@ async function fetchGpApiJson<T>(path: string): Promise<T[]> {
 	}
 }
 
-async function fetchElectionJson<T>(path: string, params: Record<string, string>): Promise<T[]> {
+async function fetchElectionJson<T>(
+	path: string,
+	params: Record<string, string>,
+	tags?: readonly string[],
+): Promise<T[]> {
 	const search = new URLSearchParams(params).toString();
 	const url = `${ELECTION_API_BASE.replace(/\/$/, '')}/${path.replace(/^\//, '')}?${search}`;
 	try {
-		const res = await fetch(url, CACHE_1H);
+		const res = await fetch(url, cacheInit(tags));
 		if (!res.ok) {
 			console.error(`[sitemap] Election API ${res.status} ${url}`);
 			return [];
@@ -602,21 +616,27 @@ type PeopleSitemapData = {
 
 let cachedPeopleSitemapData: Promise<PeopleSitemapData> | null = null;
 
-/** Clears the module-level people sitemap cache. Used by revalidate-person and tests. */
+/**
+ * Clears the process-local in-flight Promise (same instance only).
+ * Pair with revalidateTag(PEOPLE_SITEMAP_CACHE_TAG) so other instances hit a
+ * fresh Next.js data cache on next access. Used by revalidate-person and tests.
+ */
 export function clearPeopleSitemapCache(): void {
 	cachedPeopleSitemapData = null;
 }
 
 /**
  * Shared gp-api + election-api lookup for the /people sitemap band.
- * All 27 alphabetical shards call this; the Promise is hoisted so they share
- * a single upstream round-trip (mirrors getCachedElectionRouteParams).
+ * Concurrent shard callers share one in-flight Promise; once it settles the
+ * module slot clears so the next access goes through the tagged Next.js data
+ * cache (mirrors Sanity sitemap revalidateTag busting).
  */
 async function getCachedPeopleSitemapData(): Promise<PeopleSitemapData> {
 	if (!cachedPeopleSitemapData) {
-		cachedPeopleSitemapData = (async () => {
+		const load = (async (): Promise<PeopleSitemapData> => {
 			const published = await fetchGpApiJson<{ personId?: string; updatedAt?: string }>(
 				'v1/public-person-profiles/published',
+				[PEOPLE_SITEMAP_CACHE_TAG],
 			);
 			const updatedByPersonId = new Map<string, string | undefined>();
 			for (const row of published) {
@@ -634,22 +654,25 @@ async function getCachedPeopleSitemapData(): Promise<PeopleSitemapData> {
 			const persons = (
 				await Promise.all(
 					idBatches.map(async (batch) =>
-						fetchElectionJson<PeopleSitemapPerson>('v1/persons', {
-							ids: batch.join(','),
-							columns: 'id,slug',
-						}),
+						fetchElectionJson<PeopleSitemapPerson>(
+							'v1/persons',
+							{
+								ids: batch.join(','),
+								columns: 'id,slug',
+							},
+							[PEOPLE_SITEMAP_CACHE_TAG],
+						),
 					),
 				)
 			).flat();
 
 			return { updatedByPersonId, persons };
-		})().then((result) => {
-			// Empty published set or empty persons (indistinguishable from a swallowed
-			// gp-api / election-api failure) must not poison the process-lifetime cache.
-			if (result.updatedByPersonId.size === 0 || result.persons.length === 0) {
+		})();
+		cachedPeopleSitemapData = load;
+		void load.finally(() => {
+			if (cachedPeopleSitemapData === load) {
 				cachedPeopleSitemapData = null;
 			}
-			return result;
 		});
 	}
 	return cachedPeopleSitemapData;


### PR DESCRIPTION
…route

Enhances the POST handler in the revalidate-person API to clear the people sitemap cache upon revalidation. This ensures that the sitemap reflects the most current data after a person is revalidated. Additionally, updates the clearPeopleSitemapCache function documentation to indicate its usage in both revalidation and testing contexts.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small addition to an existing secret-protected revalidation path; only invalidates process-local sitemap caching alongside the existing tag revalidation.
> 
> **Overview**
> When gp-api triggers **on-demand person revalidation**, the handler still busts the per-person cache tag, and now also calls **`clearPeopleSitemapCache()`** so the module-level promise that backs all `/people` sitemap shards is dropped and the next sitemap build refetches published profiles and slugs.
> 
> The **`clearPeopleSitemapCache`** doc comment is updated to note it is used from the revalidate route as well as tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67a909f7a96f50752afe70f232df11ac7f7ac00a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->