### PR TITLE
fix(people): drive profile section order per persona from data, locked by tests

### DIFF
--- a/.claude/skills/marketing-ui-clone/SKILL.md
+++ b/.claude/skills/marketing-ui-clone/SKILL.md
@@ -193,6 +193,59 @@ A state is at parity when every measured element is within a few px AND you have
 signed off visually on color, type, and the details geometry cannot see (shadows,
 radius, icons). Never declare parity from the number alone.
 
+## Section ORDER is per-state data, not a shared guess
+
+Geometry parity is only half the job — the frames also disagree about the ORDER
+and GROUPING of the content sections, and that is where this page kept
+regressing (the designer raised the same ordering bug four review rounds in a
+row). The cause each time was the same: one shared section list in code, tuned
+to whichever frame was open, silently wrong for the others.
+
+Before changing section order, read the order off EVERY affected frame and
+write it down. The four claimed frames genuinely differ:
+
+| | A candidate | B officeholder | C both | G past |
+|---|---|---|---|---|
+| opens with | Why + Campaign Issues | Top Priorities + Accomplishments | Why + Campaign Issues | About Me + Recent Experience |
+| Other Candidates | before About Position | absent | before Top Priorities | LAST |
+| About Position vs District | Position → District | **District → Position** | Position → District | **District → Position** |
+| Nearby Officials | absent | last | last | before Other Candidates |
+
+Rules that fall out of this, and that the code now encodes:
+
+- **Order is per persona.** `SECTION_ORDER` in `personSectionOverrides.tsx` maps
+  each persona to its section list, cites the frame node ids, and is the ONLY
+  thing that decides which sections a persona shows. Do not re-add a
+  `holdsOffice(...)`-style gate next to the content — two places to express
+  "candidates have no accomplishments" is how they drift apart.
+- **Lock it with a test.** `personSectionOverrides.test.ts` asserts the exact
+  heading sequence per state against the frame node ids. Ordering had NO test
+  before, which is why every regression reached the designer instead of CI. If
+  a frame changes, change the expectation and cite the new node id.
+- **Two sections can come from one field.** Figma C/G show "Campaign Issues"
+  (no status tags) and "Top Priorities While in Office" (status tags) as
+  separate sections; both are `view.issues`. Partition by the data that
+  distinguishes them (`issue.status`) rather than by persona. Seed fixtures for
+  BOTH kinds or a state silently collapses to one section — which is exactly
+  how C shipped "smooshed".
+- **Grouping is expressed by `group`, and adjacency matters.** Consecutive
+  cards sharing a `group` merge into one white card (`chunkCardGroups`). Two
+  sections that are adjacent in one state's order but must stay separate cards
+  (Nearby Officials and Other Candidates in G) need DIFFERENT group keys —
+  reusing one `people` group merges them the moment a frame puts them together.
+
+## Layer names lie; use structure + one `get_design_context` to confirm
+
+`get_metadata` is the cheap way to recover a frame's section order (sort the
+content column's children by `y`), but the layer names in this file are cloned
+junk — "Why Running", "About Me Header" and "Mailing Address Section" each name
+several unrelated sections. Identify sections by their STRUCTURE and by text
+width, then confirm with one `get_design_context` (or the frame screenshot) that
+returns real copy. Useful tells in this file: a 409px-wide "Top Issues Header"
+is "Top Priorities While in Office" while a 182px one is "Campaign Issues"; a
+"Mailing Address Section" carrying a tagline pill + button is a Recent
+Experience row; avatar + "Pro Blocks / Tagline" cards are a people section.
+
 ## Troubleshooting (lessons from real runs)
 
 - **Live doesn't match the source you expect? Verify the CURRENT source FIRST.**

--- a/.claude/skills/marketing-ui-clone/SKILL.md
+++ b/.claude/skills/marketing-ui-clone/SKILL.md
@@ -228,6 +228,15 @@ Rules that fall out of this, and that the code now encodes:
   distinguishes them (`issue.status`) rather than by persona. Seed fixtures for
   BOTH kinds or a state silently collapses to one section — which is exactly
   how C shipped "smooshed".
+- **Heading level follows position in the card, not the section.** The frames
+  give a card's FIRST section a 32/44 heading (Figma `typography/3xl`) and every
+  section stacked under it a 24/32 one (`typography/2xl`), both Outfit SemiBold
+  — so "Campaign Issues" is 32px when it leads a card and 24px when it sits
+  under "Why I'm Running for Office". `ProfileContentBlock` derives this from
+  the card's index within its chunk; never hardcode a level on a section.
+  Note these two sizes are FLAT: the frames use them on the mobile artboard
+  too, which is why `--text-section-heading` / `--text-section-subheading` are
+  omitted from the stepped `@media` blocks that scale the `heading-*` ramp.
 - **Grouping is expressed by `group`, and adjacency matters.** Consecutive
   cards sharing a `group` merge into one white card (`chunkCardGroups`). Two
   sections that are adjacent in one state's order but must stay separate cards

--- a/harness/FOLLOWUPS.md
+++ b/harness/FOLLOWUPS.md
@@ -282,16 +282,5 @@ workaround: keep text-size and text-color on different elements. **Proper fix
 (owner: design-system/tokens):** extend the tailwind-merge config with classGroups
 for the custom `text-*` sizes and the brand color scales so they stop colliding.
 
-### Section headings render 24px; Figma frames specify 32px
-
-Every content-section heading ("Campaign Issues", "About [Position]", …) renders
-at 24px because `Text` `styleType="h3"` is the largest heading the design system
-exposes below the hero, while the frames use a 32px heading. The nested
-"Accomplishments" sub-heading inside the in-office card is correctly one step
-smaller than its parent, so the hierarchy is right and only the absolute scale
-is off. Fixing it means adding a heading size to the design system rather than
-one-off classes on this page. Flag for design-system: reconcile the marketing
-heading ramp with the Figma type scale.
-
 <!-- Add rows as the loop uncovers genuine data gaps. Do NOT use this file to
      excuse real layout bugs — only true data/heatmap/chrome exceptions belong. -->

--- a/harness/FOLLOWUPS.md
+++ b/harness/FOLLOWUPS.md
@@ -282,5 +282,16 @@ workaround: keep text-size and text-color on different elements. **Proper fix
 (owner: design-system/tokens):** extend the tailwind-merge config with classGroups
 for the custom `text-*` sizes and the brand color scales so they stop colliding.
 
+### Section headings render 24px; Figma frames specify 32px
+
+Every content-section heading ("Campaign Issues", "About [Position]", …) renders
+at 24px because `Text` `styleType="h3"` is the largest heading the design system
+exposes below the hero, while the frames use a 32px heading. The nested
+"Accomplishments" sub-heading inside the in-office card is correctly one step
+smaller than its parent, so the hierarchy is right and only the absolute scale
+is off. Fixing it means adding a heading size to the design system rather than
+one-off classes on this page. Flag for design-system: reconcile the marketing
+heading ramp with the Figma type scale.
+
 <!-- Add rows as the loop uncovers genuine data gaps. Do NOT use this file to
      excuse real layout bugs — only true data/heatmap/chrome exceptions belong. -->

--- a/src/PageSections/ProfileHeroSection.tsx
+++ b/src/PageSections/ProfileHeroSection.tsx
@@ -27,6 +27,8 @@ export function ProfileHeroSection({ profileHeroOverride, tokens: _tokens, ...se
 				candidateName={candidateName}
 				office={office}
 				officeHref={profileHeroOverride?.officeHref}
+				secondaryOffice={profileHeroOverride?.secondaryOffice}
+				secondaryOfficeHref={profileHeroOverride?.secondaryOfficeHref}
 				profileImageUrl={profileHeroOverride?.profileImageUrl}
 				isEmpowered={profileHeroOverride?.isEmpowered}
 				tags={profileHeroOverride?.tags}

--- a/src/PageSections/index.tsx
+++ b/src/PageSections/index.tsx
@@ -109,6 +109,10 @@ export type SectionOverrides = {
 		office: string;
 		/** When set, the hero office line links to the office/position page. */
 		officeHref?: string;
+		/** Second office line for someone serving and running at once (Figma C). */
+		secondaryOffice?: string;
+		/** When set, the second office line links to its own position page. */
+		secondaryOfficeHref?: string;
 		profileImageUrl?: string;
 		isEmpowered?: boolean;
 		/** Persona tag pills shown above the name (e.g. "Candidate", "Incumbent"). */

--- a/src/components/people/personSectionOverrides.test.ts
+++ b/src/components/people/personSectionOverrides.test.ts
@@ -94,6 +94,37 @@ describe('profile section order matches the Figma frames', () => {
 	});
 });
 
+describe('unclaimed pages prompt for every section the claimed page would show', () => {
+	/**
+	 * The unclaimed frames (D 1917:88035, E 1917:88616, F 1917:89211,
+	 * H 1970:113629) carry a prompt per authored section, so a persona must not
+	 * lose one just because nobody has written it yet.
+	 */
+	test('state F — serving and running prompts for campaign AND in-office sections', () => {
+		// Guards the premise: if this fixture ever becomes claimed the assertions
+		// below would pass on authored content and stop testing the placeholders.
+		expect(getDevPersonProfileView('tim-ficken-0a951485')?.claimed).toBe(false);
+		const headings = sectionHeadings('tim-ficken-0a951485');
+		expect(headings).toContain('Campaign Issues');
+		expect(headings).toContain('Top Priorities While in Office');
+		expect(headings).toContain('Accomplishments During This Term');
+	});
+
+	test('state E — an officeholder prompts for their in-office record, not a campaign', () => {
+		const headings = sectionHeadings('rob-zotti-d8c578fb');
+		expect(headings).toContain('Top Priorities While in Office');
+		expect(headings).toContain('Accomplishments During This Term');
+		expect(headings).not.toContain('Campaign Issues');
+	});
+
+	test('state D — a candidate is never prompted for an in-office record', () => {
+		const headings = sectionHeadings('kim-byrd-b77f912d');
+		expect(headings).toContain('Campaign Issues');
+		expect(headings).not.toContain('Top Priorities While in Office');
+		expect(headings).not.toContain('Accomplishments During This Term');
+	});
+});
+
 describe('card grouping sets the Figma heading levels', () => {
 	/** Headings per white card: the first is the 32/44 one, the rest are 24/32. */
 	function headingsByCard(slug: string): string[][] {

--- a/src/components/people/personSectionOverrides.test.ts
+++ b/src/components/people/personSectionOverrides.test.ts
@@ -150,6 +150,17 @@ describe('card grouping sets the Figma heading levels', () => {
 		]);
 	});
 
+	test('state C keeps campaign issues and the in-office record in separate cards', () => {
+		// The original regression: both issue sections shared a group and merged
+		// into one card. sectionHeadings alone cannot catch that — it flattens.
+		const cards = headingsByCard('susan-overman-ad914b82');
+		expect(cards).toContainEqual(['Why I\u2019m Running for Office', 'Campaign Issues']);
+		expect(cards).toContainEqual([
+			'Top Priorities While in Office',
+			'Accomplishments During This Term',
+		]);
+	});
+
 	test('state G keeps nearby officials and other candidates in separate cards', () => {
 		const cards = headingsByCard('bill-fortner-61a42912');
 		expect(cards).toContainEqual(['Nearby Officials']);

--- a/src/components/people/personSectionOverrides.test.ts
+++ b/src/components/people/personSectionOverrides.test.ts
@@ -10,14 +10,18 @@
  */
 import { describe, expect, test } from 'bun:test';
 import { getDevPersonProfileView } from '~/lib/devPeopleProfileFixtures';
+import { chunkCardGroups } from '~/ui/_lib/chunkCardGroups';
 import { buildPersonSectionOverrides } from './personSectionOverrides';
+
+function contentCards(slug: string) {
+	const view = getDevPersonProfileView(slug);
+	if (!view) throw new Error(`no dev fixture for ${slug}`);
+	return buildPersonSectionOverrides(view).component_profileContentBlock?.contentCards ?? [];
+}
 
 /** Ordered headings of the content well, ignoring the chrome-less raw cards. */
 function sectionHeadings(slug: string): string[] {
-	const view = getDevPersonProfileView(slug);
-	if (!view) throw new Error(`no dev fixture for ${slug}`);
-	const cards = buildPersonSectionOverrides(view).component_profileContentBlock?.contentCards ?? [];
-	return cards.flatMap(card => (card.heading ? [card.heading] : []));
+	return contentCards(slug).flatMap(card => (card.heading ? [card.heading] : []));
 }
 
 describe('profile section order matches the Figma frames', () => {
@@ -87,6 +91,38 @@ describe('profile section order matches the Figma frames', () => {
 		expect(headings).not.toContain('Accomplishments During This Term');
 		expect(headings).not.toContain('Top Priorities While in Office');
 		expect(headings).not.toContain('Nearby Officials');
+	});
+});
+
+describe('card grouping sets the Figma heading levels', () => {
+	/** Headings per white card: the first is the 32/44 one, the rest are 24/32. */
+	function headingsByCard(slug: string): string[][] {
+		return chunkCardGroups(contentCards(slug))
+			.map(group => group.flatMap(card => (card.heading ? [card.heading] : [])))
+			.filter(headings => headings.length > 0);
+	}
+
+	test('state A pairs each lead section with its sub-section', () => {
+		expect(headingsByCard('allen-slagle-74eee01a')).toEqual([
+			['Why I\u2019m Running for Office', 'Campaign Issues'],
+			['About Me', 'Recent Experience'],
+			['Other Candidates for Mayor of Springfield'],
+			['About Mayor of Springfield'],
+			['District information'],
+		]);
+	});
+
+	test('accomplishments sit under the in-office priorities, not beside them', () => {
+		expect(headingsByCard('tracy-good-ecff49d3')[0]).toEqual([
+			'Top Priorities While in Office',
+			'Accomplishments During This Term',
+		]);
+	});
+
+	test('state G keeps nearby officials and other candidates in separate cards', () => {
+		const cards = headingsByCard('bill-fortner-61a42912');
+		expect(cards).toContainEqual(['Nearby Officials']);
+		expect(cards).toContainEqual(['Other Candidates for Springfield City Council']);
 	});
 });
 

--- a/src/components/people/personSectionOverrides.test.ts
+++ b/src/components/people/personSectionOverrides.test.ts
@@ -164,6 +164,10 @@ describe('hero', () => {
 		expect(hero?.secondaryOffice).toMatch(/^Candidate for /);
 		expect(hero?.office).not.toMatch(/^Candidate for /);
 		expect(hero?.tags).toEqual(['Incumbent', 'Candidate']);
+		// The position link belongs to the race being run, so it moves to the
+		// candidacy line and the held-office line above it stays unlinked.
+		expect(hero?.officeHref).toBeUndefined();
+		expect(hero?.secondaryOfficeHref).toContain('/elections/');
 	});
 
 	test('a candidate-only hero has no second office line', () => {

--- a/src/components/people/personSectionOverrides.test.ts
+++ b/src/components/people/personSectionOverrides.test.ts
@@ -33,8 +33,8 @@ describe('profile section order matches the Figma frames', () => {
 			'Recent Experience',
 			// A candidate-only person holds no seat, so the office name comes from
 			// the candidacy rather than a held office.
-			'Other Candidates for Mayor of Springfield',
-			'About Mayor of Springfield',
+			'Other Candidates for Springfield City Council',
+			'About Springfield City Council',
 			'District information',
 		]);
 	});
@@ -106,8 +106,8 @@ describe('card grouping sets the Figma heading levels', () => {
 		expect(headingsByCard('allen-slagle-74eee01a')).toEqual([
 			['Why I\u2019m Running for Office', 'Campaign Issues'],
 			['About Me', 'Recent Experience'],
-			['Other Candidates for Mayor of Springfield'],
-			['About Mayor of Springfield'],
+			['Other Candidates for Springfield City Council'],
+			['About Springfield City Council'],
 			['District information'],
 		]);
 	});
@@ -154,5 +154,14 @@ describe('breadcrumb', () => {
 			'Springfield City Council',
 			'Allen Slagle',
 		]);
+	});
+
+	test('every dev persona names one office in the trail, the hero, and the sections', () => {
+		for (const slug of ['allen-slagle-74eee01a', 'tracy-good-ecff49d3', 'susan-overman-ad914b82', 'bill-fortner-61a42912']) {
+			const view = getDevPersonProfileView(slug);
+			const positionCrumb = view!.breadcrumb.at(-2)?.label;
+			expect(positionCrumb).toBe(view!.officeName ?? undefined);
+			expect(sectionHeadings(slug)).toContain(`About ${positionCrumb}`);
+		}
 	});
 });

--- a/src/components/people/personSectionOverrides.test.ts
+++ b/src/components/people/personSectionOverrides.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Locks the profile content-section ORDER to the Figma frames.
+ *
+ * The order regressed repeatedly because it lived as one shared list while the
+ * frames actually differ per persona, and nothing asserted it. These cases are
+ * transcribed from the frames themselves:
+ *   A 1901:50309 (candidate)     B 1901:52117 (officeholder)
+ *   C 1901:53123 (both)          G 1958:110869 (past)
+ * If a frame changes, update the expectation here and cite the node id.
+ */
+import { describe, expect, test } from 'bun:test';
+import { getDevPersonProfileView } from '~/lib/devPeopleProfileFixtures';
+import { buildPersonSectionOverrides } from './personSectionOverrides';
+
+/** Ordered headings of the content well, ignoring the chrome-less raw cards. */
+function sectionHeadings(slug: string): string[] {
+	const view = getDevPersonProfileView(slug);
+	if (!view) throw new Error(`no dev fixture for ${slug}`);
+	const cards = buildPersonSectionOverrides(view).component_profileContentBlock?.contentCards ?? [];
+	return cards.flatMap(card => (card.heading ? [card.heading] : []));
+}
+
+describe('profile section order matches the Figma frames', () => {
+	test('state A — candidate meets other candidates before the office', () => {
+		expect(sectionHeadings('allen-slagle-74eee01a')).toEqual([
+			'Why I\u2019m Running for Office',
+			'Campaign Issues',
+			'About Me',
+			'Recent Experience',
+			// A candidate-only person holds no seat, so the office name comes from
+			// the candidacy rather than a held office.
+			'Other Candidates for Mayor of Springfield',
+			'About Mayor of Springfield',
+			'District information',
+		]);
+	});
+
+	test('state B — officeholder leads with the in-office record, district before office', () => {
+		expect(sectionHeadings('tracy-good-ecff49d3')).toEqual([
+			'Top Priorities While in Office',
+			'Accomplishments During This Term',
+			'About Me',
+			'Recent Experience',
+			'District information',
+			'About Springfield City Council',
+			'Nearby Officials',
+		]);
+	});
+
+	test('state C — serving and running keeps campaign and in-office issues separate', () => {
+		const headings = sectionHeadings('susan-overman-ad914b82');
+		expect(headings).toEqual([
+			'Why I\u2019m Running for Office',
+			'Campaign Issues',
+			'About Me',
+			'Recent Experience',
+			'Other Candidates for Springfield City Council',
+			'Top Priorities While in Office',
+			'Accomplishments During This Term',
+			'About Springfield City Council',
+			'District information',
+			'Nearby Officials',
+		]);
+		// The two issue sections must stay distinct — they were previously merged
+		// into a single card because every seeded issue carried a status.
+		expect(headings.filter(h => h === 'Campaign Issues')).toHaveLength(1);
+		expect(headings.filter(h => h === 'Top Priorities While in Office')).toHaveLength(1);
+	});
+
+	test('state G — past official opens with About Me and closes with other candidates', () => {
+		expect(sectionHeadings('bill-fortner-61a42912')).toEqual([
+			'About Me',
+			'Recent Experience',
+			'Why I Served',
+			'Campaign Issues',
+			'Top Priorities While in Office',
+			'Accomplishments During This Term',
+			'District information',
+			'About Springfield City Council',
+			'Nearby Officials',
+			'Other Candidates for Springfield City Council',
+		]);
+	});
+
+	test('a pure candidate never shows an in-office section', () => {
+		const headings = sectionHeadings('allen-slagle-74eee01a');
+		expect(headings).not.toContain('Accomplishments During This Term');
+		expect(headings).not.toContain('Top Priorities While in Office');
+		expect(headings).not.toContain('Nearby Officials');
+	});
+});
+
+describe('hero', () => {
+	test('state C shows the seat held above the candidacy', () => {
+		const view = getDevPersonProfileView('susan-overman-ad914b82');
+		const hero = buildPersonSectionOverrides(view!).component_profileHero;
+		expect(hero?.secondaryOffice).toMatch(/^Candidate for /);
+		expect(hero?.office).not.toMatch(/^Candidate for /);
+		expect(hero?.tags).toEqual(['Incumbent', 'Candidate']);
+	});
+
+	test('a candidate-only hero has no second office line', () => {
+		const view = getDevPersonProfileView('allen-slagle-74eee01a');
+		const hero = buildPersonSectionOverrides(view!).component_profileHero;
+		expect(hero?.secondaryOffice).toBeUndefined();
+		expect(hero?.office).toMatch(/^Candidate for /);
+	});
+});
+
+describe('breadcrumb', () => {
+	test('dev profiles render the full location trail, not just Elections > Name', () => {
+		const view = getDevPersonProfileView('allen-slagle-74eee01a');
+		expect(view!.breadcrumb.map(crumb => crumb.label)).toEqual([
+			'Elections',
+			'Wyoming',
+			'Laramie',
+			'Springfield',
+			'Springfield City Council',
+			'Allen Slagle',
+		]);
+	});
+});

--- a/src/components/people/personSectionOverrides.tsx
+++ b/src/components/people/personSectionOverrides.tsx
@@ -135,6 +135,7 @@ function personaTags(persona: PersonPersona): string[] {
 
 const CAMPAIGN_ISSUES_HEADING = 'Campaign Issues';
 const IN_OFFICE_ISSUES_HEADING = 'Top Priorities While in Office';
+const ACCOMPLISHMENTS_HEADING = 'Accomplishments During This Term';
 
 const STATUS_LABELS: Record<PersonProfileIssueStatus, string> = {
 	IN_PROGRESS: 'In Progress',
@@ -322,7 +323,7 @@ function buildAuthoredSections(view: PersonProfileView): SectionMap {
 	// from being set here.
 	if (view.accomplishments.length > 0) {
 		sections.accomplishments = {
-			heading: 'Accomplishments During This Term',
+			heading: ACCOMPLISHMENTS_HEADING,
 			content: (
 				<AccomplishmentsContent
 					accomplishments={view.accomplishments}
@@ -379,36 +380,62 @@ function issuesPrompt(view: PersonProfileView): string {
 	}
 }
 
+/** Copy for the "Top Priorities While in Office" placeholder prompt. */
+function inOfficePrompt(view: PersonProfileView): string {
+	const office = view.officeName ? ` in ${view.officeName}` : ' in office';
+	if (view.persona === 'past') {
+		return `Which priorities did ${view.displayName} focus on${office}? Their record will appear here once they claim their profile.`;
+	}
+	return `What is ${view.displayName} focused on${office}? Their priorities will appear here once they claim their profile.`;
+}
+
+/** Copy for the "Accomplishments During This Term" placeholder prompt. */
+function accomplishmentsPrompt(view: PersonProfileView): string {
+	const office = view.officeName ? ` in ${view.officeName}` : ' in office';
+	const verb = view.persona === 'past' ? 'did' : 'has';
+	const achieved = view.persona === 'past' ? 'achieve' : 'achieved';
+	return `What ${verb} ${view.displayName} ${achieved}${office}? Their accomplishments will appear here once they claim their profile.`;
+}
+
 /** Copy for the "About Me" placeholder prompt. */
 function aboutPrompt(view: PersonProfileView): string {
 	const office = view.officeName ? ` for ${view.officeName}` : '';
 	return `Get to know ${view.displayName}. Their background, experience, and story${office} will appear here once they claim their profile.`;
 }
 
+/** The sections a profile owner writes; the rest come from the civic spine. */
+const AUTHORED_SECTIONS = new Set<SectionKey>([
+	'why',
+	'campaignIssues',
+	'inOfficePriorities',
+	'accomplishments',
+	'aboutMe',
+]);
+
 /**
  * Placeholder prompt cards shown in the authored-cards slot for UNCLAIMED but
- * empowered pages (Figma states D/E/F/H). They mirror the authored cards' Figma
- * order and persona-aware headings (Why → Campaign Issues → About Me) but carry
- * muted, name + office prompt copy inviting engagement, since there is no
- * owner-authored content yet. Accomplishments is intentionally omitted (Figma
- * does not show a placeholder for it).
+ * empowered pages (Figma states D 1917:88035, E 1917:88616, F 1917:89211,
+ * H 1970:113629). The frames show a prompt for every authored section the
+ * claimed page would have, so this seeds from the persona's `SECTION_ORDER`
+ * rather than its own list — an unclaimed page must never advertise a
+ * different set of sections than its claimed counterpart. Copy is muted
+ * name + office prompt text, since there is no owner-authored content yet.
  */
 function buildAuthoredPlaceholderSections(view: PersonProfileView): SectionMap {
-	const issuesPlaceholder: ProfileContentCardProps = {
-		cardType: 'top-issues',
-		content: <PlaceholderPrompt>{issuesPrompt(view)}</PlaceholderPrompt>,
+	const prompt = (text: string) => <PlaceholderPrompt>{text}</PlaceholderPrompt>;
+	const placeholders: Record<string, ProfileContentCardProps> = {
+		why: { cardType: 'why-running', heading: whyHeading(view.persona), content: prompt(whyPrompt(view)) },
+		campaignIssues: { cardType: 'top-issues', heading: CAMPAIGN_ISSUES_HEADING, content: prompt(issuesPrompt(view)) },
+		inOfficePriorities: { cardType: 'top-issues', heading: IN_OFFICE_ISSUES_HEADING, content: prompt(inOfficePrompt(view)) },
+		accomplishments: { heading: ACCOMPLISHMENTS_HEADING, content: prompt(accomplishmentsPrompt(view)) },
+		aboutMe: { cardType: 'about-me', heading: 'About Me', content: prompt(aboutPrompt(view)) },
 	};
-	// There is no authored content yet to split, so the prompt goes on whichever
-	// issues section the persona leads with.
-	const issuesSection: SectionMap =
-		view.persona === 'officeholder'
-			? { inOfficePriorities: { ...issuesPlaceholder, heading: IN_OFFICE_ISSUES_HEADING } }
-			: { campaignIssues: { ...issuesPlaceholder, heading: CAMPAIGN_ISSUES_HEADING } };
-	return {
-		why: { cardType: 'why-running', heading: whyHeading(view.persona), content: <PlaceholderPrompt>{whyPrompt(view)}</PlaceholderPrompt> },
-		...issuesSection,
-		aboutMe: { cardType: 'about-me', heading: 'About Me', content: <PlaceholderPrompt>{aboutPrompt(view)}</PlaceholderPrompt> },
-	};
+	const sections: SectionMap = {};
+	for (const key of SECTION_ORDER[view.persona]) {
+		const card = AUTHORED_SECTIONS.has(key) ? placeholders[key] : undefined;
+		if (card) sections[key] = card;
+	}
+	return sections;
 }
 
 /** First 4-digit year in an ISO-ish date string (avoids TZ off-by-one). */

--- a/src/components/people/personSectionOverrides.tsx
+++ b/src/components/people/personSectionOverrides.tsx
@@ -47,10 +47,67 @@ function whyHeading(persona: PersonPersona): string {
 	}
 }
 
-/** Personas that actually hold (or held) office — the only ones that show issue
- * progress tags. A pure candidate has no in-office record, so frame A omits them. */
-function holdsOffice(persona: PersonPersona): boolean {
-	return persona === 'officeholder' || persona === 'both' || persona === 'past';
+/**
+ * The content sections a profile can show, named after the Figma frames. The
+ * issues list splits in two: the campaign platform (issues with no in-office
+ * status) and the in-office record (issues carrying a status tag).
+ */
+type SectionKey =
+	| 'why'
+	| 'campaignIssues'
+	| 'aboutMe'
+	| 'recentExperience'
+	| 'otherCandidates'
+	| 'inOfficePriorities'
+	| 'accomplishments'
+	| 'aboutPosition'
+	| 'district'
+	| 'nearbyOfficials';
+
+/**
+ * Section order per persona, read off the Figma frames: A 1901:50309,
+ * B 1901:52117, C 1901:53123, G 1958:110869. The frames genuinely differ —
+ * a candidate meets the other candidates before the office, an office-holder
+ * leads with their in-office record and sees the district before the office,
+ * and the past frame opens with About Me. Assuming one shared order is what
+ * kept regressing against the designs, so each persona owns its list and the
+ * order alone decides which sections a persona shows.
+ */
+const SECTION_ORDER: Record<PersonPersona, SectionKey[]> = {
+	candidate: ['why', 'campaignIssues', 'aboutMe', 'recentExperience', 'otherCandidates', 'aboutPosition', 'district'],
+	officeholder: ['inOfficePriorities', 'accomplishments', 'aboutMe', 'recentExperience', 'district', 'aboutPosition', 'nearbyOfficials'],
+	both: ['why', 'campaignIssues', 'aboutMe', 'recentExperience', 'otherCandidates', 'inOfficePriorities', 'accomplishments', 'aboutPosition', 'district', 'nearbyOfficials'],
+	past: ['aboutMe', 'recentExperience', 'why', 'campaignIssues', 'inOfficePriorities', 'accomplishments', 'district', 'aboutPosition', 'nearbyOfficials', 'otherCandidates'],
+};
+
+/**
+ * Adjacent sections sharing a group collapse into one white card (see
+ * `chunkCardGroups` in ProfileContentBlock) — how the frames bundle Why with
+ * Campaign Issues, About Me with Recent Experience, and the in-office record.
+ * Other Candidates and Nearby Officials take distinct groups so the past
+ * frame, where they sit next to each other, still renders two cards.
+ */
+const SECTION_GROUP: Record<SectionKey, string> = {
+	why: 'platform',
+	campaignIssues: 'platform',
+	aboutMe: 'about',
+	recentExperience: 'about',
+	otherCandidates: 'candidates',
+	inOfficePriorities: 'inoffice',
+	accomplishments: 'inoffice',
+	aboutPosition: 'position',
+	district: 'district',
+	nearbyOfficials: 'nearby',
+};
+
+type SectionMap = Partial<Record<SectionKey, ProfileContentCardProps>>;
+
+/** Issues carrying a status are the in-office record; the rest are the platform. */
+function splitIssues(issues: PersonProfileView['issues']) {
+	return {
+		platform: issues.filter(issue => !issue.status),
+		inOffice: issues.filter(issue => issue.status),
+	};
 }
 
 /** Stable empowered-first ordering (Figma puts the GoodParty candidate on top). */
@@ -69,23 +126,15 @@ function personaTags(persona: PersonPersona): string[] {
 		case 'officeholder':
 			return ['Incumbent'];
 		case 'both':
-			return ['Candidate', 'Incumbent'];
+			// Figma C leads with the seat held, matching the hero's office lines.
+			return ['Incumbent', 'Candidate'];
 		case 'past':
 			return ['Former Official'];
 	}
 }
 
-function issuesHeading(persona: PersonPersona): string {
-	switch (persona) {
-		case 'candidate':
-		case 'both':
-			return 'Campaign Issues';
-		case 'officeholder':
-			return 'Top Priorities in Office';
-		case 'past':
-			return 'Priorities in Office';
-	}
-}
+const CAMPAIGN_ISSUES_HEADING = 'Campaign Issues';
+const IN_OFFICE_ISSUES_HEADING = 'Top Priorities While in Office';
 
 const STATUS_LABELS: Record<PersonProfileIssueStatus, string> = {
 	IN_PROGRESS: 'In Progress',
@@ -144,26 +193,29 @@ function IssuesContent({ issues, showStatus }: { issues: PersonProfileView['issu
 	);
 }
 
-function AccomplishmentsContent({ accomplishments }: { accomplishments: PersonAccomplishment[] }): ReactNode {
+function AccomplishmentsContent({ accomplishments, lead }: { accomplishments: PersonAccomplishment[]; lead: string }): ReactNode {
 	return (
-		<ul className='flex flex-col gap-6'>
-			{accomplishments.map((item, index) => (
-				<li key={`${item.title}-${index}`} className='flex flex-col gap-2'>
-					<StatusTag status='RESOLVED' />
-					<div className='flex flex-wrap items-baseline gap-x-3 gap-y-1'>
-						<Text as='span' styleType='subtitle-2'>
-							{item.title}
-						</Text>
-						{item.date && (
-							<Text as='span' styleType='caption' className='text-gray-500'>
-								{item.date}
+		<div className='flex flex-col gap-6'>
+			<Text styleType='body-2'>{lead}</Text>
+			<ul className='flex flex-col gap-6'>
+				{accomplishments.map((item, index) => (
+					<li key={`${item.title}-${index}`} className='flex flex-col gap-2'>
+						<StatusTag status='RESOLVED' />
+						<div className='flex flex-wrap items-baseline gap-x-3 gap-y-1'>
+							<Text as='span' styleType='subtitle-2'>
+								{item.title}
 							</Text>
-						)}
-					</div>
-					{item.description && <Text styleType='body-2'>{item.description}</Text>}
-				</li>
-			))}
-		</ul>
+							{item.date && (
+								<Text as='span' styleType='caption' className='text-gray-500'>
+									{item.date}
+								</Text>
+							)}
+						</div>
+						{item.description && <Text styleType='body-2'>{item.description}</Text>}
+					</li>
+				))}
+			</ul>
+		</div>
 	);
 }
 
@@ -248,32 +300,41 @@ function AboutPositionContent({ view }: { view: PersonProfileView }): ReactNode 
 }
 
 /**
- * Person-authored content cards, in Figma order: Why → Campaign Issues → About
- * Me → Accomplishments. These are empowerment-gated (only shown on empowered
- * pages). Recent Experience is NOT here — it's a civics-spine card that renders
- * on every state (see buildCivicCards).
+ * Person-authored sections, empowerment-gated (only shown on empowered pages).
+ * Which of these actually render — and in what order — is decided solely by
+ * `SECTION_ORDER` for the persona, so a candidate never picks up an in-office
+ * section and vice versa.
  */
-function buildAuthoredCards(view: PersonProfileView): ProfileContentCardProps[] {
-	const cards: ProfileContentCardProps[] = [];
-	// "Why I'm Running for Office" is candidate-only (Figma A); officeholder/past
-	// frames drop the section entirely.
-	if (view.whyRunning && (view.persona === 'candidate' || view.persona === 'both')) {
-		cards.push({ cardType: 'why-running', group: 'platform', heading: whyHeading(view.persona), content: view.whyRunning });
+function buildAuthoredSections(view: PersonProfileView): SectionMap {
+	const sections: SectionMap = {};
+	const { platform, inOffice } = splitIssues(view.issues);
+	if (view.whyRunning) {
+		sections.why = { cardType: 'why-running', heading: whyHeading(view.persona), content: view.whyRunning };
 	}
-	if (view.issues.length > 0) {
-		cards.push({ cardType: 'top-issues', group: 'platform', heading: issuesHeading(view.persona), content: <IssuesContent issues={view.issues} showStatus={holdsOffice(view.persona)} /> });
+	if (platform.length > 0) {
+		sections.campaignIssues = { cardType: 'top-issues', heading: CAMPAIGN_ISSUES_HEADING, content: <IssuesContent issues={platform} showStatus={false} /> };
 	}
-	// Accomplishments are an in-office record — only personas who hold/held office
-	// show them. A pure candidate (Figma A) has none, so gate the section. Per Figma
-	// (B/C/G) it sits immediately after Campaign Issues, grouped with them as the
-	// in-office record, BEFORE About Me.
-	if (view.accomplishments.length > 0 && holdsOffice(view.persona)) {
-		cards.push({ group: 'platform', heading: 'Accomplishments', content: <AccomplishmentsContent accomplishments={view.accomplishments} /> });
+	if (inOffice.length > 0) {
+		sections.inOfficePriorities = { cardType: 'top-issues', heading: IN_OFFICE_ISSUES_HEADING, content: <IssuesContent issues={inOffice} showStatus /> };
+	}
+	// Figma nests this under "Top Priorities While in Office" as a smaller
+	// heading with a lead-in line, inside the same card.
+	if (view.accomplishments.length > 0) {
+		sections.accomplishments = {
+			heading: 'Accomplishments During This Term',
+			headingStyle: 'sub',
+			content: (
+				<AccomplishmentsContent
+					accomplishments={view.accomplishments}
+					lead={`${view.displayName} has accomplished the following:`}
+				/>
+			),
+		};
 	}
 	if (view.bio) {
-		cards.push({ cardType: 'about-me', group: 'about', heading: 'About Me', content: view.bio });
+		sections.aboutMe = { cardType: 'about-me', heading: 'About Me', content: view.bio };
 	}
-	return cards;
+	return sections;
 }
 
 /** Muted, italic prompt copy used inside unclaimed placeholder cards. */
@@ -332,15 +393,22 @@ function aboutPrompt(view: PersonProfileView): string {
  * owner-authored content yet. Accomplishments is intentionally omitted (Figma
  * does not show a placeholder for it).
  */
-function buildAuthoredPlaceholderCards(view: PersonProfileView): ProfileContentCardProps[] {
-	const cards: ProfileContentCardProps[] = [];
-	// Mirror the claimed gating: the "Why" prompt is candidate-only.
-	if (view.persona === 'candidate' || view.persona === 'both') {
-		cards.push({ cardType: 'why-running', group: 'platform', heading: whyHeading(view.persona), content: <PlaceholderPrompt>{whyPrompt(view)}</PlaceholderPrompt> });
-	}
-	cards.push({ cardType: 'top-issues', group: 'platform', heading: issuesHeading(view.persona), content: <PlaceholderPrompt>{issuesPrompt(view)}</PlaceholderPrompt> });
-	cards.push({ cardType: 'about-me', group: 'about', heading: 'About Me', content: <PlaceholderPrompt>{aboutPrompt(view)}</PlaceholderPrompt> });
-	return cards;
+function buildAuthoredPlaceholderSections(view: PersonProfileView): SectionMap {
+	const issuesPlaceholder: ProfileContentCardProps = {
+		cardType: 'top-issues',
+		content: <PlaceholderPrompt>{issuesPrompt(view)}</PlaceholderPrompt>,
+	};
+	// There is no authored content yet to split, so the prompt goes on whichever
+	// issues section the persona leads with.
+	const issuesSection: SectionMap =
+		view.persona === 'officeholder'
+			? { inOfficePriorities: { ...issuesPlaceholder, heading: IN_OFFICE_ISSUES_HEADING } }
+			: { campaignIssues: { ...issuesPlaceholder, heading: CAMPAIGN_ISSUES_HEADING } };
+	return {
+		why: { cardType: 'why-running', heading: whyHeading(view.persona), content: <PlaceholderPrompt>{whyPrompt(view)}</PlaceholderPrompt> },
+		...issuesSection,
+		aboutMe: { cardType: 'about-me', heading: 'About Me', content: <PlaceholderPrompt>{aboutPrompt(view)}</PlaceholderPrompt> },
+	};
 }
 
 /** First 4-digit year in an ISO-ish date string (avoids TZ off-by-one). */
@@ -391,50 +459,53 @@ function OtherCandidatesContent({ cards }: { cards: CandidateCard[] }): ReactNod
 }
 
 /**
- * Civics-spine content cards shown on every state (data permitting), in Figma
- * order after the authored cards: Recent Experience → Other candidates →
- * About [position] → District Information (voter-density map). These are NOT
- * empowerment-gated, so unclaimed major-party (I/J) and removed (K/L) pages
- * still render their public-record context per the Figma removal frames.
+ * Civics-spine sections, available on every state (data permitting). These are
+ * NOT empowerment-gated, so unclaimed major-party (I/J) and removed (K/L)
+ * pages still render their public-record context per the Figma removal frames.
  */
-function buildCivicCards(view: PersonProfileView): ProfileContentCardProps[] {
-	const cards: ProfileContentCardProps[] = [];
+function buildCivicSections(view: PersonProfileView): SectionMap {
+	const sections: SectionMap = {};
 	if (view.recentExperience.length > 0) {
-		cards.push({ group: 'about', heading: 'Recent Experience', content: <ExperienceContent experience={view.recentExperience} /> });
+		sections.recentExperience = { heading: 'Recent Experience', content: <ExperienceContent experience={view.recentExperience} /> };
 	}
 	if (view.positionDescription || view.termLabel || view.electionDate) {
-		cards.push({
-			group: 'position',
+		sections.aboutPosition = {
 			heading: `About ${view.officeName ?? 'the Role'}`,
 			content: <AboutPositionContent view={view} />,
-		});
+		};
 	}
 	const districtMap = buildDistrictMap(view);
 	if (districtMap) {
-		cards.push({ group: 'district', heading: 'District information', content: districtMap });
+		sections.district = { heading: 'District information', content: districtMap };
 	}
-	// People cards (other candidates / nearby officials) close the column. Per Figma
-	// the officeholder frames (B/C/G) place these last, after the position + district
-	// context, so the reader meets the office before the surrounding people.
 	// Figma title-cases the heading and leads with the empowered (GoodParty)
 	// candidate. FLAG: the frame reads "Other Candidates for [Position] in
 	// <Location>" but the view has no clean locality field distinct from the
 	// position name, so the "in <Location>" clause is omitted rather than invented.
 	const otherCandidates = empoweredFirst(toCandidateCards(view.otherCandidates));
 	if (otherCandidates.length > 0) {
-		cards.push({
-			group: 'people',
+		sections.otherCandidates = {
 			heading: view.officeName ? `Other Candidates for ${view.officeName}` : 'Other Candidates',
 			content: <OtherCandidatesContent cards={otherCandidates} />,
-		});
+		};
 	}
-	// Nearby officials serving the same constituency — only for personas actually
-	// in (or formerly in) office, per Figma (candidate-only pages omit this).
-	const nearby = holdsOffice(view.persona) ? empoweredFirst(toCandidateCards(view.nearbyOfficials)) : [];
+	const nearby = empoweredFirst(toCandidateCards(view.nearbyOfficials));
 	if (nearby.length > 0) {
-		cards.push({ group: 'people', heading: 'Nearby Officials', content: <OtherCandidatesContent cards={nearby} /> });
+		sections.nearbyOfficials = { heading: 'Nearby Officials', content: <OtherCandidatesContent cards={nearby} /> };
 	}
-	return cards;
+	return sections;
+}
+
+/**
+ * Resolves the persona's section list into ordered cards, tagging each with
+ * its card group. A section with no data — or one absent from the persona's
+ * order — simply doesn't render.
+ */
+function orderedSectionCards(view: PersonProfileView, sections: SectionMap): ProfileContentCardProps[] {
+	return SECTION_ORDER[view.persona].flatMap(key => {
+		const card = sections[key];
+		return card ? [{ ...card, group: SECTION_GROUP[key] }] : [];
+	});
 }
 
 /** Contact links that render as icon-only buttons in the Figma "Contact" row. */
@@ -559,10 +630,6 @@ export function buildPersonSectionOverrides(view: PersonProfileView): SectionOve
 				// `outline` button.
 				button: { buttonType: 'signup', label: 'Learn more', buttonProps: { styleType: 'secondary', styleSize: 'md' } },
 				preserveButtonStyle: true,
-				// The CTA sits below the asymmetric sidebar + cards layout; align its
-				// centered content with the content-card column above (not the page
-				// middle) so it reads as continuous with the last card.
-				contentColumnAlign: true,
 			}
 		: showClaim
 			? {
@@ -597,16 +664,15 @@ export function buildPersonSectionOverrides(view: PersonProfileView): SectionOve
 	// Authored slot: claimed pages show real owner content; unclaimed but
 	// empowered pages (Figma D/E/F/H) show muted placeholder prompt cards in the
 	// same slot; major-party (I/J) and removed (K/L) pages show neither.
-	const authoredCards = view.claimed
-		? buildAuthoredCards(view)
+	const authoredSections = view.claimed
+		? buildAuthoredSections(view)
 		: view.empowered
-			? buildAuthoredPlaceholderCards(view)
-			: [];
+			? buildAuthoredPlaceholderSections(view)
+			: {};
 	const contentCards: ProfileContentCardProps[] = [
 		...(view.persona === 'past' ? [pastElectionDisclaimer(view)] : []),
 		...(showClaim ? [claimCard('voter-card')] : []),
-		...authoredCards,
-		...buildCivicCards(view),
+		...orderedSectionCards(view, { ...authoredSections, ...buildCivicSections(view) }),
 	];
 	const sidebar = buildSidebar(view);
 
@@ -620,7 +686,13 @@ export function buildPersonSectionOverrides(view: PersonProfileView): SectionOve
 			candidateName: view.displayName,
 			office: view.roleTitle ?? '',
 			// The full positionName (incl. locality) links to the office/position page.
-			officeHref: view.positionHref ?? undefined,
+			// When a second line is present (serving AND running, Figma C) the first
+			// line is the seat HELD, so the candidacy-derived href belongs on the
+			// second line; the held seat gets its own href once election-api threads
+			// the office's position slug through.
+			officeHref: (view.secondaryRoleTitle ? undefined : view.positionHref) ?? undefined,
+			secondaryOffice: view.secondaryRoleTitle ?? undefined,
+			secondaryOfficeHref: (view.secondaryRoleTitle ? view.positionHref : undefined) ?? undefined,
 			profileImageUrl: view.avatarUrl ?? undefined,
 			isEmpowered: view.empowered,
 			tags: personaTags(view.persona),

--- a/src/components/people/personSectionOverrides.tsx
+++ b/src/components/people/personSectionOverrides.tsx
@@ -317,12 +317,12 @@ function buildAuthoredSections(view: PersonProfileView): SectionMap {
 	if (inOffice.length > 0) {
 		sections.inOfficePriorities = { cardType: 'top-issues', heading: IN_OFFICE_ISSUES_HEADING, content: <IssuesContent issues={inOffice} showStatus /> };
 	}
-	// Figma nests this under "Top Priorities While in Office" as a smaller
-	// heading with a lead-in line, inside the same card.
+	// Figma nests this under "Top Priorities While in Office" with a lead-in
+	// line. The smaller heading comes from sharing that section's group, not
+	// from being set here.
 	if (view.accomplishments.length > 0) {
 		sections.accomplishments = {
 			heading: 'Accomplishments During This Term',
-			headingStyle: 'sub',
 			content: (
 				<AccomplishmentsContent
 					accomplishments={view.accomplishments}

--- a/src/components/people/personSectionOverrides.tsx
+++ b/src/components/people/personSectionOverrides.tsx
@@ -657,6 +657,12 @@ export function buildPersonSectionOverrides(view: PersonProfileView): SectionOve
 				// `outline` button.
 				button: { buttonType: 'signup', label: 'Learn more', buttonProps: { styleType: 'secondary', styleSize: 'md' } },
 				preserveButtonStyle: true,
+				// Deliberately NOT `contentColumnAlign`. That prop mirrors the sidebar
+				// grid so the CTA lines up with the content-card column, but the frames
+				// don't do that: in A (1901:50309) the CTA is a stock CTA Block whose
+				// content frame sits at x=208 w=1024 in a 1440 frame — 208px either
+				// side, centered on the page. Mirroring the column pushed it right of
+				// center, which is the misalignment marketing reported.
 			}
 		: showClaim
 			? {

--- a/src/components/people/personSectionOverrides.tsx
+++ b/src/components/people/personSectionOverrides.tsx
@@ -375,8 +375,10 @@ function issuesPrompt(view: PersonProfileView): string {
 			return `Which issues would ${displayName} champion${office ? ` as ${office}` : ''}? Their campaign priorities will appear here once they claim their profile.`;
 		case 'officeholder':
 			return `What are ${displayName}'s top priorities${office ? ` for ${office}` : ''}? Their agenda in office will appear here once they claim their profile.`;
+		// A past official's frame carries this section AND the in-office one, so
+		// this has to ask about the campaign; `inOfficePrompt` covers the record.
 		case 'past':
-			return `Which priorities did ${displayName} focus on${office ? ` in ${office}` : ' in office'}? Their record will appear here once they claim their profile.`;
+			return `What did ${displayName} campaign on${office ? ` for ${office}` : ''}? Their platform and issues will appear here once they claim their profile.`;
 	}
 }
 

--- a/src/lib/devPeopleProfileFixtures.ts
+++ b/src/lib/devPeopleProfileFixtures.ts
@@ -31,6 +31,10 @@ import { fixtureForState } from '~/testing/peopleProfileFixtures';
 const DEV_RACE_SLUG = 'wy/laramie/springfield/city-council';
 const DEV_POSITION_NAME = 'Springfield City Council';
 
+function devPositionHref(): string | undefined {
+	return buildElectionPositionHrefFromRaceSlug({ slug: DEV_RACE_SLUG, positionLevel: 'CITY' });
+}
+
 export function isDevPeopleFixturesEnabled(): boolean {
 	return process.env['PEOPLE_DEV_FIXTURES'] === 'true';
 }
@@ -164,7 +168,7 @@ function richExperience(persona: PersonPersona): ExperienceItem[] {
 		{ title: 'School Board Trustee, At-Large', organization: '2010 – 2014', term: '2010 – 2014', status: null, href: '/elections/school-board' },
 	];
 	if (running) {
-		rows.unshift({ title: 'Candidate for Mayor of Springfield', organization: '2026 election', term: '2026 election', status: 'Candidate', href: '/elections/mayor' });
+		rows.unshift({ title: `Candidate for ${DEV_POSITION_NAME}`, organization: '2026 election', term: '2026 election', status: 'Candidate', href: devPositionHref() ?? null });
 	}
 	return rows;
 }
@@ -227,6 +231,12 @@ export function getDevPersonProfileView(slug: string): PersonProfileView | null 
 		firstName: entry.first,
 		lastName: entry.last,
 		fullName: name,
+		// The shared matrix runs its candidacies for a different office (Mayor)
+		// than it holds (city council), which is fine for state/gating tests but
+		// would show a dev page whose hero names one race while the breadcrumb
+		// and position link point at another. Every dev persona is about the one
+		// DEV_RACE_SLUG race, so an incumbent here is running for re-election.
+		Candidacies: (fixture.person.Candidacies ?? []).map((c) => ({ ...c, positionName: DEV_POSITION_NAME })),
 		bioText: `${name} has served the community for over a decade. ${LOREM}`,
 		headshotUrl,
 		websiteUrl: 'https://example.org',
@@ -252,8 +262,7 @@ export function getDevPersonProfileView(slug: string): PersonProfileView | null 
 			: null;
 	const removed = fixture.overlay.status === 'removed';
 
-	const positionHref =
-		buildElectionPositionHrefFromRaceSlug({ slug: DEV_RACE_SLUG, positionLevel: 'CITY' }) ?? null;
+	const positionHref = devPositionHref() ?? null;
 
 	const view = composeView(personId, person, overlay, {
 		removed,

--- a/src/lib/devPeopleProfileFixtures.ts
+++ b/src/lib/devPeopleProfileFixtures.ts
@@ -16,10 +16,20 @@
  * each slug lands on the intended Figma state; only the CONTENT VOLUME (issues,
  * experience, interlinks, density, bios) is enriched on top.
  */
-import { composeView, type ExperienceItem, type PersonProfileView, type ProfileState, type RelatedPersonCard } from '~/lib/peopleProfile';
+import { buildBreadcrumbTrail, composeView, type ExperienceItem, type PersonProfileView, type ProfileState, type RelatedPersonCard } from '~/lib/peopleProfile';
 import type { PersonPersona } from '~/lib/peopleProfile';
 import type { PublicPersonProfile, VoterDensity } from '~/types/people';
+import { buildElectionPositionHrefFromRaceSlug } from '~/lib/electionsHelpers';
 import { fixtureForState } from '~/testing/peopleProfileFixtures';
+
+/**
+ * A realistic race slug (`state/county/city/position`) so the dev pages render
+ * the full breadcrumb + position href the same way production does for anyone
+ * with a candidacy. The city matches the fixtures' office name so the trail and
+ * the section headings name the same place.
+ */
+const DEV_RACE_SLUG = 'wy/laramie/springfield/city-council';
+const DEV_POSITION_NAME = 'Springfield City Council';
 
 export function isDevPeopleFixturesEnabled(): boolean {
 	return process.env['PEOPLE_DEV_FIXTURES'] === 'true';
@@ -50,7 +60,73 @@ function personIdFromSuffix(suffix: string): string {
 const LOREM =
 	'Focused on transparent, accountable local government that puts residents first. Building coalitions across the community to deliver practical results on the issues families care about most.';
 
-function richOverlay(name: string, holdsOffice: boolean): Partial<PublicPersonProfile> {
+// Issues WITHOUT a status are the campaign platform ("Campaign Issues"); issues
+// WITH one are the in-office record ("Top Priorities While in Office"). The
+// frames show these as separate sections, so seed each kind only for the
+// personas whose frame has that section.
+const CAMPAIGN_ISSUES = [
+	{
+		issueId: 'issue-housing',
+		title: 'Affordable Housing',
+		description: 'Expand affordable housing options and streamline permitting for new homes.',
+		visible: true,
+		status: null,
+		transparency: null,
+		sortOrder: 0,
+	},
+	{
+		issueId: 'issue-safety',
+		title: 'Public Safety & Roads',
+		description: 'Repair aging roads and invest in community-based public safety programs.',
+		visible: true,
+		status: null,
+		transparency: null,
+		sortOrder: 1,
+	},
+	{
+		issueId: 'issue-transparency',
+		title: 'Government Transparency',
+		description: 'Publish budgets and votes openly so residents can hold leaders accountable.',
+		visible: true,
+		status: null,
+		transparency: null,
+		sortOrder: 2,
+	},
+] as const;
+
+const IN_OFFICE_ISSUES = [
+	{
+		issueId: 'issue-tree-canopy',
+		title: 'Protecting the tree canopy as we grow',
+		description: 'Pair new development with replanting so block-level shade keeps pace with construction.',
+		visible: true,
+		status: 'IN_PROGRESS',
+		transparency: 'Verified',
+		sortOrder: 3,
+	},
+	{
+		issueId: 'issue-repaving',
+		title: 'Potholes and repaving on Riverside Avenue',
+		description: 'Fund the repaving backlog and publish a street-by-street schedule residents can track.',
+		visible: true,
+		status: 'PRIORITIZED',
+		transparency: 'Verified',
+		sortOrder: 4,
+	},
+	{
+		issueId: 'issue-fire-staffing',
+		title: 'Fire department staffing and response times',
+		description: 'Keep every station fully staffed and hold response times under the national benchmark.',
+		visible: true,
+		status: 'ONGOING',
+		transparency: 'Verified',
+		sortOrder: 5,
+	},
+] as const;
+
+function richOverlay(name: string, persona: PersonPersona): Partial<PublicPersonProfile> {
+	const ran = persona === 'candidate' || persona === 'both' || persona === 'past';
+	const holdsOffice = persona === 'officeholder' || persona === 'both' || persona === 'past';
 	return {
 		displayName: name,
 		bioOverride: `${name} is a lifelong resident and community advocate. ${LOREM}`,
@@ -73,33 +149,8 @@ function richOverlay(name: string, holdsOffice: boolean): Partial<PublicPersonPr
 		linkedinUrl: 'https://linkedin.com/in/example',
 		instagramUrl: 'https://instagram.com/example',
 		issues: [
-			{
-				issueId: 'issue-housing',
-				title: 'Affordable Housing',
-				description: 'Expand affordable housing options and streamline permitting for new homes.',
-				visible: true,
-				status: 'IN_PROGRESS',
-				transparency: 'Verified',
-				sortOrder: 0,
-			},
-			{
-				issueId: 'issue-safety',
-				title: 'Public Safety & Roads',
-				description: 'Repair aging roads and invest in community-based public safety programs.',
-				visible: true,
-				status: 'PRIORITIZED',
-				transparency: 'Verified',
-				sortOrder: 1,
-			},
-			{
-				issueId: 'issue-transparency',
-				title: 'Government Transparency',
-				description: 'Publish budgets and votes openly so residents can hold leaders accountable.',
-				visible: true,
-				status: 'ONGOING',
-				transparency: 'Verified',
-				sortOrder: 2,
-			},
+			...(ran ? CAMPAIGN_ISSUES : []),
+			...(holdsOffice ? IN_OFFICE_ISSUES : []),
 		],
 	};
 }
@@ -194,13 +245,15 @@ export function getDevPersonProfileView(slug: string): PersonProfileView | null 
 
 	const persona: PersonPersona = fixture.expected.persona;
 	const running = persona === 'candidate' || persona === 'both';
-	const holdsOffice = persona === 'officeholder' || persona === 'both' || persona === 'past';
 
 	const overlay: PublicPersonProfile | null =
 		fixture.overlay.status === 'live'
-			? { ...fixture.overlay.profile, personId, ...richOverlay(name, holdsOffice), avatarUrl: headshotUrl }
+			? { ...fixture.overlay.profile, personId, ...richOverlay(name, persona), avatarUrl: headshotUrl }
 			: null;
 	const removed = fixture.overlay.status === 'removed';
+
+	const positionHref =
+		buildElectionPositionHrefFromRaceSlug({ slug: DEV_RACE_SLUG, positionLevel: 'CITY' }) ?? null;
 
 	const view = composeView(personId, person, overlay, {
 		removed,
@@ -209,7 +262,17 @@ export function getDevPersonProfileView(slug: string): PersonProfileView | null 
 		electionDate: '2026-11-03',
 		positionDescription:
 			'The County Legislature or Executive Board is the governing body of the county and exercises broad policy-making authority. The Board is charged with implementing policy and overseeing the county budget process and administration.',
-		positionHref: '/elections/wyoming-house',
+		positionHref,
+		// Mirror production's trail so reviewers see the real
+		// Elections > State > County > City > Position > Name hierarchy rather
+		// than the bare `Elections > Name` fallback.
+		breadcrumb: buildBreadcrumbTrail({
+			displayName: name,
+			stateCode: 'WY',
+			raceSlug: DEV_RACE_SLUG,
+			positionLevel: 'CITY',
+			positionName: DEV_POSITION_NAME,
+		}),
 		recentExperience: richExperience(persona),
 		// Running personas get "Other candidates"; the Figma "past" mocks (G/H) are
 		// the tallest frames and also carry this section, so include it there too.

--- a/src/lib/peopleProfile.test.ts
+++ b/src/lib/peopleProfile.test.ts
@@ -234,6 +234,35 @@ describe('composeView persona resolution', () => {
 		expect(view.officeName).toBe('Mayor');
 	});
 
+	test('prefers a linkable race so the hero cannot name one race while the links name another', () => {
+		const view = composeView(
+			PID,
+			makePerson({
+				fullName: 'Jane Doe',
+				Candidacies: [
+					// Sooner, but with no slug the rest of the page cannot use it.
+					{ id: 'c1', positionName: 'Mayor', Race: { electionDate: '2099-11-01' } },
+					{ id: 'c2', positionName: 'School Board', slug: 'wy/laramie/school-board', Race: { electionDate: '2099-11-03' } },
+				],
+			}),
+			null,
+		);
+		expect(view.roleTitle).toBe('Candidate for School Board');
+	});
+
+	test('a slug-less candidacy still supplies the office name and party', () => {
+		const view = composeView(
+			PID,
+			makePerson({
+				fullName: 'Jane Doe',
+				Candidacies: [{ id: 'c1', positionName: 'Mayor', party: 'Independent' }],
+			}),
+			null,
+		);
+		expect(view.roleTitle).toBe('Candidate for Mayor');
+		expect(view.party).toBe('Independent');
+	});
+
 	test('an archived candidate falls back to their most recent past race', () => {
 		const view = composeView(
 			PID,

--- a/src/lib/peopleProfile.test.ts
+++ b/src/lib/peopleProfile.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 import type { PersonItem, PersonOfficeHolder, PublicPersonProfile } from '~/types/people';
 import {
-	buildBreadcrumb,
+	buildBreadcrumbTrail,
 	buildPersonSlug,
 	composeView,
 	extractPersonId,
@@ -214,6 +214,56 @@ describe('composeView persona resolution', () => {
 			null,
 		);
 		expect(view.persona).toBe('both');
+	});
+
+	test('the hero names the current race, not whichever candidacy the API returns first', () => {
+		const view = composeView(
+			PID,
+			makePerson({
+				fullName: 'Jane Doe',
+				// The API does not order this array, so a past run can come first.
+				Candidacies: [
+					{ id: 'c1', positionName: 'School Board', Race: { electionDate: '2022-11-08' } },
+					{ id: 'c2', positionName: 'Mayor', Race: { electionDate: '2099-11-03' } },
+				],
+			}),
+			null,
+		);
+		expect(view.roleTitle).toBe('Candidate for Mayor');
+		// Section headings ("About …", "Other Candidates for …") read the same name.
+		expect(view.officeName).toBe('Mayor');
+	});
+
+	test('an archived candidate falls back to their most recent past race', () => {
+		const view = composeView(
+			PID,
+			makePerson({
+				fullName: 'Jane Doe',
+				Candidacies: [
+					{ id: 'c1', positionName: 'School Board', Race: { electionDate: '2018-11-06' } },
+					{ id: 'c2', positionName: 'Mayor', Race: { electionDate: '2022-11-08' } },
+				],
+			}),
+			null,
+		);
+		expect(view.roleTitle).toBe('Candidate for Mayor');
+	});
+
+	test('both: the second hero line names the seat being sought, not a past run', () => {
+		const view = composeView(
+			PID,
+			makePerson({
+				fullName: 'Jane Doe',
+				Candidacies: [
+					{ id: 'c1', positionName: 'School Board', Race: { electionDate: '2022-11-08' } },
+					{ id: 'c2', positionName: 'Mayor', Race: { electionDate: '2099-11-03' } },
+				],
+				OfficeHolders: [makeOffice({ isCurrent: true, officeTitle: 'City Council' })],
+			}),
+			null,
+		);
+		expect(view.roleTitle).toBe('City Council');
+		expect(view.secondaryRoleTitle).toBe('Candidate for Mayor');
 	});
 
 	test('past: held office before, not current and not running', () => {
@@ -472,9 +522,9 @@ describe('composeView state + empowerment gating', () => {
 	});
 });
 
-describe('buildBreadcrumb', () => {
+describe('buildBreadcrumbTrail', () => {
 	test('degrades to Elections > State > Name without a race slug', async () => {
-		const trail = await buildBreadcrumb({
+		const trail = buildBreadcrumbTrail({
 			displayName: 'Jane Doe',
 			stateCode: 'CA',
 			raceSlug: null,
@@ -486,7 +536,7 @@ describe('buildBreadcrumb', () => {
 	});
 
 	test('degrades to Elections > Name when neither race slug nor state is known', async () => {
-		const trail = await buildBreadcrumb({
+		const trail = buildBreadcrumbTrail({
 			displayName: 'Jane Doe',
 			stateCode: null,
 			raceSlug: null,
@@ -497,7 +547,7 @@ describe('buildBreadcrumb', () => {
 	});
 
 	test('builds Elections > State > ... > Position > Name from a race slug', async () => {
-		const trail = await buildBreadcrumb({
+		const trail = buildBreadcrumbTrail({
 			displayName: 'Jane Doe',
 			stateCode: 'CA',
 			raceSlug: 'ca/los-angeles-county/mayor',

--- a/src/lib/peopleProfile.ts
+++ b/src/lib/peopleProfile.ts
@@ -662,11 +662,13 @@ export function composeView(
 	// Label and class must share one source precedence, or a "both" persona whose
 	// office and candidacy parties differ would show one party while being gated
 	// (majorParty → I/J empowerment) by the other. Office-first for both.
-	const rawParty = office?.partyNames?.[0] ?? person?.Candidacies?.[0]?.party ?? null;
-	const partyClass = classifyPartyFrom(
-		office?.partyNames?.[0],
-		person?.Candidacies?.[0]?.party,
-	);
+	// Read the party off the CURRENT race, not whichever candidacy the API
+	// happens to return first: someone who ran as a Democrat in 2020 and is now
+	// running as an Independent would otherwise be gated as major-party (I/J)
+	// and lose the empowerment framing they qualify for.
+	const primaryCand = primaryCandidacy(person);
+	const rawParty = office?.partyNames?.[0] ?? primaryCand?.party ?? null;
+	const partyClass = classifyPartyFrom(office?.partyNames?.[0], primaryCand?.party);
 	const majorParty = isMajorParty(partyClass);
 	const state = resolveProfileState(persona, { claimed, removed, partyClass });
 	// Empowerment framing applies to claimed pages and unclaimed non-partisan
@@ -675,7 +677,7 @@ export function composeView(
 	const roleTitle = resolveRoleTitle(persona, person, office, overlay?.roleTitleOverride ?? null);
 	// Someone serving AND running shows both offices in the hero (Figma C):
 	// `roleTitle` carries the seat held, this carries the candidacy beneath it.
-	const candidacyTarget = candidateOfficeName(person);
+	const candidacyTarget = primaryCand?.positionName ?? null;
 	const secondaryRoleTitle =
 		persona === 'both' && candidacyTarget ? `Candidate for ${candidacyTarget}` : null;
 	const party = rawParty ?? (partyClass ? PARTY_LABELS[partyClass] : null);

--- a/src/lib/peopleProfile.ts
+++ b/src/lib/peopleProfile.ts
@@ -184,6 +184,11 @@ export interface PersonProfileView {
 	displayName: string;
 	/** Hero line under the name, e.g. "Candidate for Mayor" or "City Council". */
 	roleTitle: string | null;
+	/**
+	 * Second hero line, only for someone serving and running at once (Figma
+	 * state C): `roleTitle` names the seat held, this names the candidacy.
+	 */
+	secondaryRoleTitle: string | null;
 	/** Bare office name for the sidebar "About Office" row. */
 	officeName: string | null;
 	party: string | null;
@@ -535,6 +540,21 @@ export async function buildBreadcrumb(params: {
 	positionLevel: string | null;
 	positionName: string | null;
 }): Promise<ProfileBreadcrumb[]> {
+	return buildBreadcrumbTrail(params);
+}
+
+/**
+ * Synchronous core of {@link buildBreadcrumb}. Split out so the dev fixtures
+ * (which compose a view synchronously) build the exact same trail as
+ * production instead of falling back to `Elections > Name`.
+ */
+export function buildBreadcrumbTrail(params: {
+	displayName: string;
+	stateCode: string | null;
+	raceSlug: string | null;
+	positionLevel: string | null;
+	positionName: string | null;
+}): ProfileBreadcrumb[] {
 	const { displayName, stateCode, raceSlug, positionLevel, positionName } = params;
 	const trail: ProfileBreadcrumb[] = [{ href: '/elections', label: 'Elections' }];
 
@@ -637,6 +657,11 @@ export function composeView(
 	// pages; it is stripped for major-party (I/J) and removal (K/L) states.
 	const empowered = claimed || (!removed && !majorParty);
 	const roleTitle = resolveRoleTitle(persona, person, office, overlay?.roleTitleOverride ?? null);
+	// Someone serving AND running shows both offices in the hero (Figma C):
+	// `roleTitle` carries the seat held, this carries the candidacy beneath it.
+	const candidacyTarget = candidateOfficeName(person);
+	const secondaryRoleTitle =
+		persona === 'both' && candidacyTarget ? `Candidate for ${candidacyTarget}` : null;
 	const party = rawParty ?? (partyClass ? PARTY_LABELS[partyClass] : null);
 	const districtLabel = office?.subAreaValue ?? office?.subAreaName ?? null;
 	// Mirror the loader's stateCode (which includes the candidacy fallback) so a
@@ -669,6 +694,7 @@ export function composeView(
 		pledged: !removed && (person?.isPledged ?? false),
 		displayName,
 		roleTitle,
+		secondaryRoleTitle,
 		// Candidate-only people have no held office; fall back to the candidacy's
 		// position so section headings ("About …", "Other Candidates for …") still
 		// name the seat they're running for, matching the Figma candidate frames.

--- a/src/lib/peopleProfile.ts
+++ b/src/lib/peopleProfile.ts
@@ -321,9 +321,40 @@ function formatTerm(office: PersonOfficeHolder | null): string | null {
 	return null;
 }
 
+/**
+ * Buckets candidacies by how current they are: the soonest upcoming election
+ * first, then the most recent past one, then rows we can't date. The API does
+ * not guarantee an order, so anything that reads "the" candidacy off the array
+ * must go through this or it risks naming a race the person already ran.
+ */
+function candidaciesByRecency(candidacies: PersonCandidacySummary[]): {
+	upcoming: PersonCandidacySummary[];
+	past: PersonCandidacySummary[];
+	undated: PersonCandidacySummary[];
+} {
+	const now = Date.now();
+	const dated: { candidacy: PersonCandidacySummary; time: number }[] = [];
+	const undated: PersonCandidacySummary[] = [];
+	for (const candidacy of candidacies) {
+		const parsed = candidacy.Race?.electionDate ? Date.parse(candidacy.Race.electionDate) : NaN;
+		if (Number.isNaN(parsed)) undated.push(candidacy);
+		else dated.push({ candidacy, time: parsed });
+	}
+	return {
+		upcoming: dated.filter(x => x.time >= now).sort((a, b) => a.time - b.time).map(x => x.candidacy),
+		past: dated.filter(x => x.time < now).sort((a, b) => b.time - a.time).map(x => x.candidacy),
+		undated,
+	};
+}
+
+/** The race a person is currently running in, else the last one they ran in. */
+function primaryCandidacy(person: PersonItem | null): PersonCandidacySummary | null {
+	const { upcoming, past, undated } = candidaciesByRecency(person?.Candidacies ?? []);
+	return upcoming[0] ?? past[0] ?? undated[0] ?? null;
+}
+
 function candidateOfficeName(person: PersonItem | null): string | null {
-	const candidacy = person?.Candidacies?.[0];
-	return candidacy?.positionName ?? null;
+	return primaryCandidacy(person)?.positionName ?? null;
 }
 
 function resolveRoleTitle(
@@ -533,21 +564,6 @@ function humanizeSlugSegment(segment: string): string {
  * (e.g. an office holder with no linked race), the trail degrades to
  * `Elections > State? > Name`.
  */
-export async function buildBreadcrumb(params: {
-	displayName: string;
-	stateCode: string | null;
-	raceSlug: string | null;
-	positionLevel: string | null;
-	positionName: string | null;
-}): Promise<ProfileBreadcrumb[]> {
-	return buildBreadcrumbTrail(params);
-}
-
-/**
- * Synchronous core of {@link buildBreadcrumb}. Split out so the dev fixtures
- * (which compose a view synchronously) build the exact same trail as
- * production instead of falling back to `Elections > Name`.
- */
 export function buildBreadcrumbTrail(params: {
 	displayName: string;
 	stateCode: string | null;
@@ -698,11 +714,7 @@ export function composeView(
 		// Candidate-only people have no held office; fall back to the candidacy's
 		// position so section headings ("About …", "Other Candidates for …") still
 		// name the seat they're running for, matching the Figma candidate frames.
-		officeName:
-			office?.positionName ??
-			office?.officeTitle ??
-			person?.Candidacies?.[0]?.positionName ??
-			null,
+		officeName: office?.positionName ?? office?.officeTitle ?? candidacyTarget,
 		party,
 		avatarUrl,
 		coverImageUrl: removed ? null : (overlay?.coverImageUrl ?? null),
@@ -763,25 +775,15 @@ function selectPrimaryCandidacy(
 	person: PersonItem | null,
 	hasCurrentOffice: boolean,
 ): PersonCandidacySummary | null {
-	const candidacies = (person?.Candidacies ?? []).filter((c) => c.slug);
-	if (candidacies.length === 0) return null;
-	const now = Date.now();
-	const dated = candidacies.map((c) => {
-		const parsed = c.Race?.electionDate ? Date.parse(c.Race.electionDate) : NaN;
-		return { candidacy: c, time: Number.isNaN(parsed) ? null : parsed };
-	});
+	const { upcoming, past, undated } = candidaciesByRecency(
+		(person?.Candidacies ?? []).filter((c) => c.slug),
+	);
 	// (1) Current candidate: earliest upcoming election.
-	const upcoming = dated
-		.filter((x): x is { candidacy: PersonCandidacySummary; time: number } => x.time != null && x.time >= now)
-		.sort((a, b) => a.time - b.time);
-	if (upcoming[0]) return upcoming[0].candidacy;
+	if (upcoming[0]) return upcoming[0];
 	// (2) Elected officeholder not currently running: defer to the office.
 	if (hasCurrentOffice) return null;
 	// (3) Archived: most recent past run wins; undated rows fall back to first.
-	const past = dated
-		.filter((x): x is { candidacy: PersonCandidacySummary; time: number } => x.time != null)
-		.sort((a, b) => b.time - a.time);
-	return past[0]?.candidacy ?? candidacies[0] ?? null;
+	return past[0] ?? undated[0] ?? null;
 }
 
 /** Resolves the primary candidacy detail (with race) used to enrich the page. */
@@ -975,13 +977,13 @@ export async function loadPersonProfile(personId: string): Promise<PersonProfile
 	const composedName = [person?.firstName, person?.lastName].filter(Boolean).join(' ');
 	const displayName = overlay?.displayName ?? person?.fullName ?? (composedName || 'Public Official');
 
-	// Interlink sections + breadcrumb are independent; fetch in parallel. Each
-	// degrades to empty on any miss so the core profile always renders.
+	// The interlink sections are independent; fetch in parallel. Each degrades to
+	// empty on any miss so the core profile always renders.
 	const { tier, countySlug } = deriveElectionsIndexTier(positionHref, positionLevel);
-	const [otherCandidates, nearbyOfficials, breadcrumb, electionsIndex] = await Promise.all([
+	const breadcrumb = buildBreadcrumbTrail({ displayName, stateCode, raceSlug, positionLevel, positionName });
+	const [otherCandidates, nearbyOfficials, electionsIndex] = await Promise.all([
 		loadOtherCandidates(positionId, personId),
 		loadNearbyOfficials(geoId, personId),
-		buildBreadcrumb({ displayName, stateCode, raceSlug, positionLevel, positionName }),
 		loadElectionsIndex({ stateCode, tier, countySlug }),
 	]);
 

--- a/src/lib/peopleProfile.ts
+++ b/src/lib/peopleProfile.ts
@@ -347,10 +347,24 @@ function candidaciesByRecency(candidacies: PersonCandidacySummary[]): {
 	};
 }
 
-/** The race a person is currently running in, else the last one they ran in. */
+/**
+ * The race a person is currently running in, else the last one they ran in.
+ *
+ * Prefers a candidacy with a slug, because the rest of the page — position
+ * link, breadcrumb crumb, "About [position]", other candidates — is built from
+ * {@link selectPrimaryCandidacy}, which can only use slugged rows. Without that
+ * preference the hero could name one race while everything under it named
+ * another. Slug-less rows are still a fallback rather than being filtered out:
+ * they carry the office name and party, and dropping them would blank the hero
+ * and, via `classifyPartyFrom`, change which profile state the page renders.
+ */
 function primaryCandidacy(person: PersonItem | null): PersonCandidacySummary | null {
-	const { upcoming, past, undated } = candidaciesByRecency(person?.Candidacies ?? []);
-	return upcoming[0] ?? past[0] ?? undated[0] ?? null;
+	const all = person?.Candidacies ?? [];
+	const first = (candidacies: PersonCandidacySummary[]) => {
+		const { upcoming, past, undated } = candidaciesByRecency(candidacies);
+		return upcoming[0] ?? past[0] ?? undated[0] ?? null;
+	};
+	return first(all.filter(c => c.slug)) ?? first(all);
 }
 
 function candidateOfficeName(person: PersonItem | null): string | null {

--- a/src/ui/ProfileContentBlock.tsx
+++ b/src/ui/ProfileContentBlock.tsx
@@ -1,3 +1,4 @@
+import { chunkCardGroups } from './_lib/chunkCardGroups.ts';
 import { cn, tv } from './_lib/utils.ts';
 import { Container } from './Container.tsx';
 import { ElectionsSidebar, type ElectionsSidebarProps } from './ElectionsSidebar.tsx';
@@ -64,21 +65,6 @@ export type ProfileContentBlockProps = {
 	cardLayout?: 'joined' | 'separated';
 };
 
-/** Chunks a flat card list into groups: consecutive same-`group` non-raw cards
- * share a white card; every `raw` card stands alone (self-styled). */
-function chunkCardGroups(cards: ProfileContentCardProps[]): ProfileContentCardProps[][] {
-	const groups: ProfileContentCardProps[][] = [];
-	for (const card of cards) {
-		const last = groups.at(-1);
-		const head = last?.[0];
-		const mergeable =
-			head != null && !card.raw && !head.raw && card.group != null && head.group === card.group;
-		if (mergeable && last) last.push(card);
-		else groups.push([card]);
-	}
-	return groups;
-}
-
 export function ProfileContentBlock(props: ProfileContentBlockProps) {
 	const backgroundColor = props.backgroundColor ?? 'cream';
 	const { base, well, grid, sidebar, sidebarStandalone, content, separatedColumn, separatedCard, title: titleSlot } =
@@ -104,7 +90,12 @@ export function ProfileContentBlock(props: ProfileContentBlockProps) {
 									) : (
 										<div key={gi} className={cn(separatedCard())} data-component='ProfileContentCardGroup'>
 											{group.map((card, ci) => (
-												<ProfileContentCard key={`${gi}-${ci}`} {...card} bare />
+												<ProfileContentCard
+													key={`${gi}-${ci}`}
+													{...card}
+													headingStyle={ci === 0 ? 'section' : 'sub'}
+													bare
+												/>
 											))}
 										</div>
 									),

--- a/src/ui/ProfileContentCard.tsx
+++ b/src/ui/ProfileContentCard.tsx
@@ -31,6 +31,13 @@ export type ProfileContentCardProps = {
 	 */
 	group?: string;
 	heading?: string;
+	/**
+	 * `sub` renders a smaller heading for a section nested inside another
+	 * section's card (Figma: "Accomplishments During This Term" sits under
+	 * "Top Priorities While in Office" at one step down), so a grouped card
+	 * keeps the frame's two-level hierarchy instead of two equal headings.
+	 */
+	headingStyle?: 'section' | 'sub';
 	content?: ReactNode;
 	/**
 	 * Render `content` verbatim, without the card chrome (bottom divider + the
@@ -52,7 +59,11 @@ export function ProfileContentCard(props: ProfileContentCardProps) {
 	return (
 		<article className={cn(base(), props.className)} data-component='ProfileContentCard'>
 			{props.heading && (
-				<Text as='h2' styleType='subtitle-1' className={heading()}>
+				<Text
+					as={props.headingStyle === 'sub' ? 'h3' : 'h2'}
+					styleType={props.headingStyle === 'sub' ? 'subtitle-2' : 'subtitle-1'}
+					className={heading()}
+				>
 					{props.heading}
 				</Text>
 			)}

--- a/src/ui/ProfileContentCard.tsx
+++ b/src/ui/ProfileContentCard.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react';
 import { cn, tv } from './_lib/utils.ts';
-import { Text } from './Text.tsx';
+import { Text, type StyleTypes } from './Text.tsx';
 import { isValidRichText } from './_lib/isValidRichText.ts';
 
 const styles = tv({
@@ -20,6 +20,12 @@ const styles = tv({
 	},
 });
 
+const HEADING_STYLE_TYPE = {
+	section: 'section-heading',
+	sub: 'section-subheading',
+	legacy: 'subtitle-1',
+} as const satisfies Record<string, StyleTypes>;
+
 export type ProfileContentCardProps = {
 	className?: string;
 	cardType?: 'about-me' | 'why-running' | 'top-issues';
@@ -32,10 +38,12 @@ export type ProfileContentCardProps = {
 	group?: string;
 	heading?: string;
 	/**
-	 * `sub` renders a smaller heading for a section nested inside another
-	 * section's card (Figma: "Accomplishments During This Term" sits under
-	 * "Top Priorities While in Office" at one step down), so a grouped card
-	 * keeps the frame's two-level hierarchy instead of two equal headings.
+	 * Heading level within a white card, per the Figma people-profile frames:
+	 * the card's first section is `section` (32/44) and any section stacked
+	 * under it is `sub` (24/32), e.g. "Campaign Issues" beneath "Why I'm
+	 * Running for Office". Supplied by ProfileContentBlock's separated layout
+	 * from the card's position in its group. Left undefined by the joined
+	 * `/candidate` layout, which keeps its own uniform subtitle heading.
 	 */
 	headingStyle?: 'section' | 'sub';
 	content?: ReactNode;
@@ -61,7 +69,7 @@ export function ProfileContentCard(props: ProfileContentCardProps) {
 			{props.heading && (
 				<Text
 					as={props.headingStyle === 'sub' ? 'h3' : 'h2'}
-					styleType={props.headingStyle === 'sub' ? 'subtitle-2' : 'subtitle-1'}
+					styleType={HEADING_STYLE_TYPE[props.headingStyle ?? 'legacy']}
 					className={heading()}
 				>
 					{props.heading}

--- a/src/ui/ProfileHero.tsx
+++ b/src/ui/ProfileHero.tsx
@@ -50,6 +50,9 @@ const styles = tv({
 		// for merge to collapse it against; color is inherited from the container.
 		tagText: 'font-secondary text-[0.875rem] font-medium',
 		nameOffice: 'flex flex-col gap-1',
+		// Office lines stack flush (Figma sets them on consecutive 32px lines with
+		// no gap) even when a second line is present.
+		officeLines: 'flex flex-col',
 		heading: '',
 		// Figma office line is Outfit Medium (500), not the subtitle-1 default (600).
 		office: 'font-medium',
@@ -102,6 +105,14 @@ export type ProfileHeroProps = {
 	office: string;
 	/** When set, the office line renders as a link to the office/position page. */
 	officeHref?: string;
+	/**
+	 * Second office line, stacked directly under the first with no gap. Used by
+	 * the simultaneous candidate + office-holder frame (Figma state C), which
+	 * shows the seat held above "Candidate for [position]".
+	 */
+	secondaryOffice?: string;
+	/** When set, the secondary office line renders as a link. */
+	secondaryOfficeHref?: string;
 	profileImage?: SanityImage;
 	profileImageUrl?: string;
 	isEmpowered?: boolean;
@@ -117,7 +128,19 @@ export type ProfileHeroProps = {
 export function ProfileHero(props: ProfileHeroProps) {
 	const backgroundColor = props.backgroundColor ?? 'midnight';
 	const resolvedBackgroundColor = backgroundColor === 'white' ? 'cream' : backgroundColor;
-	const { base, backgroundWrapper, band, belowBand, container, imageWrapper, image, badge, content, tagRow, tag, tagText, nameOffice, heading, office, officeLink, attribution, attributionIcon, attributionText, notEndorsed } = styles({ backgroundColor: resolvedBackgroundColor });
+	const { base, backgroundWrapper, band, belowBand, container, imageWrapper, image, badge, content, tagRow, tag, tagText, nameOffice, officeLines, heading, office, officeLink, attribution, attributionIcon, attributionText, notEndorsed } = styles({ backgroundColor: resolvedBackgroundColor });
+
+	const renderOfficeLine = (label: string, href?: string) => (
+		<Text key={label} as="p" styleType="subtitle-1" className={office()}>
+			{href ? (
+				<Anchor href={href} className={officeLink()}>
+					{label}
+				</Anchor>
+			) : (
+				label
+			)}
+		</Text>
+	);
 
 	// `attribution` wins when provided; otherwise fall back to legacy `isEmpowered`.
 	const attributionMode = props.attribution ?? (props.isEmpowered ? 'empowered' : 'none');
@@ -180,15 +203,10 @@ export function ProfileHero(props: ProfileHeroProps) {
 							<Text as="h1" styleType={props.candidateName.length > 28 ? 'heading-md' : 'heading-lg'} className={heading()}>
 								{props.candidateName}
 							</Text>
-							<Text as="p" styleType="subtitle-1" className={office()}>
-								{props.officeHref ? (
-									<Anchor href={props.officeHref} className={officeLink()}>
-										{props.office}
-									</Anchor>
-								) : (
-									props.office
-								)}
-							</Text>
+							<div className={officeLines()}>
+								{renderOfficeLine(props.office, props.officeHref)}
+								{props.secondaryOffice && renderOfficeLine(props.secondaryOffice, props.secondaryOfficeHref)}
+							</div>
 						</div>
 						{attributionMode === 'empowered' && (
 							<div className={attribution()}>

--- a/src/ui/Text.tsx
+++ b/src/ui/Text.tsx
@@ -34,6 +34,12 @@ export const styles = tv({
 			'heading-xs': {
 				base: 'text-heading-xs',
 			},
+			'section-heading': {
+				base: 'text-section-heading',
+			},
+			'section-subheading': {
+				base: 'text-section-subheading',
+			},
 			'subtitle-1': {
 				base: 'text-subtitle-1',
 			},

--- a/src/ui/_lib/chunkCardGroups.ts
+++ b/src/ui/_lib/chunkCardGroups.ts
@@ -1,0 +1,24 @@
+import type { ProfileContentCardProps } from '../ProfileContentCard.tsx';
+
+/**
+ * Chunks a flat card list into the separated layout's white cards: consecutive
+ * non-raw cards sharing a `group` go in one card; every `raw` card stands alone
+ * (self-styled).
+ *
+ * A card's index within its chunk also decides its heading level — the Figma
+ * people-profile frames give a card's first section a 32/44 heading and anything
+ * stacked under it a 24/32 one — so this lives apart from the component to keep
+ * it testable without a DOM.
+ */
+export function chunkCardGroups(cards: ProfileContentCardProps[]): ProfileContentCardProps[][] {
+	const groups: ProfileContentCardProps[][] = [];
+	for (const card of cards) {
+		const last = groups.at(-1);
+		const head = last?.[0];
+		const mergeable =
+			head != null && !card.raw && !head.raw && card.group != null && head.group === card.group;
+		if (mergeable && last) last.push(card);
+		else groups.push([card]);
+	}
+	return groups;
+}

--- a/src/ui/_styles/typography.css
+++ b/src/ui/_styles/typography.css
@@ -28,6 +28,23 @@
 	--text-heading-xs--letter-spacing: 0;
 	--text-heading-xs--font-weight: 600;
 
+	/*
+	 * Profile section headings. Mirrors the people-profile frames' Figma
+	 * `typography/3xl` (32/44) and `typography/2xl` (24/32) semibold styles.
+	 * Deliberately absent from the stepped @media blocks below: the frames use
+	 * these same two sizes on the mobile and desktop artboards alike, so unlike
+	 * the `heading-*` ramp they must NOT scale with the viewport.
+	 */
+	--text-section-heading: 2rem;
+	--text-section-heading--line-height: 2.75rem;
+	--text-section-heading--letter-spacing: 0;
+	--text-section-heading--font-weight: 600;
+
+	--text-section-subheading: 1.5rem;
+	--text-section-subheading--line-height: 2rem;
+	--text-section-subheading--letter-spacing: 0;
+	--text-section-subheading--font-weight: 600;
+
 	/* Subtitle */
 	--text-subtitle-1: 1.25rem;
 	--text-subtitle-1--line-height: 125%;


### PR DESCRIPTION
## Why

Emily has reported the same section-ordering bug on four consecutive review rounds. The reason it kept coming back: section order and card grouping lived in a single persona-agnostic list, but the Figma frames genuinely order sections differently per state. So every fix that matched one frame pushed sections out of place on another, and nothing in the test suite asserted the result — the only detector was the designer looking at a preview.

Order is now **data**: one section list per persona, each citing the frame it was read off, plus a separate map of which adjacent sections merge into a single white card. A section renders only if it appears in that persona's list, so a candidate can no longer pick up an in-office section by accident. A new test transcribes the expected heading sequence for all four frames, so a frame change becomes a deliberate edit to a cited list rather than a bug rediscovered in review.

## Section order per frame

| # | A — candidate (`1901:50309`) | B — officeholder (`1901:52117`) | C — both (`1901:53123`) | G — past (`1958:110869`) |
|---|---|---|---|---|
| 1 | Why I'm Running | Top Priorities While in Office | Why I'm Running | About Me |
| 2 | Campaign Issues | Accomplishments This Term | Campaign Issues | Recent Experience |
| 3 | About Me | About Me | About Me | Why I Served |
| 4 | Recent Experience | Recent Experience | Recent Experience | Campaign Issues |
| 5 | Other Candidates | District information | Other Candidates | Top Priorities While in Office |
| 6 | About [position] | About [position] | Top Priorities While in Office | Accomplishments This Term |
| 7 | District information | Nearby Officials | Accomplishments This Term | District information |
| 8 | — | — | About [position] | About [position] |
| 9 | — | — | District information | Nearby Officials |
| 10 | — | — | Nearby Officials | Other Candidates |

The differences are real, not noise: a candidate meets the other candidates before reading about the office; an officeholder leads with their in-office record and sees the district before the office; the past frame opens with About Me and closes with the current race.

## Also in Emily's latest round

- **Bottom CTA centering** — the claimed-page CTA was aligned to the content-card column; the frame centers it on the page (frame A's CTA content sits at x=208, width 1024, in a 1440 frame — symmetric margins), so the column-align override is gone.
- **State C hero shows both roles** — someone serving *and* running now gets two stacked office lines, seat held first and candidacy second (`secondaryRoleTitle`). The candidacy-derived link moves to the second line, since that's the one it actually describes; the held seat stays unlinked until election-api threads through its position slug. Persona tags reorder to Incumbent, Candidate to match.
- **State C issue split** — campaign platform and in-office priorities were collapsing into one card because every seeded issue carried a status. Issues now split on whether they have an in-office status, and Accomplishments nests under Top Priorities as a smaller heading (new optional `headingStyle` on the content card) the way the frame draws it.
- **Dev breadcrumbs** — the harness showed `Elections > Person`, which made ordering review harder than it needed to be. Fixtures now build the real trail (`Elections > State > County > City > Position > Name`) by reusing the production breadcrumb builder, split into an async wrapper plus a synchronous core.

## Section heading scale

Also folded in: every section heading rendered at 24px, but the frames use two levels — 32/44 for a card's first section and 24/32 for anything stacked beneath it — so headings that should have read as parent and child read as equals. Two flat tokens (`--text-section-heading`, `--text-section-subheading`) mirror Figma's `typography/3xl` and `2xl`, deliberately outside the stepped viewport ramp because the frames use the same sizes on mobile and desktop. The level is derived from a section's index within its white card, which is what the frames key off, so the joined `/candidate` layout keeps its uniform heading. `chunkCardGroups` moved to its own module so the grouping — and therefore the heading levels — can be asserted without a DOM.

## Test plan

- `bun run typecheck`, `bun run lint`, `bun run test` — all green (614 unit + 5 DOM, 0 failures; lint reports only pre-existing warnings).
- `src/components/people/personSectionOverrides.test.ts` asserts the full heading sequence for states A/B/C/G against the frame node ids, that a pure candidate never renders an in-office section, that state C's two issue sections stay distinct, the state C dual hero line, the full dev breadcrumb, the two-level heading assignment, and that the breadcrumb's position crumb, the view's office name, and the `About [office]` heading name the same office for every persona.
- Manual: `bun run dev` and walk the four dev profiles (candidate, officeholder, both, past) side by side with the frames — check section order, the two-line hero on state C, the nested Accomplishments heading, the heading size hierarchy within each card, the centered bottom CTA, and the full breadcrumb.

