### PR TITLE
test(people): cover the gp-api revalidation seam

### DIFF
--- a/e2e/revalidate-person.spec.ts
+++ b/e2e/revalidate-person.spec.ts
@@ -1,0 +1,84 @@
+import { expect, test } from '@playwright/test';
+
+/**
+ * End-to-end check of the gp-api → marketing cache-bust seam against a real
+ * deployment. The unit/integration coverage in
+ * src/app/api/revalidate-person/route.test.ts proves the handler's logic; this
+ * proves the deployed thing is reachable, configured, and that the secret in the
+ * marketing deployment matches the one gp-api sends.
+ *
+ * That last part is the failure this is really for: gp-api treats revalidation
+ * as best-effort and never retries or surfaces an error to the user, so a secret
+ * mismatch between AWS (GP_API_* bundle) and Vercel looks exactly like success
+ * from the product side while every public profile silently serves stale content
+ * until its hourly window elapses.
+ *
+ * Run against an environment:
+ *   E2E_BASE_URL=https://gp-marketing-git-develop-good-party.vercel.app \
+ *   MARKETING_REVALIDATE_SECRET=<same value gp-api sends> \
+ *   bunx playwright test e2e/revalidate-person.spec.ts
+ *
+ * Without the secret the authenticated case is skipped, so the rejection cases
+ * still run anywhere.
+ */
+
+const BASE = (process.env['E2E_BASE_URL'] ?? 'https://goodparty.org').replace(/\/+$/, '');
+const ENDPOINT = `${BASE}/api/revalidate-person`;
+const SECRET = process.env['MARKETING_REVALIDATE_SECRET'];
+
+// Any well-formed uuid works: the handler busts a cache tag, and busting a tag
+// nothing is cached under is a no-op. Using a fixed nonexistent id keeps the
+// test from touching a real person's page.
+const PROBE_PERSON_ID = '00000000-0000-4000-8000-000000000000';
+
+test.describe('POST /api/revalidate-person', () => {
+	test('is deployed and configured, not returning 503', async ({ request }) => {
+		const res = await request.post(ENDPOINT, {
+			headers: { 'x-revalidate-secret': 'definitely-not-the-secret' },
+			data: { personId: PROBE_PERSON_ID },
+		});
+
+		// 503 means MARKETING_REVALIDATE_SECRET is missing from this deployment,
+		// which is the one outcome that can't be distinguished from a stale page
+		// by looking at the product side.
+		expect(res.status(), 'MARKETING_REVALIDATE_SECRET is not set on this deployment').not.toBe(
+			503,
+		);
+		expect(res.status()).toBe(401);
+	});
+
+	test('rejects a request with no secret', async ({ request }) => {
+		const res = await request.post(ENDPOINT, { data: { personId: PROBE_PERSON_ID } });
+
+		expect(res.status()).toBe(401);
+	});
+
+	test('accepts the secret gp-api sends and reports the busted tag', async ({ request }) => {
+		test.skip(!SECRET, 'Set MARKETING_REVALIDATE_SECRET to the value gp-api sends');
+
+		const res = await request.post(ENDPOINT, {
+			headers: { 'x-revalidate-secret': SECRET as string },
+			data: { personId: PROBE_PERSON_ID },
+		});
+
+		expect(
+			res.status(),
+			'401 here means the marketing deployment and gp-api hold different secrets',
+		).toBe(200);
+		expect(await res.json()).toEqual({
+			revalidated: true,
+			tag: `person:${PROBE_PERSON_ID}`,
+		});
+	});
+
+	test('rejects a personId that is not a uuid', async ({ request }) => {
+		test.skip(!SECRET, 'Set MARKETING_REVALIDATE_SECRET to the value gp-api sends');
+
+		const res = await request.post(ENDPOINT, {
+			headers: { 'x-revalidate-secret': SECRET as string },
+			data: { personId: 'allen-slagle' },
+		});
+
+		expect(res.status()).toBe(400);
+	});
+});

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "sitemap:validate": "bun run scripts/validate-sitemap-urls.ts",
     "sitemap:prune": "bun run scripts/prune-invalid-urls.ts",
     "test:e2e:sitemap": "playwright test e2e/sitemap.spec.ts",
+    "test:e2e:revalidate": "playwright test e2e/revalidate-person.spec.ts",
     "test:integration:sitemap": "bun test integration/validate-sitemap-urls.test.ts",
     "test:integration:sitemap:batches": "bash scripts/test-sitemap-batches.sh",
     "test:unit": "bun test src --path-ignore-patterns='**/*.test.tsx'",

--- a/src/app/api/revalidate-person/route.test.ts
+++ b/src/app/api/revalidate-person/route.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import { PEOPLE_SITEMAP_CACHE_TAG } from '~/lib/sitemap-entries';
 import { resetNextCacheMock, revalidateTag } from '~/testing/nextCacheMock';
 
 /**
@@ -30,15 +31,14 @@ const PERSON_ID = '74eee01a-1111-4222-8333-444444444444';
 const realEnv = await import('~/lib/env');
 mock.module('~/lib/env', () => ({ ...realEnv, personRevalidateSecret: SECRET }));
 
-// Spread the real exports for the same reason as `~/lib/env`: a registration
-// carrying only the two names this file cares about would hand every other
-// importer in the run a module missing everything else.
-const realSitemapEntries = await import('~/lib/sitemap-entries');
-const clearPeopleSitemapCache = mock(() => undefined);
-mock.module('~/lib/sitemap-entries', () => ({
-	...realSitemapEntries,
-	clearPeopleSitemapCache,
-}));
+// `~/lib/sitemap-entries` is deliberately NOT mocked. Stubbing
+// `clearPeopleSitemapCache` would hand the stub to `sitemap-entries.test.ts`,
+// which calls the real one to reset module-level cache state between its cases —
+// bun keeps the first `mock.module` for a specifier, so whichever file evaluated
+// first would decide, and that file's fetch-count assertions would turn
+// order-dependent. The real function only nulls an in-process promise, so it is
+// safe to run here; the observable half of the sitemap bust is the revalidated
+// tag, which is asserted below.
 
 const { POST } = await import('./route');
 
@@ -56,7 +56,6 @@ async function post(body: unknown, secret?: string | null): Promise<Response> {
 
 beforeEach(() => {
 	resetNextCacheMock();
-	clearPeopleSitemapCache.mockClear();
 });
 
 describe('POST /api/revalidate-person', () => {
@@ -74,8 +73,7 @@ describe('POST /api/revalidate-person', () => {
 	test('also busts the people sitemap so a new page is discoverable', async () => {
 		await post({ personId: PERSON_ID }, SECRET);
 
-		expect(revalidateTag).toHaveBeenCalledWith('people-sitemap');
-		expect(clearPeopleSitemapCache).toHaveBeenCalled();
+		expect(revalidateTag).toHaveBeenCalledWith(PEOPLE_SITEMAP_CACHE_TAG);
 	});
 
 	// Postgres hands gp-api lowercase uuids today, but the tag is what pairs this

--- a/src/app/api/revalidate-person/route.test.ts
+++ b/src/app/api/revalidate-person/route.test.ts
@@ -30,10 +30,14 @@ const PERSON_ID = '74eee01a-1111-4222-8333-444444444444';
 const realEnv = await import('~/lib/env');
 mock.module('~/lib/env', () => ({ ...realEnv, personRevalidateSecret: SECRET }));
 
-const clearPeopleSitemapCache = mock(() => {});
+// Spread the real exports for the same reason as `~/lib/env`: a registration
+// carrying only the two names this file cares about would hand every other
+// importer in the run a module missing everything else.
+const realSitemapEntries = await import('~/lib/sitemap-entries');
+const clearPeopleSitemapCache = mock(() => undefined);
 mock.module('~/lib/sitemap-entries', () => ({
+	...realSitemapEntries,
 	clearPeopleSitemapCache,
-	PEOPLE_SITEMAP_CACHE_TAG: 'people-sitemap',
 }));
 
 const { POST } = await import('./route');

--- a/src/app/api/revalidate-person/route.test.ts
+++ b/src/app/api/revalidate-person/route.test.ts
@@ -1,0 +1,129 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import { resetNextCacheMock, revalidateTag } from '~/testing/nextCacheMock';
+
+/**
+ * Integration coverage for the receiving half of the gp-api → marketing
+ * cache-bust seam. gp-api's `MarketingRevalidationService` is unit-tested on its
+ * own side, but nothing exercised this handler, so a drift in the wire format
+ * (header name, body key, id casing) would only surface as a stale public page
+ * in production — the failure is silent, because the sender treats every
+ * response as best-effort and never retries.
+ *
+ * The request shape asserted here is the contract gp-api sends:
+ *   POST /api/revalidate-person
+ *   x-revalidate-secret: <MARKETING_REVALIDATE_SECRET>
+ *   { "personId": "<uuid>" }
+ *
+ * See packages/gp-api/src/personProfiles/services/marketing-revalidation.service.ts
+ * in the omni repo. Changing either side without the other breaks revalidation.
+ */
+
+const SECRET = 'test-revalidate-secret';
+const PERSON_ID = '74eee01a-1111-4222-8333-444444444444';
+
+// `~/lib/env` reads process.env once at module scope, and a sibling test file may
+// already have evaluated it, so setting the env var here would be too late. Mock
+// the module instead, spreading the real exports so the rest of the suite still
+// sees the genuine values. The secret is fixed for the file because the route
+// binds it at import; the unconfigured (503) branch is a guard clause and is not
+// covered here.
+const realEnv = await import('~/lib/env');
+mock.module('~/lib/env', () => ({ ...realEnv, personRevalidateSecret: SECRET }));
+
+const clearPeopleSitemapCache = mock(() => {});
+mock.module('~/lib/sitemap-entries', () => ({
+	clearPeopleSitemapCache,
+	PEOPLE_SITEMAP_CACHE_TAG: 'people-sitemap',
+}));
+
+const { POST } = await import('./route');
+
+async function post(body: unknown, secret?: string | null): Promise<Response> {
+	const headers = new Headers({ 'content-type': 'application/json' });
+	if (secret != null) headers.set('x-revalidate-secret', secret);
+	const req = new Request('https://marketing.test/api/revalidate-person', {
+		method: 'POST',
+		headers,
+		body: typeof body === 'string' ? body : JSON.stringify(body),
+	});
+	// The handler only touches the standard Request surface (headers + json()).
+	return POST(req as never);
+}
+
+beforeEach(() => {
+	resetNextCacheMock();
+	clearPeopleSitemapCache.mockClear();
+});
+
+describe('POST /api/revalidate-person', () => {
+	test('busts the person tag for a request in gp-api wire format', async () => {
+		const res = await post({ personId: PERSON_ID }, SECRET);
+
+		expect(res.status).toBe(200);
+		expect(await res.json()).toEqual({
+			revalidated: true,
+			tag: `person:${PERSON_ID}`,
+		});
+		expect(revalidateTag).toHaveBeenCalledWith(`person:${PERSON_ID}`);
+	});
+
+	test('also busts the people sitemap so a new page is discoverable', async () => {
+		await post({ personId: PERSON_ID }, SECRET);
+
+		expect(revalidateTag).toHaveBeenCalledWith('people-sitemap');
+		expect(clearPeopleSitemapCache).toHaveBeenCalled();
+	});
+
+	// Postgres hands gp-api lowercase uuids today, but the tag is what pairs this
+	// bust with the tag the page's fetches were cached under, so casing must not
+	// be load-bearing.
+	test('normalizes id casing so the tag matches the one the page cached under', async () => {
+		const res = await post({ personId: PERSON_ID.toUpperCase() }, SECRET);
+
+		expect(res.status).toBe(200);
+		expect(revalidateTag).toHaveBeenCalledWith(`person:${PERSON_ID}`);
+	});
+
+	test('rejects a wrong secret without revalidating', async () => {
+		const res = await post({ personId: PERSON_ID }, 'not-the-secret');
+
+		expect(res.status).toBe(401);
+		expect(revalidateTag).not.toHaveBeenCalled();
+	});
+
+	// A secret of a different length must not throw: the comparison HMACs both
+	// sides to equal-length digests before timingSafeEqual, which would otherwise
+	// throw on a length mismatch and turn a 401 into a 500.
+	test('rejects a secret of a different length as 401, not 500', async () => {
+		const res = await post({ personId: PERSON_ID }, 'short');
+
+		expect(res.status).toBe(401);
+	});
+
+	test('rejects a missing secret header', async () => {
+		const res = await post({ personId: PERSON_ID });
+
+		expect(res.status).toBe(401);
+		expect(revalidateTag).not.toHaveBeenCalled();
+	});
+
+	test('rejects a personId that is not a uuid', async () => {
+		const res = await post({ personId: 'allen-slagle' }, SECRET);
+
+		expect(res.status).toBe(400);
+		expect(revalidateTag).not.toHaveBeenCalled();
+	});
+
+	test('rejects a missing personId', async () => {
+		const res = await post({}, SECRET);
+
+		expect(res.status).toBe(400);
+	});
+
+	test('rejects a malformed body', async () => {
+		const res = await post('{not json', SECRET);
+
+		expect(res.status).toBe(400);
+		expect(revalidateTag).not.toHaveBeenCalled();
+	});
+});

--- a/src/lib/electionApiFetch.test.ts
+++ b/src/lib/electionApiFetch.test.ts
@@ -1,25 +1,9 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { __resetElectionApiAuthForTests } from './electionApiAuth';
-
-// Faithful passthrough for next/cache so the NEXT_RUNTIME branch can be exercised
-// without invoking the real unstable_cache (which hangs outside the Next runtime).
-// It only captures the arguments and immediately runs the wrapped function, so it
-// is harmless even if the module mock leaks to sibling files — and those never set
-// NEXT_RUNTIME, so they bypass this branch entirely.
-let capturedKeyParts: unknown;
-let capturedOptions: { revalidate?: number; tags?: readonly string[] } | undefined;
-const unstable_cache = mock(
-	(
-		fn: (...args: unknown[]) => unknown,
-		keyParts: unknown,
-		options: { revalidate?: number; tags?: readonly string[] },
-	) => {
-		capturedKeyParts = keyParts;
-		capturedOptions = options;
-		return (...args: unknown[]) => fn(...args);
-	},
-);
-mock.module('next/cache', () => ({ unstable_cache }));
+// Mocks next/cache on import so the NEXT_RUNTIME branch can be exercised without
+// invoking the real unstable_cache (which hangs outside the Next runtime). Shared
+// with the other files that mock next/cache; see the module for why.
+import { lastCacheCall, resetNextCacheMock, unstable_cache } from '~/testing/nextCacheMock';
 
 // Imported after the module mock so the dynamic import('next/cache') resolves to it.
 const { fetchElectionApiJsonCached } = await import('./electionApiFetch');
@@ -34,9 +18,7 @@ const ORIGINAL_RUNTIME = process.env['NEXT_RUNTIME'];
 let fetchCalls: number;
 
 beforeEach(() => {
-	unstable_cache.mockClear();
-	capturedKeyParts = undefined;
-	capturedOptions = undefined;
+	resetNextCacheMock();
 	fetchCalls = 0;
 	// Fail-soft auth path: unset secret so run() never touches Clerk.
 	delete process.env['GP_MARKETING_MACHINE_SECRET'];
@@ -72,9 +54,9 @@ describe('fetchElectionApiJsonCached', () => {
 		const result = await fetchElectionApiJsonCached(ELECTION_URL, ['person:abc']);
 
 		expect(unstable_cache).toHaveBeenCalledTimes(1);
-		expect(capturedKeyParts).toEqual(['election-api-json', ELECTION_URL]);
-		expect(capturedOptions?.revalidate).toBe(3600);
-		expect(capturedOptions?.tags).toEqual(['person:abc']);
+		expect(lastCacheCall.keyParts).toEqual(['election-api-json', ELECTION_URL]);
+		expect(lastCacheCall.options?.revalidate).toBe(3600);
+		expect(lastCacheCall.options?.tags).toEqual(['person:abc']);
 		expect(result).toEqual({ status: 200, ok: true, json: OK_BODY });
 	});
 
@@ -84,8 +66,8 @@ describe('fetchElectionApiJsonCached', () => {
 		await fetchElectionApiJsonCached(ELECTION_URL);
 
 		expect(unstable_cache).toHaveBeenCalledTimes(1);
-		expect(capturedOptions && 'tags' in capturedOptions).toBe(false);
-		expect(capturedOptions?.revalidate).toBe(3600);
+		expect(lastCacheCall.options && 'tags' in lastCacheCall.options).toBe(false);
+		expect(lastCacheCall.options?.revalidate).toBe(3600);
 	});
 
 	test('outside the Next runtime, bypasses unstable_cache and fetches directly', async () => {

--- a/src/testing/nextCacheMock.ts
+++ b/src/testing/nextCacheMock.ts
@@ -1,0 +1,45 @@
+/**
+ * The one `next/cache` mock for the logic suite.
+ *
+ * bun keeps the first `mock.module` registration for a specifier and ignores
+ * later ones from other files in the same run. Two test files each mocking
+ * `next/cache` with a different subset of exports therefore means whichever
+ * registration loses gets a module missing the export it needs — and because the
+ * loser silently falls through to the real CJS `next/cache`, the failure is an
+ * import-time SyntaxError in an unrelated file rather than anything pointing at
+ * the collision. Every test that needs `next/cache` mocked imports this module
+ * instead, so the registration always carries the union of the exports.
+ *
+ * `unstable_cache` is a faithful passthrough: it records its arguments and runs
+ * the wrapped function immediately, so it stays harmless for files that only
+ * care about `revalidateTag`.
+ */
+import { mock } from 'bun:test';
+
+export type CachedOptions = { revalidate?: number; tags?: readonly string[] };
+
+/** Arguments of the most recent `unstable_cache` call. */
+export const lastCacheCall: { keyParts?: unknown; options?: CachedOptions } = {};
+
+export const unstable_cache = mock(
+	(
+		fn: (...args: unknown[]) => unknown,
+		keyParts: unknown,
+		options: CachedOptions,
+	) => {
+		lastCacheCall.keyParts = keyParts;
+		lastCacheCall.options = options;
+		return (...args: unknown[]) => fn(...args);
+	},
+);
+
+export const revalidateTag = mock((tag: string) => tag);
+
+export function resetNextCacheMock(): void {
+	unstable_cache.mockClear();
+	revalidateTag.mockClear();
+	delete lastCacheCall.keyParts;
+	delete lastCacheCall.options;
+}
+
+void mock.module('next/cache', () => ({ unstable_cache, revalidateTag }));


### PR DESCRIPTION
Publishing a public profile in the product is supposed to bust the marketing page's cache. The sending half of that seam (`MarketingRevalidationService` in omni) is unit-tested; the receiving half — `/api/revalidate-person` — had no tests at all.

That gap matters more than the usual missing-coverage case because the failure is silent in both directions. gp-api fires the request best-effort and never retries or surfaces an error, so if the wire format drifts, or the secret in Vercel stops matching the one in the AWS bundle, the product reports a successful publish while every public profile keeps serving stale content until its hourly revalidate window elapses. Nothing in CI or in the product UI would say so.

Two layers:

- **Integration** (`src/app/api/revalidate-person/route.test.ts`) drives the real handler with the exact request gp-api sends — the `x-revalidate-secret` header, the `{ personId }` body — and asserts the person tag and the people-sitemap tag both get busted, that id casing isn't load-bearing (the tag has to match what the page's fetches were cached under), and that bad secrets are 401 rather than 500.
- **End-to-end** (`e2e/revalidate-person.spec.ts`) points at a deployment via `E2E_BASE_URL` and checks the endpoint is live and configured, distinguishing a 401 from the 503 that means the secret was never set. Two of its cases are gated behind having the secret in the environment; those are what confirm AWS and Vercel actually agree, which can't be checked any other way since Vercel won't reveal a Sensitive value.

The `next/cache` change is a bug this work surfaced rather than a cleanup. bun keeps the first `mock.module` registration for a specifier and ignores later ones from other files, so once one test mocked `next/cache` with only `unstable_cache`, a second test mocking it for `revalidateTag` silently fell through to the real CJS module and died with an import-time `SyntaxError` pointing at an unrelated file. Both now share one registration carrying the union of exports, verified order-independent.

Not covered: the full publish-to-page flow, which needs an authenticated Clerk session against gp-api and is too slow and flaky for CI. That stays a manual pre-release check.

Made with [Cursor](https://cursor.com)