### PR TITLE
Enhance background color handling and add tests for `resolveBg`

### DIFF
--- a/docs/adding-a-component.md
+++ b/docs/adding-a-component.md
@@ -224,6 +224,8 @@ export function ClickToCallBlockSection(section: Extract<Sections, { _type: 'com
 
 The `resolve*` helpers live in `src/ui/_lib/`. Reuse them; do not reinvent color or background logic.
 
+Always run `field_blockColorCreamMidnight` through `resolveBg` before passing it to a UI component. Content uses two spellings for the same setting (`Cream`/`MidnightDark` from the shared field, and `cream`/`midnight` from some block-local dropdowns). `resolveBg` accepts both; raw values will not match the component's style variants and the block will render with the wrong colors.
+
 ### 6. Wire the switch (`index.tsx`)
 
 Two edits, same file. Add the import near the other section imports:

--- a/src/PageSections/ListOfOfficesBlockSection.tsx
+++ b/src/PageSections/ListOfOfficesBlockSection.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { stegaClean } from 'next-sanity';
-import type { Field_blockColorCreamMidnight } from 'sanity.types';
 
 import { formatElectionDateFromApi } from '~/lib/electionsHelpers';
 import type { TokenMap } from '~/lib/resolveTokens';
@@ -20,7 +19,7 @@ export function ListOfOfficesBlockSection(props: Props) {
 	const { officesOverride, tokens, ...section } = props;
 	const search = useElectionsLandingSearch();
 	const bgValue = section.listOfOfficesBlockDesignSettings?.field_blockColorCreamMidnight;
-	const backgroundColor = bgValue ? resolveBg(stegaClean(bgValue) as Field_blockColorCreamMidnight) : 'cream';
+	const backgroundColor = bgValue ? resolveBg(stegaClean(bgValue)) : 'cream';
 
 	const offices: OfficeItem[] =
 		officesOverride?.offices ??

--- a/src/PageSections/LocationLandingPageHeroSection.tsx
+++ b/src/PageSections/LocationLandingPageHeroSection.tsx
@@ -6,6 +6,7 @@ import type { SectionOverrides, Sections } from '~/PageSections';
 import { resolveSectionText } from '~/lib/resolveSectionText';
 import type { TokenMap } from '~/lib/resolveTokens';
 import { LocationLandingPageHero } from '~/ui/LocationLandingPageHero';
+import { resolveBg } from '~/ui/_lib/resolveBg';
 import { useElectionsLandingSearch } from '~/ui/ElectionsLandingSearchContext';
 
 type Props = Extract<Sections, { _type: 'component_locationLandingPageHero' }> & {
@@ -17,7 +18,7 @@ export function LocationLandingPageHeroSection(props: Props) {
 	const { locationOverride, tokens, ...section } = props;
 	const search = useElectionsLandingSearch();
 	const backgroundColor = section.locationLandingPageHeroDesignSettings?.field_blockColorCreamMidnight
-		? stegaClean(section.locationLandingPageHeroDesignSettings.field_blockColorCreamMidnight)
+		? resolveBg(stegaClean(section.locationLandingPageHeroDesignSettings.field_blockColorCreamMidnight))
 		: 'midnight';
 
 	const locationLevel = locationOverride?.locationLevel ?? 'state';

--- a/src/ui/LocationLandingPageHero.tsx
+++ b/src/ui/LocationLandingPageHero.tsx
@@ -7,7 +7,7 @@ import { IconWrapper } from './IconResolver.tsx';
 
 const styles = tv({
 	slots: {
-		base: 'py-6 md:py-20',
+		base: 'pt-6 pb-6 md:pt-20 md:pb-10',
 		content: 'flex flex-col gap-6',
 		headline: '',
 		bodyCopy: 'text-white/80 max-w-[50rem]',

--- a/src/ui/_lib/resolveBg.test.ts
+++ b/src/ui/_lib/resolveBg.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from 'bun:test';
+import { resolveBg } from './resolveBg';
+
+describe('resolveBg', () => {
+	test('maps CMS midnight value', () => {
+		expect(resolveBg('midnight')).toBe('midnight');
+	});
+
+	test('maps legacy MidnightDark value from static templates', () => {
+		expect(resolveBg('MidnightDark')).toBe('midnight');
+	});
+
+	test('maps CMS cream value', () => {
+		expect(resolveBg('cream')).toBe('cream');
+	});
+
+	test('maps legacy Cream value from static templates', () => {
+		expect(resolveBg('Cream')).toBe('cream');
+	});
+
+	test('defaults to cream when unset', () => {
+		expect(resolveBg(undefined)).toBe('cream');
+	});
+});

--- a/src/ui/_lib/resolveBg.ts
+++ b/src/ui/_lib/resolveBg.ts
@@ -1,11 +1,6 @@
 import { stegaClean } from 'next-sanity';
-import type { Field_blockColorCreamMidnight } from 'sanity.types';
 
-export function resolveBg(background: Field_blockColorCreamMidnight) {
-	const bgMap: Record<Field_blockColorCreamMidnight, 'cream' | 'midnight'> = {
-		Cream: 'cream',
-		MidnightDark: 'midnight',
-	};
-
-	return bgMap[stegaClean(background)] ?? 'cream';
+export function resolveBg(background?: string): 'cream' | 'midnight' {
+	const value = stegaClean(background);
+	return value === 'midnight' || value === 'MidnightDark' ? 'midnight' : 'cream';
 }


### PR DESCRIPTION
Updated the background color logic in ListOfOfficesBlockSection and `LocationLandingPageHeroSection` to utilize the resolveBg function for consistent color mapping. Added a new test suite for the `resolveBg` function to ensure correct mapping of CMS and legacy color values. Adjusted styles in `LocationLandingPageHero` for better spacing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized presentation and helper changes with tests; fixes incorrect hero colors rather than altering auth or data paths.
> 
> **Overview**
> **`resolveBg`** now takes an optional `string` and maps both CMS values (`cream`/`midnight`) and legacy Sanity values (`Cream`/`MidnightDark`) to the UI variants, defaulting to `cream` when unset. Unit tests cover those mappings.
> 
> **`LocationLandingPageHeroSection`** routes `field_blockColorCreamMidnight` through **`resolveBg`** instead of passing the raw CMS string, so hero background variants match the component. **`ListOfOfficesBlockSection`** drops an unnecessary type cast while using the same helper.
> 
> **`docs/adding-a-component.md`** documents that block wrappers must always pipe `field_blockColorCreamMidnight` through **`resolveBg`**.
> 
> **`LocationLandingPageHero`** spacing is adjusted (asymmetric bottom padding on desktop: `md:pb-10` vs `md:pt-20`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15285837436e24e41a9ef9d563ec41b8d4cce911. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->