### PR TITLE
Release `develop` to `master`

### DIFF
--- a/.claude/skills/marketing-ui-clone/SKILL.md
+++ b/.claude/skills/marketing-ui-clone/SKILL.md
@@ -193,6 +193,68 @@ A state is at parity when every measured element is within a few px AND you have
 signed off visually on color, type, and the details geometry cannot see (shadows,
 radius, icons). Never declare parity from the number alone.
 
+## Section ORDER is per-state data, not a shared guess
+
+Geometry parity is only half the job — the frames also disagree about the ORDER
+and GROUPING of the content sections, and that is where this page kept
+regressing (the designer raised the same ordering bug four review rounds in a
+row). The cause each time was the same: one shared section list in code, tuned
+to whichever frame was open, silently wrong for the others.
+
+Before changing section order, read the order off EVERY affected frame and
+write it down. The four claimed frames genuinely differ:
+
+| | A candidate | B officeholder | C both | G past |
+|---|---|---|---|---|
+| opens with | Why + Campaign Issues | Top Priorities + Accomplishments | Why + Campaign Issues | About Me + Recent Experience |
+| Other Candidates | before About Position | absent | before Top Priorities | LAST |
+| About Position vs District | Position → District | **District → Position** | Position → District | **District → Position** |
+| Nearby Officials | absent | last | last | before Other Candidates |
+
+Rules that fall out of this, and that the code now encodes:
+
+- **Order is per persona.** `SECTION_ORDER` in `personSectionOverrides.tsx` maps
+  each persona to its section list, cites the frame node ids, and is the ONLY
+  thing that decides which sections a persona shows. Do not re-add a
+  `holdsOffice(...)`-style gate next to the content — two places to express
+  "candidates have no accomplishments" is how they drift apart.
+- **Lock it with a test.** `personSectionOverrides.test.ts` asserts the exact
+  heading sequence per state against the frame node ids. Ordering had NO test
+  before, which is why every regression reached the designer instead of CI. If
+  a frame changes, change the expectation and cite the new node id.
+- **Two sections can come from one field.** Figma C/G show "Campaign Issues"
+  (no status tags) and "Top Priorities While in Office" (status tags) as
+  separate sections; both are `view.issues`. Partition by the data that
+  distinguishes them (`issue.status`) rather than by persona. Seed fixtures for
+  BOTH kinds or a state silently collapses to one section — which is exactly
+  how C shipped "smooshed".
+- **Heading level follows position in the card, not the section.** The frames
+  give a card's FIRST section a 32/44 heading (Figma `typography/3xl`) and every
+  section stacked under it a 24/32 one (`typography/2xl`), both Outfit SemiBold
+  — so "Campaign Issues" is 32px when it leads a card and 24px when it sits
+  under "Why I'm Running for Office". `ProfileContentBlock` derives this from
+  the card's index within its chunk; never hardcode a level on a section.
+  Note these two sizes are FLAT: the frames use them on the mobile artboard
+  too, which is why `--text-section-heading` / `--text-section-subheading` are
+  omitted from the stepped `@media` blocks that scale the `heading-*` ramp.
+- **Grouping is expressed by `group`, and adjacency matters.** Consecutive
+  cards sharing a `group` merge into one white card (`chunkCardGroups`). Two
+  sections that are adjacent in one state's order but must stay separate cards
+  (Nearby Officials and Other Candidates in G) need DIFFERENT group keys —
+  reusing one `people` group merges them the moment a frame puts them together.
+
+## Layer names lie; use structure + one `get_design_context` to confirm
+
+`get_metadata` is the cheap way to recover a frame's section order (sort the
+content column's children by `y`), but the layer names in this file are cloned
+junk — "Why Running", "About Me Header" and "Mailing Address Section" each name
+several unrelated sections. Identify sections by their STRUCTURE and by text
+width, then confirm with one `get_design_context` (or the frame screenshot) that
+returns real copy. Useful tells in this file: a 409px-wide "Top Issues Header"
+is "Top Priorities While in Office" while a 182px one is "Campaign Issues"; a
+"Mailing Address Section" carrying a tagline pill + button is a Recent
+Experience row; avatar + "Pro Blocks / Tagline" cards are a people section.
+
 ## Troubleshooting (lessons from real runs)
 
 - **Live doesn't match the source you expect? Verify the CURRENT source FIRST.**

--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,16 @@ SANITY_REVALIDATE_SECRET=
 # (election-api -> gp-api). Override with GP_API_BASE_URL if needed.
 ELECTIONS_API_BASE_URL=
 
+# Clerk M2M auth for election-api (SERVER-ONLY — never expose as NEXT_PUBLIC_).
+# gp-marketing mints a machine token with GP_MARKETING_MACHINE_SECRET and sends
+# it on server-side election-api reads (Server Components, sitemap/build
+# scripts). The gp-marketing machine must be connected to the election-api
+# machine in the Clerk dashboard. If unset, election-api requests go out
+# unauthenticated (fine only while election-api is in observe-only mode).
+CLERK_SECRET_KEY=
+CLERK_PUBLISHABLE_KEY=
+GP_MARKETING_MACHINE_SECRET=
+
 # Shared secret gp-api sends (header x-revalidate-secret) to POST /api/revalidate-person
 # to on-demand cache-bust a public /people/* page after publish/unpublish/delete/edit.
 # Must match gp-api's MARKETING_REVALIDATE_SECRET. Paste without trailing newlines.

--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,4 @@ storybook-static/
 # Playwright test artifacts
 playwright-report/
 test-results/
+.vercel

--- a/bun.lock
+++ b/bun.lock
@@ -7,6 +7,7 @@
       "dependencies": {
         "@amplitude/experiment-js-client": "^1.20.3",
         "@amplitude/experiment-node-server": "^1.13.4",
+        "@clerk/backend": "^2.29.7",
         "@csstools/postcss-global-data": "^3.1.0",
         "@deck.gl/aggregation-layers": "^9.3.6",
         "@deck.gl/core": "^9.3.6",
@@ -423,6 +424,12 @@
     "@babel/traverse": ["@babel/traverse@7.28.5", "", { "dependencies": { "@babel/code-frame": "^7.27.1", "@babel/generator": "^7.28.5", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.28.5", "@babel/template": "^7.27.2", "@babel/types": "^7.28.5", "debug": "^4.3.1" } }, "sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ=="],
 
     "@babel/types": ["@babel/types@7.28.5", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA=="],
+
+    "@clerk/backend": ["@clerk/backend@2.33.6", "", { "dependencies": { "@clerk/shared": "^3.47.8", "@clerk/types": "^4.101.26", "standardwebhooks": "^1.0.0", "tslib": "2.8.1" } }, "sha512-5foMmTHEQFt4mDv7AN0RDwUHZhGcg/JYe5hnl9SU/LFS8ZHY29Z2HDtIBmzKgjRfOJTMKj1AM81LgK2UFsGm9Q=="],
+
+    "@clerk/shared": ["@clerk/shared@3.47.8", "", { "dependencies": { "csstype": "3.1.3", "dequal": "2.0.3", "glob-to-regexp": "0.4.1", "js-cookie": "3.0.7", "std-env": "^3.9.0", "swr": "2.3.4" }, "peerDependencies": { "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0", "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0" }, "optionalPeers": ["react", "react-dom"] }, "sha512-cPURU1it/Eal4uXO9SOcHzw9sfE6Opi21W8EJUg+Ri80Q6JKtK8qBmyOpIyqgf09EanexhTzS4xrmYlvn2p7Iw=="],
+
+    "@clerk/types": ["@clerk/types@4.101.26", "", { "dependencies": { "@clerk/shared": "^3.47.8" } }, "sha512-tUeiElAZoXu9Dxom9t6IjkEfsfP7aWSVf5x5mCoHnSr2w+wV4EtEwoLl9vexT5LL0di4qidROSfcrOnorzczIQ=="],
 
     "@codemirror/autocomplete": ["@codemirror/autocomplete@6.20.0", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.17.0", "@lezer/common": "^1.0.0" } }, "sha512-bOwvTOIJcG5FVo5gUUupiwYh8MioPLQ4UcqbcRf7UQ98X90tCa9E1kZ3Z7tqwpZxYyOvh1YTYbmZE9RTfTp5hg=="],
 
@@ -1381,6 +1388,8 @@
     "@sentry/core": ["@sentry/core@8.55.0", "", {}, "sha512-6g7jpbefjHYs821Z+EBJ8r4Z7LT5h80YSWRJaylGS4nW5W5Z2KXzpdnyFarv37O7QjauzVC2E+PABmpkw5/JGA=="],
 
     "@sentry/react": ["@sentry/react@8.55.0", "", { "dependencies": { "@sentry/browser": "8.55.0", "@sentry/core": "8.55.0", "hoist-non-react-statics": "^3.3.2" }, "peerDependencies": { "react": "^16.14.0 || 17.x || 18.x || 19.x" } }, "sha512-/qNBvFLpvSa/Rmia0jpKfJdy16d4YZaAnH/TuKLAtm0BWlsPQzbXCU4h8C5Hsst0Do0zG613MEtEmWpWrVOqWA=="],
+
+    "@stablelib/base64": ["@stablelib/base64@1.0.1", "", {}, "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ=="],
 
     "@standard-schema/spec": ["@standard-schema/spec@1.0.0", "", {}, "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA=="],
 
@@ -2380,6 +2389,8 @@
 
     "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="],
 
+    "fast-sha256": ["fast-sha256@1.3.0", "", {}, "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ=="],
+
     "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
 
     "fastq": ["fastq@1.19.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ=="],
@@ -2759,6 +2770,8 @@
     "jotai": ["jotai@2.16.0", "", { "peerDependencies": { "@babel/core": ">=7.0.0", "@babel/template": ">=7.0.0", "@types/react": ">=17.0.0", "react": ">=17.0.0" }, "optionalPeers": ["@babel/core", "@babel/template", "@types/react", "react"] }, "sha512-NmkwPBet0SHQ28GBfEb10sqnbVOYyn6DL4iazZgGRDUKxSWL0iqcm+IK4TqTSFC2ixGk+XX2e46Wbv364a3cKg=="],
 
     "js-base64": ["js-base64@3.7.8", "", {}, "sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow=="],
+
+    "js-cookie": ["js-cookie@3.0.7", "", {}, "sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw=="],
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
@@ -3546,6 +3559,8 @@
 
     "stackframe": ["stackframe@1.3.4", "", {}, "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw=="],
 
+    "standardwebhooks": ["standardwebhooks@1.0.0", "", { "dependencies": { "@stablelib/base64": "^1.0.0", "fast-sha256": "^1.3.0" } }, "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg=="],
+
     "std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
 
     "stdin-discarder": ["stdin-discarder@0.2.2", "", {}, "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ=="],
@@ -3951,6 +3966,10 @@
     "@babel/register/find-cache-dir": ["find-cache-dir@2.1.0", "", { "dependencies": { "commondir": "^1.0.1", "make-dir": "^2.0.0", "pkg-dir": "^3.0.0" } }, "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ=="],
 
     "@babel/register/make-dir": ["make-dir@2.1.0", "", { "dependencies": { "pify": "^4.0.1", "semver": "^5.6.0" } }, "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA=="],
+
+    "@clerk/shared/csstype": ["csstype@3.1.3", "", {}, "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="],
+
+    "@clerk/shared/swr": ["swr@2.3.4", "", { "dependencies": { "dequal": "^2.0.3", "use-sync-external-store": "^1.4.0" }, "peerDependencies": { "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-bYd2lrhc+VarcpkgWclcUi92wYCpOgMws9Sd1hG1ntAu0NEy+14CbotuFjshBU2kt9rYj9TSmDcybpxpeTU1fg=="],
 
     "@csstools/selector-resolve-nested/postcss-selector-parser": ["postcss-selector-parser@7.1.1", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg=="],
 

--- a/e2e/revalidate-person.spec.ts
+++ b/e2e/revalidate-person.spec.ts
@@ -1,0 +1,84 @@
+import { expect, test } from '@playwright/test';
+
+/**
+ * End-to-end check of the gp-api → marketing cache-bust seam against a real
+ * deployment. The unit/integration coverage in
+ * src/app/api/revalidate-person/route.test.ts proves the handler's logic; this
+ * proves the deployed thing is reachable, configured, and that the secret in the
+ * marketing deployment matches the one gp-api sends.
+ *
+ * That last part is the failure this is really for: gp-api treats revalidation
+ * as best-effort and never retries or surfaces an error to the user, so a secret
+ * mismatch between AWS (GP_API_* bundle) and Vercel looks exactly like success
+ * from the product side while every public profile silently serves stale content
+ * until its hourly window elapses.
+ *
+ * Run against an environment:
+ *   E2E_BASE_URL=https://gp-marketing-git-develop-good-party.vercel.app \
+ *   MARKETING_REVALIDATE_SECRET=<same value gp-api sends> \
+ *   bunx playwright test e2e/revalidate-person.spec.ts
+ *
+ * Without the secret the authenticated case is skipped, so the rejection cases
+ * still run anywhere.
+ */
+
+const BASE = (process.env['E2E_BASE_URL'] ?? 'https://goodparty.org').replace(/\/+$/, '');
+const ENDPOINT = `${BASE}/api/revalidate-person`;
+const SECRET = process.env['MARKETING_REVALIDATE_SECRET'];
+
+// Any well-formed uuid works: the handler busts a cache tag, and busting a tag
+// nothing is cached under is a no-op. Using a fixed nonexistent id keeps the
+// test from touching a real person's page.
+const PROBE_PERSON_ID = '00000000-0000-4000-8000-000000000000';
+
+test.describe('POST /api/revalidate-person', () => {
+	test('is deployed and configured, not returning 503', async ({ request }) => {
+		const res = await request.post(ENDPOINT, {
+			headers: { 'x-revalidate-secret': 'definitely-not-the-secret' },
+			data: { personId: PROBE_PERSON_ID },
+		});
+
+		// 503 means MARKETING_REVALIDATE_SECRET is missing from this deployment,
+		// which is the one outcome that can't be distinguished from a stale page
+		// by looking at the product side.
+		expect(res.status(), 'MARKETING_REVALIDATE_SECRET is not set on this deployment').not.toBe(
+			503,
+		);
+		expect(res.status()).toBe(401);
+	});
+
+	test('rejects a request with no secret', async ({ request }) => {
+		const res = await request.post(ENDPOINT, { data: { personId: PROBE_PERSON_ID } });
+
+		expect(res.status()).toBe(401);
+	});
+
+	test('accepts the secret gp-api sends and reports the busted tag', async ({ request }) => {
+		test.skip(!SECRET, 'Set MARKETING_REVALIDATE_SECRET to the value gp-api sends');
+
+		const res = await request.post(ENDPOINT, {
+			headers: { 'x-revalidate-secret': SECRET as string },
+			data: { personId: PROBE_PERSON_ID },
+		});
+
+		expect(
+			res.status(),
+			'401 here means the marketing deployment and gp-api hold different secrets',
+		).toBe(200);
+		expect(await res.json()).toEqual({
+			revalidated: true,
+			tag: `person:${PROBE_PERSON_ID}`,
+		});
+	});
+
+	test('rejects a personId that is not a uuid', async ({ request }) => {
+		test.skip(!SECRET, 'Set MARKETING_REVALIDATE_SECRET to the value gp-api sends');
+
+		const res = await request.post(ENDPOINT, {
+			headers: { 'x-revalidate-secret': SECRET as string },
+			data: { personId: 'allen-slagle' },
+		});
+
+		expect(res.status()).toBe(400);
+	});
+});

--- a/harness/FOLLOWUPS.md
+++ b/harness/FOLLOWUPS.md
@@ -258,6 +258,16 @@ intentional? Until that is decided, parity work uses exact values for
 shadcn-derived components. This section is the evidence base — append each new
 "Figma value has no gp-marketing token" case as the loop finds it.
 
+- **Hero band gradient blue `#26498f`** (ProfileHero, Figma frame A `1901:50311`:
+  `linear-gradient(156.73deg, #0b1529 68.4%, #26498f 125.1%)`). RESOLVED: promoted
+  to the `--goodparty-blue-bright` token (`hsl(220 58% 35%)`, == `#26498f`; a
+  lighter, more-saturated member of the midnight family) in `_styles/colors.css`,
+  and the gradient now references it. The stops were also re-fit (`--midnight-900`
+  30% → `--goodparty-blue-bright`) because Figma's `68.4% / 125.1%` stops were
+  measured on its full-height hero frame and pushed the blue off-canvas on our
+  short 224px band, making it read as one flat color. Flag for design: bless
+  `--goodparty-blue-bright` as an official token / sync it to Figma.
+
 ### Related infra bug: tailwind-merge drops font-size when combined with text color
 
 The tailwind-merge used by the `Text` component / `cn` / `tv` slots does not

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "sitemap:validate": "bun run scripts/validate-sitemap-urls.ts",
     "sitemap:prune": "bun run scripts/prune-invalid-urls.ts",
     "test:e2e:sitemap": "playwright test e2e/sitemap.spec.ts",
+    "test:e2e:revalidate": "playwright test e2e/revalidate-person.spec.ts",
     "test:integration:sitemap": "bun test integration/validate-sitemap-urls.test.ts",
     "test:integration:sitemap:batches": "bash scripts/test-sitemap-batches.sh",
     "test:unit": "bun test src --path-ignore-patterns='**/*.test.tsx'",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   "dependencies": {
     "@amplitude/experiment-js-client": "^1.20.3",
     "@amplitude/experiment-node-server": "^1.13.4",
+    "@clerk/backend": "^2.29.7",
     "@csstools/postcss-global-data": "^3.1.0",
     "@deck.gl/aggregation-layers": "^9.3.6",
     "@deck.gl/core": "^9.3.6",

--- a/scripts/generate-sitemaps.ts
+++ b/scripts/generate-sitemaps.ts
@@ -205,7 +205,7 @@ async function main(): Promise<void> {
 		environment: {
 			appBase: base,
 			sanityProjectId: process.env['NEXT_PUBLIC_SANITY_PROJECT_ID'] ?? '3rbseux7',
-			electionApiBase: process.env['NEXT_PUBLIC_ELECTION_API_BASE'] ?? process.env['ELECTIONS_API_BASE_URL'] ?? 'https://election-api.goodparty.org',
+			electionApiBase: process.env['ELECTIONS_API_BASE_URL'] ?? 'https://election-api.goodparty.org',
 		},
 		stats: {
 			totalUrls: allGeneratedUrls.length,

--- a/scripts/validate-election-pages.ts
+++ b/scripts/validate-election-pages.ts
@@ -12,6 +12,7 @@ import { mkdir, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { US_STATE_CODES } from '../src/lib/sitemap-entries';
 import { getStateName } from '../src/lib/electionsHelpers';
+import { electionApiAuthHeaders } from '../src/lib/electionApiAuth';
 
 const DEFAULT_BASE_URL = 'https://goodparty.org';
 const DEFAULT_CONCURRENCY = 10;
@@ -20,9 +21,7 @@ const DEFAULT_TIMEOUT_MS = 15_000;
 const STATE_FACTS_MARKER = /data-section=["']Location Facts Block["']/i;
 
 const ELECTION_API_BASE =
-	process.env['NEXT_PUBLIC_ELECTION_API_BASE'] ??
-	process.env['ELECTIONS_API_BASE_URL'] ??
-	'https://election-api.goodparty.org';
+	process.env['ELECTIONS_API_BASE_URL'] ?? 'https://election-api.goodparty.org';
 
 const BAD_PATTERNS = [
 	/\b[a-z][a-z-]*\s+County\b/, // lowercase word + " County" = broken fallback (e.g. "buckeye County"), not "Yuma County"
@@ -101,7 +100,8 @@ async function fetchElectionJson<T>(path: string, params: Record<string, string>
 	const search = new URLSearchParams(params).toString();
 	const url = `${ELECTION_API_BASE.replace(/\/$/, '')}/${path.replace(/^\//, '')}?${search}`;
 	try {
-		const res = await fetch(url);
+		const authHeaders = await electionApiAuthHeaders();
+		const res = await fetch(url, { headers: authHeaders });
 		if (!res.ok) return [];
 		const data: unknown = await res.json();
 		if (Array.isArray(data)) return data as T[];

--- a/src/PageSections/BreadcrumbBlockSection.tsx
+++ b/src/PageSections/BreadcrumbBlockSection.tsx
@@ -23,7 +23,11 @@ export function BreadcrumbBlockSection({ breadcrumbOverride, ...section }: Props
 			<BreadcrumbBlock
 				backgroundColor={backgroundColor}
 				breadcrumbs={breadcrumbs}
-				className='pb-4 md:pb-6'
+				// Figma breadcrumb strip is a compact 68px band between the 80px nav
+				// and the hero (24px above/below the line). The shared block defaults
+				// to py-(--container-padding) (~80px), which stacks a big dark gap
+				// above the hero — collapse it to the Figma rhythm here.
+				className='py-4 md:py-6'
 			/>
 		</section>
 	);

--- a/src/PageSections/ProfileHeroSection.tsx
+++ b/src/PageSections/ProfileHeroSection.tsx
@@ -27,6 +27,8 @@ export function ProfileHeroSection({ profileHeroOverride, tokens: _tokens, ...se
 				candidateName={candidateName}
 				office={office}
 				officeHref={profileHeroOverride?.officeHref}
+				secondaryOffice={profileHeroOverride?.secondaryOffice}
+				secondaryOfficeHref={profileHeroOverride?.secondaryOfficeHref}
 				profileImageUrl={profileHeroOverride?.profileImageUrl}
 				isEmpowered={profileHeroOverride?.isEmpowered}
 				tags={profileHeroOverride?.tags}

--- a/src/PageSections/index.tsx
+++ b/src/PageSections/index.tsx
@@ -109,6 +109,10 @@ export type SectionOverrides = {
 		office: string;
 		/** When set, the hero office line links to the office/position page. */
 		officeHref?: string;
+		/** Second office line for someone serving and running at once (Figma C). */
+		secondaryOffice?: string;
+		/** When set, the second office line links to its own position page. */
+		secondaryOfficeHref?: string;
 		profileImageUrl?: string;
 		isEmpowered?: boolean;
 		/** Persona tag pills shown above the name (e.g. "Candidate", "Incumbent"). */

--- a/src/app/api/revalidate-person/route.test.ts
+++ b/src/app/api/revalidate-person/route.test.ts
@@ -1,0 +1,131 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import { PEOPLE_SITEMAP_CACHE_TAG } from '~/lib/sitemap-entries';
+import { resetNextCacheMock, revalidateTag } from '~/testing/nextCacheMock';
+
+/**
+ * Integration coverage for the receiving half of the gp-api → marketing
+ * cache-bust seam. gp-api's `MarketingRevalidationService` is unit-tested on its
+ * own side, but nothing exercised this handler, so a drift in the wire format
+ * (header name, body key, id casing) would only surface as a stale public page
+ * in production — the failure is silent, because the sender treats every
+ * response as best-effort and never retries.
+ *
+ * The request shape asserted here is the contract gp-api sends:
+ *   POST /api/revalidate-person
+ *   x-revalidate-secret: <MARKETING_REVALIDATE_SECRET>
+ *   { "personId": "<uuid>" }
+ *
+ * See packages/gp-api/src/personProfiles/services/marketing-revalidation.service.ts
+ * in the omni repo. Changing either side without the other breaks revalidation.
+ */
+
+const SECRET = 'test-revalidate-secret';
+const PERSON_ID = '74eee01a-1111-4222-8333-444444444444';
+
+// `~/lib/env` reads process.env once at module scope, and a sibling test file may
+// already have evaluated it, so setting the env var here would be too late. Mock
+// the module instead, spreading the real exports so the rest of the suite still
+// sees the genuine values. The secret is fixed for the file because the route
+// binds it at import; the unconfigured (503) branch is a guard clause and is not
+// covered here.
+const realEnv = await import('~/lib/env');
+mock.module('~/lib/env', () => ({ ...realEnv, personRevalidateSecret: SECRET }));
+
+// `~/lib/sitemap-entries` is deliberately NOT mocked. Stubbing
+// `clearPeopleSitemapCache` would hand the stub to `sitemap-entries.test.ts`,
+// which calls the real one to reset module-level cache state between its cases —
+// bun keeps the first `mock.module` for a specifier, so whichever file evaluated
+// first would decide, and that file's fetch-count assertions would turn
+// order-dependent. The real function only nulls an in-process promise, so it is
+// safe to run here; the observable half of the sitemap bust is the revalidated
+// tag, which is asserted below.
+
+const { POST } = await import('./route');
+
+async function post(body: unknown, secret?: string | null): Promise<Response> {
+	const headers = new Headers({ 'content-type': 'application/json' });
+	if (secret != null) headers.set('x-revalidate-secret', secret);
+	const req = new Request('https://marketing.test/api/revalidate-person', {
+		method: 'POST',
+		headers,
+		body: typeof body === 'string' ? body : JSON.stringify(body),
+	});
+	// The handler only touches the standard Request surface (headers + json()).
+	return POST(req as never);
+}
+
+beforeEach(() => {
+	resetNextCacheMock();
+});
+
+describe('POST /api/revalidate-person', () => {
+	test('busts the person tag for a request in gp-api wire format', async () => {
+		const res = await post({ personId: PERSON_ID }, SECRET);
+
+		expect(res.status).toBe(200);
+		expect(await res.json()).toEqual({
+			revalidated: true,
+			tag: `person:${PERSON_ID}`,
+		});
+		expect(revalidateTag).toHaveBeenCalledWith(`person:${PERSON_ID}`);
+	});
+
+	test('also busts the people sitemap so a new page is discoverable', async () => {
+		await post({ personId: PERSON_ID }, SECRET);
+
+		expect(revalidateTag).toHaveBeenCalledWith(PEOPLE_SITEMAP_CACHE_TAG);
+	});
+
+	// Postgres hands gp-api lowercase uuids today, but the tag is what pairs this
+	// bust with the tag the page's fetches were cached under, so casing must not
+	// be load-bearing.
+	test('normalizes id casing so the tag matches the one the page cached under', async () => {
+		const res = await post({ personId: PERSON_ID.toUpperCase() }, SECRET);
+
+		expect(res.status).toBe(200);
+		expect(revalidateTag).toHaveBeenCalledWith(`person:${PERSON_ID}`);
+	});
+
+	test('rejects a wrong secret without revalidating', async () => {
+		const res = await post({ personId: PERSON_ID }, 'not-the-secret');
+
+		expect(res.status).toBe(401);
+		expect(revalidateTag).not.toHaveBeenCalled();
+	});
+
+	// A secret of a different length must not throw: the comparison HMACs both
+	// sides to equal-length digests before timingSafeEqual, which would otherwise
+	// throw on a length mismatch and turn a 401 into a 500.
+	test('rejects a secret of a different length as 401, not 500', async () => {
+		const res = await post({ personId: PERSON_ID }, 'short');
+
+		expect(res.status).toBe(401);
+	});
+
+	test('rejects a missing secret header', async () => {
+		const res = await post({ personId: PERSON_ID });
+
+		expect(res.status).toBe(401);
+		expect(revalidateTag).not.toHaveBeenCalled();
+	});
+
+	test('rejects a personId that is not a uuid', async () => {
+		const res = await post({ personId: 'allen-slagle' }, SECRET);
+
+		expect(res.status).toBe(400);
+		expect(revalidateTag).not.toHaveBeenCalled();
+	});
+
+	test('rejects a missing personId', async () => {
+		const res = await post({}, SECRET);
+
+		expect(res.status).toBe(400);
+	});
+
+	test('rejects a malformed body', async () => {
+		const res = await post('{not json', SECRET);
+
+		expect(res.status).toBe(400);
+		expect(revalidateTag).not.toHaveBeenCalled();
+	});
+});

--- a/src/app/api/revalidate-person/route.unconfigured.test.ts
+++ b/src/app/api/revalidate-person/route.unconfigured.test.ts
@@ -1,0 +1,57 @@
+/**
+ * The 503 "not configured" branch, which cannot be covered from route.test.ts.
+ *
+ * `~/lib/env` reads process.env at module scope and the route binds the secret at
+ * import, so a single file can only ever exercise one side of the guard. This file
+ * gets its own module registry, so it can bind the same route against an absent
+ * secret.
+ *
+ * The mock spreads the real exports rather than returning a bare object: other
+ * modules pulled in through this import graph read other env values, and replacing
+ * the whole module with a single key would strand them on undefined.
+ *
+ * Worth guarding because the failure mode is silent. If the branch is ever dropped,
+ * a deployment missing MARKETING_REVALIDATE_SECRET stops announcing itself and
+ * instead compares against an undefined secret — which is a 500 at best, and at
+ * worst degrades into accepting whatever the caller sent.
+ */
+import { describe, expect, mock, test } from 'bun:test';
+
+const realEnv = await import('~/lib/env');
+mock.module('~/lib/env', () => ({ ...realEnv, personRevalidateSecret: undefined }));
+
+const { POST } = await import('./route');
+
+const PERSON_ID = '74eee01a-1111-4222-8333-444444444444';
+
+async function post(secret: string | null): Promise<Response> {
+	const headers = new Headers({ 'content-type': 'application/json' });
+	if (secret != null) headers.set('x-revalidate-secret', secret);
+	const req = new Request('https://marketing.test/api/revalidate-person', {
+		method: 'POST',
+		headers,
+		body: JSON.stringify({ personId: PERSON_ID }),
+	});
+	// The handler only touches the standard Request surface (headers + json()).
+	return POST(req as never);
+}
+
+describe('POST /api/revalidate-person — secret not configured', () => {
+	test('answers 503 rather than comparing against an absent secret', async () => {
+		const res = await post('any-secret');
+
+		expect(res.status).toBe(503);
+	});
+
+	// The guard has to precede the header check: an unconfigured deployment is a
+	// deployment problem, and reporting it as 401 would send whoever is debugging
+	// it hunting for a secret mismatch that doesn't exist.
+	test('reports the misconfiguration even when no secret is sent', async () => {
+		const res = await post(null);
+
+		expect(res.status).toBe(503);
+		expect(await res.json()).toMatchObject({
+			error: expect.stringContaining('MARKETING_REVALIDATE_SECRET'),
+		});
+	});
+});

--- a/src/components/people/personSectionOverrides.test.ts
+++ b/src/components/people/personSectionOverrides.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Locks the profile content-section ORDER to the Figma frames.
+ *
+ * The order regressed repeatedly because it lived as one shared list while the
+ * frames actually differ per persona, and nothing asserted it. These cases are
+ * transcribed from the frames themselves:
+ *   A 1901:50309 (candidate)     B 1901:52117 (officeholder)
+ *   C 1901:53123 (both)          G 1958:110869 (past)
+ * If a frame changes, update the expectation here and cite the node id.
+ */
+import { describe, expect, test } from 'bun:test';
+import { getDevPersonProfileView } from '~/lib/devPeopleProfileFixtures';
+import { chunkCardGroups } from '~/ui/_lib/chunkCardGroups';
+import { buildPersonSectionOverrides } from './personSectionOverrides';
+
+function contentCards(slug: string) {
+	const view = getDevPersonProfileView(slug);
+	if (!view) throw new Error(`no dev fixture for ${slug}`);
+	return buildPersonSectionOverrides(view).component_profileContentBlock?.contentCards ?? [];
+}
+
+/** Ordered headings of the content well, ignoring the chrome-less raw cards. */
+function sectionHeadings(slug: string): string[] {
+	return contentCards(slug).flatMap(card => (card.heading ? [card.heading] : []));
+}
+
+describe('profile section order matches the Figma frames', () => {
+	test('state A — candidate meets other candidates before the office', () => {
+		expect(sectionHeadings('allen-slagle-74eee01a')).toEqual([
+			'Why I\u2019m Running for Office',
+			'Campaign Issues',
+			'About Me',
+			'Recent Experience',
+			// A candidate-only person holds no seat, so the office name comes from
+			// the candidacy rather than a held office.
+			'Other Candidates for Springfield City Council',
+			'About Springfield City Council',
+			'District information',
+		]);
+	});
+
+	test('state B — officeholder leads with the in-office record, district before office', () => {
+		expect(sectionHeadings('tracy-good-ecff49d3')).toEqual([
+			'Top Priorities While in Office',
+			'Accomplishments During This Term',
+			'About Me',
+			'Recent Experience',
+			'District information',
+			'About Springfield City Council',
+			'Nearby Officials',
+		]);
+	});
+
+	test('state C — serving and running keeps campaign and in-office issues separate', () => {
+		const headings = sectionHeadings('susan-overman-ad914b82');
+		expect(headings).toEqual([
+			'Why I\u2019m Running for Office',
+			'Campaign Issues',
+			'About Me',
+			'Recent Experience',
+			'Other Candidates for Springfield City Council',
+			'Top Priorities While in Office',
+			'Accomplishments During This Term',
+			'About Springfield City Council',
+			'District information',
+			'Nearby Officials',
+		]);
+		// The two issue sections must stay distinct — they were previously merged
+		// into a single card because every seeded issue carried a status.
+		expect(headings.filter(h => h === 'Campaign Issues')).toHaveLength(1);
+		expect(headings.filter(h => h === 'Top Priorities While in Office')).toHaveLength(1);
+	});
+
+	test('state G — past official opens with About Me and closes with other candidates', () => {
+		expect(sectionHeadings('bill-fortner-61a42912')).toEqual([
+			'About Me',
+			'Recent Experience',
+			'Why I Served',
+			'Campaign Issues',
+			'Top Priorities While in Office',
+			'Accomplishments During This Term',
+			'District information',
+			'About Springfield City Council',
+			'Nearby Officials',
+			'Other Candidates for Springfield City Council',
+		]);
+	});
+
+	test('a pure candidate never shows an in-office section', () => {
+		const headings = sectionHeadings('allen-slagle-74eee01a');
+		expect(headings).not.toContain('Accomplishments During This Term');
+		expect(headings).not.toContain('Top Priorities While in Office');
+		expect(headings).not.toContain('Nearby Officials');
+	});
+});
+
+describe('unclaimed pages prompt for every section the claimed page would show', () => {
+	/**
+	 * The unclaimed frames (D 1917:88035, E 1917:88616, F 1917:89211,
+	 * H 1970:113629) carry a prompt per authored section, so a persona must not
+	 * lose one just because nobody has written it yet.
+	 */
+	test('state F — serving and running prompts for campaign AND in-office sections', () => {
+		// Guards the premise: if this fixture ever becomes claimed the assertions
+		// below would pass on authored content and stop testing the placeholders.
+		expect(getDevPersonProfileView('tim-ficken-0a951485')?.claimed).toBe(false);
+		const headings = sectionHeadings('tim-ficken-0a951485');
+		expect(headings).toContain('Campaign Issues');
+		expect(headings).toContain('Top Priorities While in Office');
+		expect(headings).toContain('Accomplishments During This Term');
+	});
+
+	test('state E — an officeholder prompts for their in-office record, not a campaign', () => {
+		const headings = sectionHeadings('rob-zotti-d8c578fb');
+		expect(headings).toContain('Top Priorities While in Office');
+		expect(headings).toContain('Accomplishments During This Term');
+		expect(headings).not.toContain('Campaign Issues');
+	});
+
+	test('state D — a candidate is never prompted for an in-office record', () => {
+		const headings = sectionHeadings('kim-byrd-b77f912d');
+		expect(headings).toContain('Campaign Issues');
+		expect(headings).not.toContain('Top Priorities While in Office');
+		expect(headings).not.toContain('Accomplishments During This Term');
+	});
+});
+
+describe('card grouping sets the Figma heading levels', () => {
+	/** Headings per white card: the first is the 32/44 one, the rest are 24/32. */
+	function headingsByCard(slug: string): string[][] {
+		return chunkCardGroups(contentCards(slug))
+			.map(group => group.flatMap(card => (card.heading ? [card.heading] : [])))
+			.filter(headings => headings.length > 0);
+	}
+
+	test('state A pairs each lead section with its sub-section', () => {
+		expect(headingsByCard('allen-slagle-74eee01a')).toEqual([
+			['Why I\u2019m Running for Office', 'Campaign Issues'],
+			['About Me', 'Recent Experience'],
+			['Other Candidates for Springfield City Council'],
+			['About Springfield City Council'],
+			['District information'],
+		]);
+	});
+
+	test('accomplishments sit under the in-office priorities, not beside them', () => {
+		expect(headingsByCard('tracy-good-ecff49d3')[0]).toEqual([
+			'Top Priorities While in Office',
+			'Accomplishments During This Term',
+		]);
+	});
+
+	test('state C keeps campaign issues and the in-office record in separate cards', () => {
+		// The original regression: both issue sections shared a group and merged
+		// into one card. sectionHeadings alone cannot catch that — it flattens.
+		const cards = headingsByCard('susan-overman-ad914b82');
+		expect(cards).toContainEqual(['Why I\u2019m Running for Office', 'Campaign Issues']);
+		expect(cards).toContainEqual([
+			'Top Priorities While in Office',
+			'Accomplishments During This Term',
+		]);
+	});
+
+	test('state G keeps nearby officials and other candidates in separate cards', () => {
+		const cards = headingsByCard('bill-fortner-61a42912');
+		expect(cards).toContainEqual(['Nearby Officials']);
+		expect(cards).toContainEqual(['Other Candidates for Springfield City Council']);
+	});
+});
+
+describe('hero', () => {
+	test('state C shows the seat held above the candidacy', () => {
+		const view = getDevPersonProfileView('susan-overman-ad914b82');
+		const hero = buildPersonSectionOverrides(view!).component_profileHero;
+		expect(hero?.secondaryOffice).toMatch(/^Candidate for /);
+		expect(hero?.office).not.toMatch(/^Candidate for /);
+		expect(hero?.tags).toEqual(['Incumbent', 'Candidate']);
+		// The position link belongs to the race being run, so it moves to the
+		// candidacy line and the held-office line above it stays unlinked.
+		expect(hero?.officeHref).toBeUndefined();
+		expect(hero?.secondaryOfficeHref).toContain('/elections/');
+	});
+
+	test('a candidate-only hero has no second office line', () => {
+		const view = getDevPersonProfileView('allen-slagle-74eee01a');
+		const hero = buildPersonSectionOverrides(view!).component_profileHero;
+		expect(hero?.secondaryOffice).toBeUndefined();
+		expect(hero?.office).toMatch(/^Candidate for /);
+	});
+});
+
+describe('breadcrumb', () => {
+	test('dev profiles render the full location trail, not just Elections > Name', () => {
+		const view = getDevPersonProfileView('allen-slagle-74eee01a');
+		expect(view!.breadcrumb.map(crumb => crumb.label)).toEqual([
+			'Elections',
+			'Wyoming',
+			'Laramie',
+			'Springfield',
+			'Springfield City Council',
+			'Allen Slagle',
+		]);
+	});
+
+	test('every dev persona names one office in the trail, the hero, and the sections', () => {
+		for (const slug of ['allen-slagle-74eee01a', 'tracy-good-ecff49d3', 'susan-overman-ad914b82', 'bill-fortner-61a42912']) {
+			const view = getDevPersonProfileView(slug);
+			const positionCrumb = view!.breadcrumb.at(-2)?.label;
+			expect(positionCrumb).toBe(view!.officeName ?? undefined);
+			expect(sectionHeadings(slug)).toContain(`About ${positionCrumb}`);
+		}
+	});
+});

--- a/src/components/people/personSectionOverrides.tsx
+++ b/src/components/people/personSectionOverrides.tsx
@@ -47,10 +47,67 @@ function whyHeading(persona: PersonPersona): string {
 	}
 }
 
-/** Personas that actually hold (or held) office — the only ones that show issue
- * progress tags. A pure candidate has no in-office record, so frame A omits them. */
-function holdsOffice(persona: PersonPersona): boolean {
-	return persona === 'officeholder' || persona === 'both' || persona === 'past';
+/**
+ * The content sections a profile can show, named after the Figma frames. The
+ * issues list splits in two: the campaign platform (issues with no in-office
+ * status) and the in-office record (issues carrying a status tag).
+ */
+type SectionKey =
+	| 'why'
+	| 'campaignIssues'
+	| 'aboutMe'
+	| 'recentExperience'
+	| 'otherCandidates'
+	| 'inOfficePriorities'
+	| 'accomplishments'
+	| 'aboutPosition'
+	| 'district'
+	| 'nearbyOfficials';
+
+/**
+ * Section order per persona, read off the Figma frames: A 1901:50309,
+ * B 1901:52117, C 1901:53123, G 1958:110869. The frames genuinely differ —
+ * a candidate meets the other candidates before the office, an office-holder
+ * leads with their in-office record and sees the district before the office,
+ * and the past frame opens with About Me. Assuming one shared order is what
+ * kept regressing against the designs, so each persona owns its list and the
+ * order alone decides which sections a persona shows.
+ */
+const SECTION_ORDER: Record<PersonPersona, SectionKey[]> = {
+	candidate: ['why', 'campaignIssues', 'aboutMe', 'recentExperience', 'otherCandidates', 'aboutPosition', 'district'],
+	officeholder: ['inOfficePriorities', 'accomplishments', 'aboutMe', 'recentExperience', 'district', 'aboutPosition', 'nearbyOfficials'],
+	both: ['why', 'campaignIssues', 'aboutMe', 'recentExperience', 'otherCandidates', 'inOfficePriorities', 'accomplishments', 'aboutPosition', 'district', 'nearbyOfficials'],
+	past: ['aboutMe', 'recentExperience', 'why', 'campaignIssues', 'inOfficePriorities', 'accomplishments', 'district', 'aboutPosition', 'nearbyOfficials', 'otherCandidates'],
+};
+
+/**
+ * Adjacent sections sharing a group collapse into one white card (see
+ * `chunkCardGroups` in ProfileContentBlock) — how the frames bundle Why with
+ * Campaign Issues, About Me with Recent Experience, and the in-office record.
+ * Other Candidates and Nearby Officials take distinct groups so the past
+ * frame, where they sit next to each other, still renders two cards.
+ */
+const SECTION_GROUP: Record<SectionKey, string> = {
+	why: 'platform',
+	campaignIssues: 'platform',
+	aboutMe: 'about',
+	recentExperience: 'about',
+	otherCandidates: 'candidates',
+	inOfficePriorities: 'inoffice',
+	accomplishments: 'inoffice',
+	aboutPosition: 'position',
+	district: 'district',
+	nearbyOfficials: 'nearby',
+};
+
+type SectionMap = Partial<Record<SectionKey, ProfileContentCardProps>>;
+
+/** Issues carrying a status are the in-office record; the rest are the platform. */
+function splitIssues(issues: PersonProfileView['issues']) {
+	return {
+		platform: issues.filter(issue => !issue.status),
+		inOffice: issues.filter(issue => issue.status),
+	};
 }
 
 /** Stable empowered-first ordering (Figma puts the GoodParty candidate on top). */
@@ -69,23 +126,16 @@ function personaTags(persona: PersonPersona): string[] {
 		case 'officeholder':
 			return ['Incumbent'];
 		case 'both':
-			return ['Candidate', 'Incumbent'];
+			// Figma C leads with the seat held, matching the hero's office lines.
+			return ['Incumbent', 'Candidate'];
 		case 'past':
 			return ['Former Official'];
 	}
 }
 
-function issuesHeading(persona: PersonPersona): string {
-	switch (persona) {
-		case 'candidate':
-		case 'both':
-			return 'Campaign Issues';
-		case 'officeholder':
-			return 'Top Priorities in Office';
-		case 'past':
-			return 'Priorities in Office';
-	}
-}
+const CAMPAIGN_ISSUES_HEADING = 'Campaign Issues';
+const IN_OFFICE_ISSUES_HEADING = 'Top Priorities While in Office';
+const ACCOMPLISHMENTS_HEADING = 'Accomplishments During This Term';
 
 const STATUS_LABELS: Record<PersonProfileIssueStatus, string> = {
 	IN_PROGRESS: 'In Progress',
@@ -144,26 +194,29 @@ function IssuesContent({ issues, showStatus }: { issues: PersonProfileView['issu
 	);
 }
 
-function AccomplishmentsContent({ accomplishments }: { accomplishments: PersonAccomplishment[] }): ReactNode {
+function AccomplishmentsContent({ accomplishments, lead }: { accomplishments: PersonAccomplishment[]; lead: string }): ReactNode {
 	return (
-		<ul className='flex flex-col gap-6'>
-			{accomplishments.map((item, index) => (
-				<li key={`${item.title}-${index}`} className='flex flex-col gap-2'>
-					<StatusTag status='RESOLVED' />
-					<div className='flex flex-wrap items-baseline gap-x-3 gap-y-1'>
-						<Text as='span' styleType='subtitle-2'>
-							{item.title}
-						</Text>
-						{item.date && (
-							<Text as='span' styleType='caption' className='text-gray-500'>
-								{item.date}
+		<div className='flex flex-col gap-6'>
+			<Text styleType='body-2'>{lead}</Text>
+			<ul className='flex flex-col gap-6'>
+				{accomplishments.map((item, index) => (
+					<li key={`${item.title}-${index}`} className='flex flex-col gap-2'>
+						<StatusTag status='RESOLVED' />
+						<div className='flex flex-wrap items-baseline gap-x-3 gap-y-1'>
+							<Text as='span' styleType='subtitle-2'>
+								{item.title}
 							</Text>
-						)}
-					</div>
-					{item.description && <Text styleType='body-2'>{item.description}</Text>}
-				</li>
-			))}
-		</ul>
+							{item.date && (
+								<Text as='span' styleType='caption' className='text-gray-500'>
+									{item.date}
+								</Text>
+							)}
+						</div>
+						{item.description && <Text styleType='body-2'>{item.description}</Text>}
+					</li>
+				))}
+			</ul>
+		</div>
 	);
 }
 
@@ -248,32 +301,41 @@ function AboutPositionContent({ view }: { view: PersonProfileView }): ReactNode 
 }
 
 /**
- * Person-authored content cards, in Figma order: Why → Campaign Issues → About
- * Me → Accomplishments. These are empowerment-gated (only shown on empowered
- * pages). Recent Experience is NOT here — it's a civics-spine card that renders
- * on every state (see buildCivicCards).
+ * Person-authored sections, empowerment-gated (only shown on empowered pages).
+ * Which of these actually render — and in what order — is decided solely by
+ * `SECTION_ORDER` for the persona, so a candidate never picks up an in-office
+ * section and vice versa.
  */
-function buildAuthoredCards(view: PersonProfileView): ProfileContentCardProps[] {
-	const cards: ProfileContentCardProps[] = [];
-	// "Why I'm Running for Office" is candidate-only (Figma A); officeholder/past
-	// frames drop the section entirely.
-	if (view.whyRunning && (view.persona === 'candidate' || view.persona === 'both')) {
-		cards.push({ cardType: 'why-running', group: 'platform', heading: whyHeading(view.persona), content: view.whyRunning });
+function buildAuthoredSections(view: PersonProfileView): SectionMap {
+	const sections: SectionMap = {};
+	const { platform, inOffice } = splitIssues(view.issues);
+	if (view.whyRunning) {
+		sections.why = { cardType: 'why-running', heading: whyHeading(view.persona), content: view.whyRunning };
 	}
-	if (view.issues.length > 0) {
-		cards.push({ cardType: 'top-issues', group: 'platform', heading: issuesHeading(view.persona), content: <IssuesContent issues={view.issues} showStatus={holdsOffice(view.persona)} /> });
+	if (platform.length > 0) {
+		sections.campaignIssues = { cardType: 'top-issues', heading: CAMPAIGN_ISSUES_HEADING, content: <IssuesContent issues={platform} showStatus={false} /> };
 	}
-	// Accomplishments are an in-office record — only personas who hold/held office
-	// show them. A pure candidate (Figma A) has none, so gate the section. Per Figma
-	// (B/C/G) it sits immediately after Campaign Issues, grouped with them as the
-	// in-office record, BEFORE About Me.
-	if (view.accomplishments.length > 0 && holdsOffice(view.persona)) {
-		cards.push({ group: 'platform', heading: 'Accomplishments', content: <AccomplishmentsContent accomplishments={view.accomplishments} /> });
+	if (inOffice.length > 0) {
+		sections.inOfficePriorities = { cardType: 'top-issues', heading: IN_OFFICE_ISSUES_HEADING, content: <IssuesContent issues={inOffice} showStatus /> };
+	}
+	// Figma nests this under "Top Priorities While in Office" with a lead-in
+	// line. The smaller heading comes from sharing that section's group, not
+	// from being set here.
+	if (view.accomplishments.length > 0) {
+		sections.accomplishments = {
+			heading: ACCOMPLISHMENTS_HEADING,
+			content: (
+				<AccomplishmentsContent
+					accomplishments={view.accomplishments}
+					lead={`${view.displayName} has accomplished the following:`}
+				/>
+			),
+		};
 	}
 	if (view.bio) {
-		cards.push({ cardType: 'about-me', group: 'about', heading: 'About Me', content: view.bio });
+		sections.aboutMe = { cardType: 'about-me', heading: 'About Me', content: view.bio };
 	}
-	return cards;
+	return sections;
 }
 
 /** Muted, italic prompt copy used inside unclaimed placeholder cards. */
@@ -313,9 +375,28 @@ function issuesPrompt(view: PersonProfileView): string {
 			return `Which issues would ${displayName} champion${office ? ` as ${office}` : ''}? Their campaign priorities will appear here once they claim their profile.`;
 		case 'officeholder':
 			return `What are ${displayName}'s top priorities${office ? ` for ${office}` : ''}? Their agenda in office will appear here once they claim their profile.`;
+		// A past official's frame carries this section AND the in-office one, so
+		// this has to ask about the campaign; `inOfficePrompt` covers the record.
 		case 'past':
-			return `Which priorities did ${displayName} focus on${office ? ` in ${office}` : ' in office'}? Their record will appear here once they claim their profile.`;
+			return `What did ${displayName} campaign on${office ? ` for ${office}` : ''}? Their platform and issues will appear here once they claim their profile.`;
 	}
+}
+
+/** Copy for the "Top Priorities While in Office" placeholder prompt. */
+function inOfficePrompt(view: PersonProfileView): string {
+	const office = view.officeName ? ` in ${view.officeName}` : ' in office';
+	if (view.persona === 'past') {
+		return `Which priorities did ${view.displayName} focus on${office}? Their record will appear here once they claim their profile.`;
+	}
+	return `What is ${view.displayName} focused on${office}? Their priorities will appear here once they claim their profile.`;
+}
+
+/** Copy for the "Accomplishments During This Term" placeholder prompt. */
+function accomplishmentsPrompt(view: PersonProfileView): string {
+	const office = view.officeName ? ` in ${view.officeName}` : ' in office';
+	const verb = view.persona === 'past' ? 'did' : 'has';
+	const achieved = view.persona === 'past' ? 'achieve' : 'achieved';
+	return `What ${verb} ${view.displayName} ${achieved}${office}? Their accomplishments will appear here once they claim their profile.`;
 }
 
 /** Copy for the "About Me" placeholder prompt. */
@@ -324,23 +405,39 @@ function aboutPrompt(view: PersonProfileView): string {
 	return `Get to know ${view.displayName}. Their background, experience, and story${office} will appear here once they claim their profile.`;
 }
 
+/** The sections a profile owner writes; the rest come from the civic spine. */
+const AUTHORED_SECTIONS = new Set<SectionKey>([
+	'why',
+	'campaignIssues',
+	'inOfficePriorities',
+	'accomplishments',
+	'aboutMe',
+]);
+
 /**
  * Placeholder prompt cards shown in the authored-cards slot for UNCLAIMED but
- * empowered pages (Figma states D/E/F/H). They mirror the authored cards' Figma
- * order and persona-aware headings (Why → Campaign Issues → About Me) but carry
- * muted, name + office prompt copy inviting engagement, since there is no
- * owner-authored content yet. Accomplishments is intentionally omitted (Figma
- * does not show a placeholder for it).
+ * empowered pages (Figma states D 1917:88035, E 1917:88616, F 1917:89211,
+ * H 1970:113629). The frames show a prompt for every authored section the
+ * claimed page would have, so this seeds from the persona's `SECTION_ORDER`
+ * rather than its own list — an unclaimed page must never advertise a
+ * different set of sections than its claimed counterpart. Copy is muted
+ * name + office prompt text, since there is no owner-authored content yet.
  */
-function buildAuthoredPlaceholderCards(view: PersonProfileView): ProfileContentCardProps[] {
-	const cards: ProfileContentCardProps[] = [];
-	// Mirror the claimed gating: the "Why" prompt is candidate-only.
-	if (view.persona === 'candidate' || view.persona === 'both') {
-		cards.push({ cardType: 'why-running', group: 'platform', heading: whyHeading(view.persona), content: <PlaceholderPrompt>{whyPrompt(view)}</PlaceholderPrompt> });
+function buildAuthoredPlaceholderSections(view: PersonProfileView): SectionMap {
+	const prompt = (text: string) => <PlaceholderPrompt>{text}</PlaceholderPrompt>;
+	const placeholders: Record<string, ProfileContentCardProps> = {
+		why: { cardType: 'why-running', heading: whyHeading(view.persona), content: prompt(whyPrompt(view)) },
+		campaignIssues: { cardType: 'top-issues', heading: CAMPAIGN_ISSUES_HEADING, content: prompt(issuesPrompt(view)) },
+		inOfficePriorities: { cardType: 'top-issues', heading: IN_OFFICE_ISSUES_HEADING, content: prompt(inOfficePrompt(view)) },
+		accomplishments: { heading: ACCOMPLISHMENTS_HEADING, content: prompt(accomplishmentsPrompt(view)) },
+		aboutMe: { cardType: 'about-me', heading: 'About Me', content: prompt(aboutPrompt(view)) },
+	};
+	const sections: SectionMap = {};
+	for (const key of SECTION_ORDER[view.persona]) {
+		const card = AUTHORED_SECTIONS.has(key) ? placeholders[key] : undefined;
+		if (card) sections[key] = card;
 	}
-	cards.push({ cardType: 'top-issues', group: 'platform', heading: issuesHeading(view.persona), content: <PlaceholderPrompt>{issuesPrompt(view)}</PlaceholderPrompt> });
-	cards.push({ cardType: 'about-me', group: 'about', heading: 'About Me', content: <PlaceholderPrompt>{aboutPrompt(view)}</PlaceholderPrompt> });
-	return cards;
+	return sections;
 }
 
 /** First 4-digit year in an ISO-ish date string (avoids TZ off-by-one). */
@@ -391,50 +488,53 @@ function OtherCandidatesContent({ cards }: { cards: CandidateCard[] }): ReactNod
 }
 
 /**
- * Civics-spine content cards shown on every state (data permitting), in Figma
- * order after the authored cards: Recent Experience → Other candidates →
- * About [position] → District Information (voter-density map). These are NOT
- * empowerment-gated, so unclaimed major-party (I/J) and removed (K/L) pages
- * still render their public-record context per the Figma removal frames.
+ * Civics-spine sections, available on every state (data permitting). These are
+ * NOT empowerment-gated, so unclaimed major-party (I/J) and removed (K/L)
+ * pages still render their public-record context per the Figma removal frames.
  */
-function buildCivicCards(view: PersonProfileView): ProfileContentCardProps[] {
-	const cards: ProfileContentCardProps[] = [];
+function buildCivicSections(view: PersonProfileView): SectionMap {
+	const sections: SectionMap = {};
 	if (view.recentExperience.length > 0) {
-		cards.push({ group: 'about', heading: 'Recent Experience', content: <ExperienceContent experience={view.recentExperience} /> });
+		sections.recentExperience = { heading: 'Recent Experience', content: <ExperienceContent experience={view.recentExperience} /> };
 	}
 	if (view.positionDescription || view.termLabel || view.electionDate) {
-		cards.push({
-			group: 'position',
+		sections.aboutPosition = {
 			heading: `About ${view.officeName ?? 'the Role'}`,
 			content: <AboutPositionContent view={view} />,
-		});
+		};
 	}
 	const districtMap = buildDistrictMap(view);
 	if (districtMap) {
-		cards.push({ group: 'district', heading: 'District information', content: districtMap });
+		sections.district = { heading: 'District information', content: districtMap };
 	}
-	// People cards (other candidates / nearby officials) close the column. Per Figma
-	// the officeholder frames (B/C/G) place these last, after the position + district
-	// context, so the reader meets the office before the surrounding people.
 	// Figma title-cases the heading and leads with the empowered (GoodParty)
 	// candidate. FLAG: the frame reads "Other Candidates for [Position] in
 	// <Location>" but the view has no clean locality field distinct from the
 	// position name, so the "in <Location>" clause is omitted rather than invented.
 	const otherCandidates = empoweredFirst(toCandidateCards(view.otherCandidates));
 	if (otherCandidates.length > 0) {
-		cards.push({
-			group: 'people',
+		sections.otherCandidates = {
 			heading: view.officeName ? `Other Candidates for ${view.officeName}` : 'Other Candidates',
 			content: <OtherCandidatesContent cards={otherCandidates} />,
-		});
+		};
 	}
-	// Nearby officials serving the same constituency — only for personas actually
-	// in (or formerly in) office, per Figma (candidate-only pages omit this).
-	const nearby = holdsOffice(view.persona) ? empoweredFirst(toCandidateCards(view.nearbyOfficials)) : [];
+	const nearby = empoweredFirst(toCandidateCards(view.nearbyOfficials));
 	if (nearby.length > 0) {
-		cards.push({ group: 'people', heading: 'Nearby Officials', content: <OtherCandidatesContent cards={nearby} /> });
+		sections.nearbyOfficials = { heading: 'Nearby Officials', content: <OtherCandidatesContent cards={nearby} /> };
 	}
-	return cards;
+	return sections;
+}
+
+/**
+ * Resolves the persona's section list into ordered cards, tagging each with
+ * its card group. A section with no data — or one absent from the persona's
+ * order — simply doesn't render.
+ */
+function orderedSectionCards(view: PersonProfileView, sections: SectionMap): ProfileContentCardProps[] {
+	return SECTION_ORDER[view.persona].flatMap(key => {
+		const card = sections[key];
+		return card ? [{ ...card, group: SECTION_GROUP[key] }] : [];
+	});
 }
 
 /** Contact links that render as icon-only buttons in the Figma "Contact" row. */
@@ -559,10 +659,12 @@ export function buildPersonSectionOverrides(view: PersonProfileView): SectionOve
 				// `outline` button.
 				button: { buttonType: 'signup', label: 'Learn more', buttonProps: { styleType: 'secondary', styleSize: 'md' } },
 				preserveButtonStyle: true,
-				// The CTA sits below the asymmetric sidebar + cards layout; align its
-				// centered content with the content-card column above (not the page
-				// middle) so it reads as continuous with the last card.
-				contentColumnAlign: true,
+				// Deliberately NOT `contentColumnAlign`. That prop mirrors the sidebar
+				// grid so the CTA lines up with the content-card column, but the frames
+				// don't do that: in A (1901:50309) the CTA is a stock CTA Block whose
+				// content frame sits at x=208 w=1024 in a 1440 frame — 208px either
+				// side, centered on the page. Mirroring the column pushed it right of
+				// center, which is the misalignment marketing reported.
 			}
 		: showClaim
 			? {
@@ -597,16 +699,15 @@ export function buildPersonSectionOverrides(view: PersonProfileView): SectionOve
 	// Authored slot: claimed pages show real owner content; unclaimed but
 	// empowered pages (Figma D/E/F/H) show muted placeholder prompt cards in the
 	// same slot; major-party (I/J) and removed (K/L) pages show neither.
-	const authoredCards = view.claimed
-		? buildAuthoredCards(view)
+	const authoredSections = view.claimed
+		? buildAuthoredSections(view)
 		: view.empowered
-			? buildAuthoredPlaceholderCards(view)
-			: [];
+			? buildAuthoredPlaceholderSections(view)
+			: {};
 	const contentCards: ProfileContentCardProps[] = [
 		...(view.persona === 'past' ? [pastElectionDisclaimer(view)] : []),
 		...(showClaim ? [claimCard('voter-card')] : []),
-		...authoredCards,
-		...buildCivicCards(view),
+		...orderedSectionCards(view, { ...authoredSections, ...buildCivicSections(view) }),
 	];
 	const sidebar = buildSidebar(view);
 
@@ -620,7 +721,13 @@ export function buildPersonSectionOverrides(view: PersonProfileView): SectionOve
 			candidateName: view.displayName,
 			office: view.roleTitle ?? '',
 			// The full positionName (incl. locality) links to the office/position page.
-			officeHref: view.positionHref ?? undefined,
+			// When a second line is present (serving AND running, Figma C) the first
+			// line is the seat HELD, so the candidacy-derived href belongs on the
+			// second line; the held seat gets its own href once election-api threads
+			// the office's position slug through.
+			officeHref: (view.secondaryRoleTitle ? undefined : view.positionHref) ?? undefined,
+			secondaryOffice: view.secondaryRoleTitle ?? undefined,
+			secondaryOfficeHref: (view.secondaryRoleTitle ? view.positionHref : undefined) ?? undefined,
 			profileImageUrl: view.avatarUrl ?? undefined,
 			isEmpowered: view.empowered,
 			tags: personaTags(view.persona),

--- a/src/components/people/personSectionOverrides.tsx
+++ b/src/components/people/personSectionOverrides.tsx
@@ -171,7 +171,7 @@ function ExperienceContent({ experience }: { experience: PersonProfileView['rece
 	return (
 		<ul className='flex flex-col gap-5'>
 			{experience.map((item, index) => (
-				<li key={`${item.title}-${index}`} className='flex flex-col gap-3'>
+				<li key={`${item.title}-${index}`} className='flex flex-col gap-4'>
 					<div className='flex items-center justify-between gap-3'>
 						<Text as='span' styleType='subtitle-2'>
 							{item.title}

--- a/src/components/people/personSectionOverrides.tsx
+++ b/src/components/people/personSectionOverrides.tsx
@@ -11,6 +11,7 @@ import type { ElectionItem } from '~/ui/ElectionsIndexBlock';
 import type { ProfileContentCardProps } from '~/ui/ProfileContentCard';
 import type { ElectionsSidebarProps } from '~/ui/ElectionsSidebar';
 import { IconResolver } from '~/ui/IconResolver';
+import { cn } from '~/ui/_lib/utils';
 import { Text } from '~/ui/Text';
 import { ButtonLink } from '~/ui/Inputs/Button';
 import { CandidatesCard } from '~/ui/CandidatesCard';
@@ -94,8 +95,8 @@ const STATUS_LABELS: Record<PersonProfileIssueStatus, string> = {
 };
 
 // Inline "Pro Blocks / Tagline" pill from Figma: white fill, hairline gray border,
-// rounded-md, subtle shadow, no icon. Used for persona/status tags on the content
-// sections (Recent Experience, Accomplishments, Issues, Other Candidates).
+// rounded-md, subtle shadow, no icon. Used for persona tags on Recent Experience
+// rows and the Other Candidates cards.
 function TypeTag({ label }: { label: string }) {
 	return (
 		<span className='inline-flex w-fit shrink-0 items-center rounded-[6px] border border-gray-300 bg-white px-2.5 py-1 text-midnight-900 shadow-xs'>
@@ -106,61 +107,60 @@ function TypeTag({ label }: { label: string }) {
 	);
 }
 
+// Figma "Top Issues Type Tag": a solid colour-coded chip (rounded-xs, no border)
+// with uppercase 12px Outfit SemiBold text, keyed by issue/accomplishment status.
+// Colour on the container, size/weight on the inner span so tailwind-merge can't
+// collapse the size against the colour (see marketing-ui-clone skill).
+const STATUS_TAG_STYLES: Record<PersonProfileIssueStatus, string> = {
+	IN_PROGRESS: 'bg-blue-100 text-blue-900',
+	PRIORITIZED: 'bg-bright-yellow-100 text-bright-yellow-900',
+	ONGOING: 'bg-red-100 text-red-900',
+	RESOLVED: 'bg-halo-green-100 text-halo-green-900',
+};
+
+function StatusTag({ status }: { status: PersonProfileIssueStatus }) {
+	return (
+		<span className={cn('inline-flex w-fit shrink-0 items-center rounded-xs px-2 py-1', STATUS_TAG_STYLES[status])}>
+			<span className='font-primary text-[0.75rem] leading-4 font-semibold tracking-[1px] uppercase'>
+				{STATUS_LABELS[status]}
+			</span>
+		</span>
+	);
+}
+
 function IssuesContent({ issues, showStatus }: { issues: PersonProfileView['issues']; showStatus: boolean }): ReactNode {
 	return (
-		<ol className='flex flex-col gap-6'>
-			{issues.map((issue, index) => (
+		<ul className='flex flex-col gap-6'>
+			{issues.map((issue) => (
 				<li key={issue.id} className='flex flex-col gap-2'>
-					<div className='flex items-baseline gap-3'>
-						<Text as='span' styleType='subtitle-1' className='text-btn-primary-bg'>
-							{index + 1}
-						</Text>
-						<Text as='span' styleType='subtitle-1'>
-							{issue.title}
-						</Text>
-					</div>
-					{issue.description && (
-						<div className='pl-7'>
-							<Text styleType='body-2'>{issue.description}</Text>
-						</div>
-					)}
-					{showStatus && issue.status && (
-						<div className='pl-7'>
-							<TypeTag label={STATUS_LABELS[issue.status]} />
-						</div>
-					)}
+					{showStatus && issue.status && <StatusTag status={issue.status} />}
+					<Text as='h4' styleType='subtitle-1'>
+						{issue.title}
+					</Text>
+					{issue.description && <Text styleType='body-2'>{issue.description}</Text>}
 				</li>
 			))}
-		</ol>
+		</ul>
 	);
 }
 
 function AccomplishmentsContent({ accomplishments }: { accomplishments: PersonAccomplishment[] }): ReactNode {
 	return (
-		<ul className='flex flex-col gap-5'>
+		<ul className='flex flex-col gap-6'>
 			{accomplishments.map((item, index) => (
-				<li key={`${item.title}-${index}`} className='flex flex-col gap-1'>
-					<div className='flex items-start justify-between gap-3'>
-						<div className='flex min-w-0 flex-wrap items-baseline gap-x-3 gap-y-1'>
-							<span className='inline-flex items-center gap-2'>
-								<IconResolver icon='star' className='h-4 w-4 text-btn-primary-bg' />
-								<Text as='span' styleType='subtitle-2'>
-									{item.title}
-								</Text>
-							</span>
-							{item.date && (
-								<Text as='span' styleType='caption' className='text-gray-500'>
-									{item.date}
-								</Text>
-							)}
-						</div>
-						<TypeTag label='Resolved' />
+				<li key={`${item.title}-${index}`} className='flex flex-col gap-2'>
+					<StatusTag status='RESOLVED' />
+					<div className='flex flex-wrap items-baseline gap-x-3 gap-y-1'>
+						<Text as='span' styleType='subtitle-2'>
+							{item.title}
+						</Text>
+						{item.date && (
+							<Text as='span' styleType='caption' className='text-gray-500'>
+								{item.date}
+							</Text>
+						)}
 					</div>
-					{item.description && (
-						<div className='pl-6'>
-							<Text styleType='body-2'>{item.description}</Text>
-						</div>
-					)}
+					{item.description && <Text styleType='body-2'>{item.description}</Text>}
 				</li>
 			))}
 		</ul>
@@ -171,7 +171,7 @@ function ExperienceContent({ experience }: { experience: PersonProfileView['rece
 	return (
 		<ul className='flex flex-col gap-5'>
 			{experience.map((item, index) => (
-				<li key={`${item.title}-${index}`} className='flex flex-col gap-1'>
+				<li key={`${item.title}-${index}`} className='flex flex-col gap-3'>
 					<div className='flex items-center justify-between gap-3'>
 						<Text as='span' styleType='subtitle-2'>
 							{item.title}
@@ -208,22 +208,25 @@ function ExperienceContent({ experience }: { experience: PersonProfileView['rece
  */
 function AboutPositionContent({ view }: { view: PersonProfileView }): ReactNode {
 	const electionDate = view.electionDate ? formatElectionDateFromApi(view.electionDate) : null;
-	const rows: Array<{ label: string; value: string }> = [];
-	if (view.termLabel) rows.push({ label: 'Term length', value: view.termLabel });
-	if (electionDate) rows.push({ label: 'Next election', value: electionDate });
+	const rows: Array<{ icon: string; label: string; value: string }> = [];
+	if (view.termLabel) rows.push({ icon: 'calendar', label: 'Term length', value: view.termLabel });
+	if (electionDate) rows.push({ icon: 'vote', label: 'Next election', value: electionDate });
 	return (
 		<div className='flex flex-col gap-4'>
 			{view.positionDescription && <Text styleType='body-2'>{view.positionDescription}</Text>}
 			{rows.length > 0 && (
-				<dl className='flex flex-col gap-2'>
+				<dl className='flex flex-col gap-4'>
 					{rows.map(r => (
-						<div key={r.label} className='flex items-baseline justify-between gap-4'>
-							<Text as='dt' styleType='caption' className='text-gray-500'>
-								{r.label}
-							</Text>
-							<Text as='dd' styleType='subtitle-2'>
-								{r.value}
-							</Text>
+						<div key={r.label} className='flex items-start gap-3'>
+							<IconResolver icon={r.icon} className='mt-0.5 h-6 w-6 shrink-0 text-midnight-900' />
+							<div className='flex min-w-0 flex-col gap-0.5'>
+								<Text as='dt' styleType='subtitle-2'>
+									{r.label}
+								</Text>
+								<Text as='dd' styleType='body-2' className='text-gray-500'>
+									{r.value}
+								</Text>
+							</div>
 						</div>
 					))}
 				</dl>
@@ -260,13 +263,15 @@ function buildAuthoredCards(view: PersonProfileView): ProfileContentCardProps[] 
 	if (view.issues.length > 0) {
 		cards.push({ cardType: 'top-issues', group: 'platform', heading: issuesHeading(view.persona), content: <IssuesContent issues={view.issues} showStatus={holdsOffice(view.persona)} /> });
 	}
+	// Accomplishments are an in-office record — only personas who hold/held office
+	// show them. A pure candidate (Figma A) has none, so gate the section. Per Figma
+	// (B/C/G) it sits immediately after Campaign Issues, grouped with them as the
+	// in-office record, BEFORE About Me.
+	if (view.accomplishments.length > 0 && holdsOffice(view.persona)) {
+		cards.push({ group: 'platform', heading: 'Accomplishments', content: <AccomplishmentsContent accomplishments={view.accomplishments} /> });
+	}
 	if (view.bio) {
 		cards.push({ cardType: 'about-me', group: 'about', heading: 'About Me', content: view.bio });
-	}
-	// Accomplishments are an in-office record — only personas who hold/held office
-	// show them. A pure candidate (Figma A) has none, so gate the section.
-	if (view.accomplishments.length > 0 && holdsOffice(view.persona)) {
-		cards.push({ group: 'about', heading: 'Accomplishments', content: <AccomplishmentsContent accomplishments={view.accomplishments} /> });
 	}
 	return cards;
 }
@@ -397,7 +402,21 @@ function buildCivicCards(view: PersonProfileView): ProfileContentCardProps[] {
 	if (view.recentExperience.length > 0) {
 		cards.push({ group: 'about', heading: 'Recent Experience', content: <ExperienceContent experience={view.recentExperience} /> });
 	}
-	// Figma title-cases this heading and leads with the empowered (GoodParty)
+	if (view.positionDescription || view.termLabel || view.electionDate) {
+		cards.push({
+			group: 'position',
+			heading: `About ${view.officeName ?? 'the Role'}`,
+			content: <AboutPositionContent view={view} />,
+		});
+	}
+	const districtMap = buildDistrictMap(view);
+	if (districtMap) {
+		cards.push({ group: 'district', heading: 'District information', content: districtMap });
+	}
+	// People cards (other candidates / nearby officials) close the column. Per Figma
+	// the officeholder frames (B/C/G) place these last, after the position + district
+	// context, so the reader meets the office before the surrounding people.
+	// Figma title-cases the heading and leads with the empowered (GoodParty)
 	// candidate. FLAG: the frame reads "Other Candidates for [Position] in
 	// <Location>" but the view has no clean locality field distinct from the
 	// position name, so the "in <Location>" clause is omitted rather than invented.
@@ -414,17 +433,6 @@ function buildCivicCards(view: PersonProfileView): ProfileContentCardProps[] {
 	const nearby = holdsOffice(view.persona) ? empoweredFirst(toCandidateCards(view.nearbyOfficials)) : [];
 	if (nearby.length > 0) {
 		cards.push({ group: 'people', heading: 'Nearby Officials', content: <OtherCandidatesContent cards={nearby} /> });
-	}
-	if (view.positionDescription || view.termLabel || view.electionDate) {
-		cards.push({
-			group: 'position',
-			heading: `About ${view.officeName ?? 'the Role'}`,
-			content: <AboutPositionContent view={view} />,
-		});
-	}
-	const districtMap = buildDistrictMap(view);
-	if (districtMap) {
-		cards.push({ group: 'district', heading: 'District information', content: districtMap });
 	}
 	return cards;
 }

--- a/src/lib/devPeopleProfileFixtures.ts
+++ b/src/lib/devPeopleProfileFixtures.ts
@@ -120,14 +120,22 @@ function richExperience(persona: PersonPersona): ExperienceItem[] {
 
 function relatedCards(prefix: string, count: number, empoweredEvery = 3): RelatedPersonCard[] {
 	const NAMES = ['Garrett Borton', 'Nathan Todd', 'Don Taylor', 'Henry Nessul', 'Vera Huber', 'Gilian Sears', 'Cheri Steinmetz', 'Eric Barlow', 'Marcia Bean', 'Lori Smallwood', 'Serena Lipp', 'Abby Angelos'];
-	return Array.from({ length: count }, (_, i) => ({
-		personId: `${prefix}-${i}`,
-		name: NAMES[i % NAMES.length]!,
-		subtitle: i % 2 === 0 ? 'Republican' : 'Nonpartisan',
-		href: `/people/${prefix}-${i}`,
-		isEmpowered: i % empoweredEvery === 0,
-		avatarUrl: null,
-	}));
+	// Realistic party mix, but ONLY non-partisan/independent people can be
+	// GoodParty-empowered — a Republican/Democrat card must never show the
+	// "Empowered by GoodParty.org" badge (we only empower non-partisan/3rd-party).
+	const PARTIES = ['Nonpartisan', 'Republican', 'Independent', 'Democrat'];
+	return Array.from({ length: count }, (_, i) => {
+		const subtitle = PARTIES[i % PARTIES.length]!;
+		const isMajorParty = subtitle === 'Republican' || subtitle === 'Democrat';
+		return {
+			personId: `${prefix}-${i}`,
+			name: NAMES[i % NAMES.length]!,
+			subtitle,
+			href: `/people/${prefix}-${i}`,
+			isEmpowered: !isMajorParty && i % empoweredEvery === 0,
+			avatarUrl: null,
+		};
+	});
 }
 
 function richVoterDensity(): VoterDensity {

--- a/src/lib/devPeopleProfileFixtures.ts
+++ b/src/lib/devPeopleProfileFixtures.ts
@@ -16,10 +16,24 @@
  * each slug lands on the intended Figma state; only the CONTENT VOLUME (issues,
  * experience, interlinks, density, bios) is enriched on top.
  */
-import { composeView, type ExperienceItem, type PersonProfileView, type ProfileState, type RelatedPersonCard } from '~/lib/peopleProfile';
+import { buildBreadcrumbTrail, composeView, type ExperienceItem, type PersonProfileView, type ProfileState, type RelatedPersonCard } from '~/lib/peopleProfile';
 import type { PersonPersona } from '~/lib/peopleProfile';
 import type { PublicPersonProfile, VoterDensity } from '~/types/people';
+import { buildElectionPositionHrefFromRaceSlug } from '~/lib/electionsHelpers';
 import { fixtureForState } from '~/testing/peopleProfileFixtures';
+
+/**
+ * A realistic race slug (`state/county/city/position`) so the dev pages render
+ * the full breadcrumb + position href the same way production does for anyone
+ * with a candidacy. The city matches the fixtures' office name so the trail and
+ * the section headings name the same place.
+ */
+const DEV_RACE_SLUG = 'wy/laramie/springfield/city-council';
+const DEV_POSITION_NAME = 'Springfield City Council';
+
+function devPositionHref(): string | undefined {
+	return buildElectionPositionHrefFromRaceSlug({ slug: DEV_RACE_SLUG, positionLevel: 'CITY' });
+}
 
 export function isDevPeopleFixturesEnabled(): boolean {
 	return process.env['PEOPLE_DEV_FIXTURES'] === 'true';
@@ -50,7 +64,73 @@ function personIdFromSuffix(suffix: string): string {
 const LOREM =
 	'Focused on transparent, accountable local government that puts residents first. Building coalitions across the community to deliver practical results on the issues families care about most.';
 
-function richOverlay(name: string, holdsOffice: boolean): Partial<PublicPersonProfile> {
+// Issues WITHOUT a status are the campaign platform ("Campaign Issues"); issues
+// WITH one are the in-office record ("Top Priorities While in Office"). The
+// frames show these as separate sections, so seed each kind only for the
+// personas whose frame has that section.
+const CAMPAIGN_ISSUES = [
+	{
+		issueId: 'issue-housing',
+		title: 'Affordable Housing',
+		description: 'Expand affordable housing options and streamline permitting for new homes.',
+		visible: true,
+		status: null,
+		transparency: null,
+		sortOrder: 0,
+	},
+	{
+		issueId: 'issue-safety',
+		title: 'Public Safety & Roads',
+		description: 'Repair aging roads and invest in community-based public safety programs.',
+		visible: true,
+		status: null,
+		transparency: null,
+		sortOrder: 1,
+	},
+	{
+		issueId: 'issue-transparency',
+		title: 'Government Transparency',
+		description: 'Publish budgets and votes openly so residents can hold leaders accountable.',
+		visible: true,
+		status: null,
+		transparency: null,
+		sortOrder: 2,
+	},
+] as const;
+
+const IN_OFFICE_ISSUES = [
+	{
+		issueId: 'issue-tree-canopy',
+		title: 'Protecting the tree canopy as we grow',
+		description: 'Pair new development with replanting so block-level shade keeps pace with construction.',
+		visible: true,
+		status: 'IN_PROGRESS',
+		transparency: 'Verified',
+		sortOrder: 3,
+	},
+	{
+		issueId: 'issue-repaving',
+		title: 'Potholes and repaving on Riverside Avenue',
+		description: 'Fund the repaving backlog and publish a street-by-street schedule residents can track.',
+		visible: true,
+		status: 'PRIORITIZED',
+		transparency: 'Verified',
+		sortOrder: 4,
+	},
+	{
+		issueId: 'issue-fire-staffing',
+		title: 'Fire department staffing and response times',
+		description: 'Keep every station fully staffed and hold response times under the national benchmark.',
+		visible: true,
+		status: 'ONGOING',
+		transparency: 'Verified',
+		sortOrder: 5,
+	},
+] as const;
+
+function richOverlay(name: string, persona: PersonPersona): Partial<PublicPersonProfile> {
+	const ran = persona === 'candidate' || persona === 'both' || persona === 'past';
+	const holdsOffice = persona === 'officeholder' || persona === 'both' || persona === 'past';
 	return {
 		displayName: name,
 		bioOverride: `${name} is a lifelong resident and community advocate. ${LOREM}`,
@@ -73,33 +153,8 @@ function richOverlay(name: string, holdsOffice: boolean): Partial<PublicPersonPr
 		linkedinUrl: 'https://linkedin.com/in/example',
 		instagramUrl: 'https://instagram.com/example',
 		issues: [
-			{
-				issueId: 'issue-housing',
-				title: 'Affordable Housing',
-				description: 'Expand affordable housing options and streamline permitting for new homes.',
-				visible: true,
-				status: 'IN_PROGRESS',
-				transparency: 'Verified',
-				sortOrder: 0,
-			},
-			{
-				issueId: 'issue-safety',
-				title: 'Public Safety & Roads',
-				description: 'Repair aging roads and invest in community-based public safety programs.',
-				visible: true,
-				status: 'PRIORITIZED',
-				transparency: 'Verified',
-				sortOrder: 1,
-			},
-			{
-				issueId: 'issue-transparency',
-				title: 'Government Transparency',
-				description: 'Publish budgets and votes openly so residents can hold leaders accountable.',
-				visible: true,
-				status: 'ONGOING',
-				transparency: 'Verified',
-				sortOrder: 2,
-			},
+			...(ran ? CAMPAIGN_ISSUES : []),
+			...(holdsOffice ? IN_OFFICE_ISSUES : []),
 		],
 	};
 }
@@ -113,7 +168,7 @@ function richExperience(persona: PersonPersona): ExperienceItem[] {
 		{ title: 'School Board Trustee, At-Large', organization: '2010 – 2014', term: '2010 – 2014', status: null, href: '/elections/school-board' },
 	];
 	if (running) {
-		rows.unshift({ title: 'Candidate for Mayor of Springfield', organization: '2026 election', term: '2026 election', status: 'Candidate', href: '/elections/mayor' });
+		rows.unshift({ title: `Candidate for ${DEV_POSITION_NAME}`, organization: '2026 election', term: '2026 election', status: 'Candidate', href: devPositionHref() ?? null });
 	}
 	return rows;
 }
@@ -176,6 +231,12 @@ export function getDevPersonProfileView(slug: string): PersonProfileView | null 
 		firstName: entry.first,
 		lastName: entry.last,
 		fullName: name,
+		// The shared matrix runs its candidacies for a different office (Mayor)
+		// than it holds (city council), which is fine for state/gating tests but
+		// would show a dev page whose hero names one race while the breadcrumb
+		// and position link point at another. Every dev persona is about the one
+		// DEV_RACE_SLUG race, so an incumbent here is running for re-election.
+		Candidacies: (fixture.person.Candidacies ?? []).map((c) => ({ ...c, positionName: DEV_POSITION_NAME })),
 		bioText: `${name} has served the community for over a decade. ${LOREM}`,
 		headshotUrl,
 		websiteUrl: 'https://example.org',
@@ -194,13 +255,14 @@ export function getDevPersonProfileView(slug: string): PersonProfileView | null 
 
 	const persona: PersonPersona = fixture.expected.persona;
 	const running = persona === 'candidate' || persona === 'both';
-	const holdsOffice = persona === 'officeholder' || persona === 'both' || persona === 'past';
 
 	const overlay: PublicPersonProfile | null =
 		fixture.overlay.status === 'live'
-			? { ...fixture.overlay.profile, personId, ...richOverlay(name, holdsOffice), avatarUrl: headshotUrl }
+			? { ...fixture.overlay.profile, personId, ...richOverlay(name, persona), avatarUrl: headshotUrl }
 			: null;
 	const removed = fixture.overlay.status === 'removed';
+
+	const positionHref = devPositionHref() ?? null;
 
 	const view = composeView(personId, person, overlay, {
 		removed,
@@ -209,7 +271,17 @@ export function getDevPersonProfileView(slug: string): PersonProfileView | null 
 		electionDate: '2026-11-03',
 		positionDescription:
 			'The County Legislature or Executive Board is the governing body of the county and exercises broad policy-making authority. The Board is charged with implementing policy and overseeing the county budget process and administration.',
-		positionHref: '/elections/wyoming-house',
+		positionHref,
+		// Mirror production's trail so reviewers see the real
+		// Elections > State > County > City > Position > Name hierarchy rather
+		// than the bare `Elections > Name` fallback.
+		breadcrumb: buildBreadcrumbTrail({
+			displayName: name,
+			stateCode: 'WY',
+			raceSlug: DEV_RACE_SLUG,
+			positionLevel: 'CITY',
+			positionName: DEV_POSITION_NAME,
+		}),
 		recentExperience: richExperience(persona),
 		// Running personas get "Other candidates"; the Figma "past" mocks (G/H) are
 		// the tallest frames and also carry this section, so include it there too.

--- a/src/lib/electionApiAuth.test.ts
+++ b/src/lib/electionApiAuth.test.ts
@@ -1,0 +1,175 @@
+import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from 'bun:test';
+
+import {
+	__resetElectionApiAuthForTests,
+	__setCreateTokenForTests,
+	electionApiAuthHeaders,
+	getElectionApiToken,
+} from './electionApiAuth';
+
+// Clerk's createToken returns `expiration` as a Unix timestamp in seconds.
+const expirationInSeconds = (secondsFromNow: number): number =>
+	Math.floor(Date.now() / 1000) + secondsFromNow;
+
+const createToken = mock(
+	async (): Promise<{ token: string | null; expiration: number | null }> => ({
+		token: 'fresh-token',
+		expiration: expirationInSeconds(600),
+	}),
+);
+
+const ORIGINAL_SECRET = process.env['GP_MARKETING_MACHINE_SECRET'];
+
+beforeEach(() => {
+	createToken.mockClear();
+	createToken.mockImplementation(async () => ({
+		token: 'fresh-token',
+		expiration: expirationInSeconds(600),
+	}));
+	process.env['GP_MARKETING_MACHINE_SECRET'] = 'test-machine-secret';
+	__resetElectionApiAuthForTests();
+	__setCreateTokenForTests(createToken);
+});
+
+afterEach(() => {
+	if (ORIGINAL_SECRET === undefined) {
+		delete process.env['GP_MARKETING_MACHINE_SECRET'];
+	} else {
+		process.env['GP_MARKETING_MACHINE_SECRET'] = ORIGINAL_SECRET;
+	}
+	__resetElectionApiAuthForTests();
+});
+
+describe('getElectionApiToken', () => {
+	test('returns cached token when outside the renewal buffer', async () => {
+		__resetElectionApiAuthForTests({
+			cachedToken: 'cached-token',
+			tokenExpiration: Date.now() + 120_000,
+		});
+		__setCreateTokenForTests(createToken);
+
+		await expect(getElectionApiToken()).resolves.toBe('cached-token');
+		expect(createToken).toHaveBeenCalledTimes(0);
+	});
+
+	test('remints when no token is cached', async () => {
+		await expect(getElectionApiToken()).resolves.toBe('fresh-token');
+		expect(createToken).toHaveBeenCalledTimes(1);
+	});
+
+	test('remints when the cached token is fully expired', async () => {
+		__resetElectionApiAuthForTests({
+			cachedToken: 'stale-token',
+			tokenExpiration: Date.now() - 1_000,
+		});
+		__setCreateTokenForTests(createToken);
+
+		await expect(getElectionApiToken()).resolves.toBe('fresh-token');
+		expect(createToken).toHaveBeenCalledTimes(1);
+	});
+
+	test('remints when the cached token is within the 30s renewal buffer', async () => {
+		__resetElectionApiAuthForTests({
+			cachedToken: 'near-expiry-token',
+			tokenExpiration: Date.now() + 10_000,
+		});
+		__setCreateTokenForTests(createToken);
+
+		await expect(getElectionApiToken()).resolves.toBe('fresh-token');
+		expect(createToken).toHaveBeenCalledTimes(1);
+	});
+
+	test('dedupes concurrent calls into a single mint', async () => {
+		let resolveMint!: (value: { token: string; expiration: number }) => void;
+		createToken.mockImplementation(
+			async () =>
+				await new Promise<{ token: string; expiration: number }>(resolve => {
+					resolveMint = resolve;
+				}),
+		);
+
+		const first = getElectionApiToken();
+		const second = getElectionApiToken();
+
+		expect(createToken).toHaveBeenCalledTimes(1);
+
+		resolveMint({ token: 'shared-token', expiration: expirationInSeconds(600) });
+		await expect(Promise.all([first, second])).resolves.toEqual(['shared-token', 'shared-token']);
+		expect(createToken).toHaveBeenCalledTimes(1);
+	});
+
+	test('missing machine secret returns null and logs once across two calls', async () => {
+		delete process.env['GP_MARKETING_MACHINE_SECRET'];
+		const errorSpy = spyOn(console, 'error').mockImplementation(() => undefined);
+
+		await expect(getElectionApiToken()).resolves.toBeNull();
+		await expect(getElectionApiToken()).resolves.toBeNull();
+
+		expect(createToken).toHaveBeenCalledTimes(0);
+		expect(errorSpy.mock.calls.filter(call => String(call[0]).includes('GP_MARKETING_MACHINE_SECRET'))).toHaveLength(
+			1,
+		);
+
+		errorSpy.mockRestore();
+	});
+
+	test('mint failure returns the still-valid cached token', async () => {
+		__resetElectionApiAuthForTests({
+			cachedToken: 'still-valid',
+			tokenExpiration: Date.now() + 10_000,
+		});
+		__setCreateTokenForTests(createToken);
+		createToken.mockImplementation(async () => {
+			throw new Error('Clerk unavailable');
+		});
+		const errorSpy = spyOn(console, 'error').mockImplementation(() => undefined);
+
+		await expect(getElectionApiToken()).resolves.toBe('still-valid');
+		expect(createToken).toHaveBeenCalledTimes(1);
+
+		errorSpy.mockRestore();
+	});
+
+	test('mint failure enters a cooldown that skips further Clerk calls', async () => {
+		createToken.mockImplementation(async () => {
+			throw new Error('Clerk unavailable');
+		});
+		const errorSpy = spyOn(console, 'error').mockImplementation(() => undefined);
+
+		await expect(getElectionApiToken()).resolves.toBeNull();
+		await expect(getElectionApiToken()).resolves.toBeNull();
+
+		expect(createToken).toHaveBeenCalledTimes(1);
+
+		errorSpy.mockRestore();
+	});
+
+	test('cooldown still serves a usable cached token without reminting', async () => {
+		__resetElectionApiAuthForTests({
+			cachedToken: 'cached-during-cooldown',
+			tokenExpiration: Date.now() + 10_000,
+			mintCooldownUntil: Date.now() + 30_000,
+		});
+		__setCreateTokenForTests(createToken);
+
+		await expect(getElectionApiToken()).resolves.toBe('cached-during-cooldown');
+		expect(createToken).toHaveBeenCalledTimes(0);
+	});
+});
+
+describe('electionApiAuthHeaders', () => {
+	test('returns Authorization when a token is available', async () => {
+		await expect(electionApiAuthHeaders()).resolves.toEqual({
+			Authorization: 'Bearer fresh-token',
+		});
+	});
+
+	test('returns an empty object when no token is available', async () => {
+		delete process.env['GP_MARKETING_MACHINE_SECRET'];
+		const errorSpy = spyOn(console, 'error').mockImplementation(() => undefined);
+
+		await expect(electionApiAuthHeaders()).resolves.toEqual({});
+
+		errorSpy.mockRestore();
+	});
+});

--- a/src/lib/electionApiAuth.ts
+++ b/src/lib/electionApiAuth.ts
@@ -1,0 +1,172 @@
+import { createClerkClient } from '@clerk/backend';
+
+/**
+ * Server-only Clerk JWT-format M2M token minter for calling election-api.
+ *
+ * gp-marketing is a caller: it mints tokens with its own machine secret
+ * (GP_MARKETING_MACHINE_SECRET); election-api verifies as the recipient
+ * (networkless, since the token is a JWT). The gp-marketing machine must be
+ * connected to the election-api machine in the Clerk dashboard.
+ *
+ * NEVER import this from client components — GP_MARKETING_MACHINE_SECRET and
+ * CLERK_SECRET_KEY are server-only. All election-api reads already run
+ * server-side (Server Components, route handlers, sitemap/build scripts).
+ *
+ * Deliberately does NOT `import 'server-only'`: this module is also imported by
+ * offline CLI scripts (`scripts/validate-election-pages.ts`, and
+ * `scripts/generate-sitemaps.ts` via `sitemap-entries.ts`). Under bun/tsx the
+ * `server-only` package's default export throws, so the sentinel would break
+ * those tools. Client-bundle safety still holds because no Client Component
+ * imports this file (and `@clerk/backend` is Node-only).
+ *
+ * If the machine secret is unset, minting is skipped and requests go out
+ * unauthenticated. That is intentional: it keeps gp-marketing working while
+ * election-api is still in observe-only mode. Once ELECTION_API_AUTH_ENFORCED
+ * is on, the secret must be present or election-api will return 401.
+ */
+
+const TOKEN_RENEWAL_BUFFER_MS = 30_000;
+const MINT_COOLDOWN_MS = 30_000;
+const TOKEN_TTL_SECONDS = 600;
+
+export type CreateM2MToken = (params: {
+	machineSecretKey: string;
+	secondsUntilExpiration: number;
+	tokenFormat?: 'jwt';
+}) => Promise<{ token?: string | null; expiration?: number | null }>;
+
+type ClerkM2MClient = {
+	m2m: {
+		createToken(params: {
+			machineSecretKey: string;
+			secondsUntilExpiration: number;
+			tokenFormat?: 'jwt';
+		}): Promise<{ token?: string | null; expiration?: number | null }>;
+	};
+};
+
+let clerkClient: ClerkM2MClient | null = null;
+let createTokenForTests: CreateM2MToken | null = null;
+
+function getClerkClient(): ClerkM2MClient {
+	if (!clerkClient) {
+		clerkClient = createClerkClient({
+			secretKey: process.env['CLERK_SECRET_KEY'],
+			publishableKey: process.env['CLERK_PUBLISHABLE_KEY'],
+		}) as ClerkM2MClient;
+	}
+	return clerkClient;
+}
+
+async function createToken(params: {
+	machineSecretKey: string;
+	secondsUntilExpiration: number;
+	tokenFormat?: 'jwt';
+}): Promise<{ token?: string | null; expiration?: number | null }> {
+	if (createTokenForTests) return createTokenForTests(params);
+	return getClerkClient().m2m.createToken(params);
+}
+
+let cachedToken: string | null = null;
+let tokenExpiration: number | null = null;
+let pending: Promise<string | null> | null = null;
+let warnedMissingSecret = false;
+let mintCooldownUntil = 0;
+
+/** True when a cached token exists and has not yet reached its real expiry. */
+function isTokenUsable(): boolean {
+	return cachedToken != null && tokenExpiration != null && Date.now() < tokenExpiration;
+}
+
+/** True when there is no usable cached token, or it is within the renewal buffer. */
+function needsRenewal(): boolean {
+	if (!cachedToken || tokenExpiration == null) return true;
+	return Date.now() >= tokenExpiration - TOKEN_RENEWAL_BUFFER_MS;
+}
+
+function usableCachedToken(): string | null {
+	return isTokenUsable() ? cachedToken : null;
+}
+
+function enterMintCooldown(): void {
+	mintCooldownUntil = Date.now() + MINT_COOLDOWN_MS;
+}
+
+async function mint(): Promise<string | null> {
+	const machineSecret = process.env['GP_MARKETING_MACHINE_SECRET'];
+	if (!machineSecret) {
+		if (!warnedMissingSecret) {
+			warnedMissingSecret = true;
+			console.error(
+				'[electionApiAuth] GP_MARKETING_MACHINE_SECRET is not set; election-api requests will be unauthenticated',
+			);
+		}
+		return usableCachedToken();
+	}
+	try {
+		const minted = await createToken({
+			machineSecretKey: machineSecret,
+			tokenFormat: 'jwt',
+			secondsUntilExpiration: TOKEN_TTL_SECONDS,
+		});
+		if (!minted.token || minted.expiration == null) {
+			enterMintCooldown();
+			return usableCachedToken();
+		}
+		cachedToken = minted.token;
+		// Clerk returns `expiration` as a Unix timestamp in seconds; the cache
+		// checks compare against Date.now() in ms, so convert here or the token
+		// is treated as already expired and re-minted on every request.
+		tokenExpiration = minted.expiration * 1000;
+		mintCooldownUntil = 0;
+		return minted.token;
+	} catch (err) {
+		console.error(
+			'[electionApiAuth] failed to mint M2M token',
+			err instanceof Error ? err.message : String(err),
+		);
+		enterMintCooldown();
+		return usableCachedToken();
+	}
+}
+
+/** Returns a cached M2M token, minting/renewing as needed. Null if unavailable. */
+export async function getElectionApiToken(): Promise<string | null> {
+	if (!needsRenewal()) return cachedToken;
+	if (Date.now() < mintCooldownUntil) return usableCachedToken();
+	if (pending) return pending;
+	const promise = mint();
+	pending = promise;
+	try {
+		return await promise;
+	} finally {
+		if (pending === promise) pending = null;
+	}
+}
+
+/** Authorization header for an election-api request (empty if no token). */
+export async function electionApiAuthHeaders(): Promise<Record<string, string>> {
+	const token = await getElectionApiToken();
+	return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
+/** Test-only: inject a createToken implementation (null restores Clerk). */
+export function __setCreateTokenForTests(fn: CreateM2MToken | null): void {
+	createTokenForTests = fn;
+}
+
+/** Test-only: reset module cache / cooldown state (and optionally seed a token). */
+export function __resetElectionApiAuthForTests(seed?: {
+	cachedToken?: string | null;
+	tokenExpiration?: number | null;
+	mintCooldownUntil?: number;
+	warnedMissingSecret?: boolean;
+}): void {
+	cachedToken = seed?.cachedToken ?? null;
+	tokenExpiration = seed?.tokenExpiration ?? null;
+	mintCooldownUntil = seed?.mintCooldownUntil ?? 0;
+	warnedMissingSecret = seed?.warnedMissingSecret ?? false;
+	pending = null;
+	clerkClient = null;
+	createTokenForTests = null;
+}

--- a/src/lib/electionApiFetch.test.ts
+++ b/src/lib/electionApiFetch.test.ts
@@ -79,4 +79,30 @@ describe('fetchElectionApiJsonCached', () => {
 		expect(fetchCalls).toBe(1);
 		expect(result).toEqual({ status: 200, ok: true, json: OK_BODY });
 	});
+
+	test('returns 404 rather than throwing, so a missing record stays cacheable', async () => {
+		globalThis.fetch = (async () => {
+			fetchCalls += 1;
+			return new Response(null, { status: 404 });
+		}) as unknown as typeof fetch;
+
+		const result = await fetchElectionApiJsonCached(ELECTION_URL);
+
+		expect(result).toEqual({ status: 404, ok: false, json: null });
+	});
+
+	// The throw is what keeps unstable_cache from storing the failure: it caches what
+	// the wrapped function returns, so a returned 5xx would pin this URL to an error
+	// for the full hour and the caller's retries — which go back through this same
+	// cache entry — would never re-run the fetch.
+	test.each([500, 502, 503, 401, 400])('throws on %s so the failure is never cached', async (status) => {
+		globalThis.fetch = (async () => {
+			fetchCalls += 1;
+			return new Response(null, { status });
+		}) as unknown as typeof fetch;
+
+		const promise = fetchElectionApiJsonCached(ELECTION_URL);
+
+		await expect(promise).rejects.toMatchObject({ name: 'ElectionApiError', status });
+	});
 });

--- a/src/lib/electionApiFetch.test.ts
+++ b/src/lib/electionApiFetch.test.ts
@@ -1,25 +1,9 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { __resetElectionApiAuthForTests } from './electionApiAuth';
-
-// Faithful passthrough for next/cache so the NEXT_RUNTIME branch can be exercised
-// without invoking the real unstable_cache (which hangs outside the Next runtime).
-// It only captures the arguments and immediately runs the wrapped function, so it
-// is harmless even if the module mock leaks to sibling files — and those never set
-// NEXT_RUNTIME, so they bypass this branch entirely.
-let capturedKeyParts: unknown;
-let capturedOptions: { revalidate?: number; tags?: readonly string[] } | undefined;
-const unstable_cache = mock(
-	(
-		fn: (...args: unknown[]) => unknown,
-		keyParts: unknown,
-		options: { revalidate?: number; tags?: readonly string[] },
-	) => {
-		capturedKeyParts = keyParts;
-		capturedOptions = options;
-		return (...args: unknown[]) => fn(...args);
-	},
-);
-mock.module('next/cache', () => ({ unstable_cache }));
+// Mocks next/cache on import so the NEXT_RUNTIME branch can be exercised without
+// invoking the real unstable_cache (which hangs outside the Next runtime). Shared
+// with the other files that mock next/cache; see the module for why.
+import { lastCacheCall, resetNextCacheMock, unstable_cache } from '~/testing/nextCacheMock';
 
 // Imported after the module mock so the dynamic import('next/cache') resolves to it.
 const { fetchElectionApiJsonCached } = await import('./electionApiFetch');
@@ -34,9 +18,7 @@ const ORIGINAL_RUNTIME = process.env['NEXT_RUNTIME'];
 let fetchCalls: number;
 
 beforeEach(() => {
-	unstable_cache.mockClear();
-	capturedKeyParts = undefined;
-	capturedOptions = undefined;
+	resetNextCacheMock();
 	fetchCalls = 0;
 	// Fail-soft auth path: unset secret so run() never touches Clerk.
 	delete process.env['GP_MARKETING_MACHINE_SECRET'];
@@ -72,9 +54,9 @@ describe('fetchElectionApiJsonCached', () => {
 		const result = await fetchElectionApiJsonCached(ELECTION_URL, ['person:abc']);
 
 		expect(unstable_cache).toHaveBeenCalledTimes(1);
-		expect(capturedKeyParts).toEqual(['election-api-json', ELECTION_URL]);
-		expect(capturedOptions?.revalidate).toBe(3600);
-		expect(capturedOptions?.tags).toEqual(['person:abc']);
+		expect(lastCacheCall.keyParts).toEqual(['election-api-json', ELECTION_URL]);
+		expect(lastCacheCall.options?.revalidate).toBe(3600);
+		expect(lastCacheCall.options?.tags).toEqual(['person:abc']);
 		expect(result).toEqual({ status: 200, ok: true, json: OK_BODY });
 	});
 
@@ -84,8 +66,8 @@ describe('fetchElectionApiJsonCached', () => {
 		await fetchElectionApiJsonCached(ELECTION_URL);
 
 		expect(unstable_cache).toHaveBeenCalledTimes(1);
-		expect(capturedOptions && 'tags' in capturedOptions).toBe(false);
-		expect(capturedOptions?.revalidate).toBe(3600);
+		expect(lastCacheCall.options && 'tags' in lastCacheCall.options).toBe(false);
+		expect(lastCacheCall.options?.revalidate).toBe(3600);
 	});
 
 	test('outside the Next runtime, bypasses unstable_cache and fetches directly', async () => {

--- a/src/lib/electionApiFetch.test.ts
+++ b/src/lib/electionApiFetch.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { __resetElectionApiAuthForTests } from './electionApiAuth';
+
+// Faithful passthrough for next/cache so the NEXT_RUNTIME branch can be exercised
+// without invoking the real unstable_cache (which hangs outside the Next runtime).
+// It only captures the arguments and immediately runs the wrapped function, so it
+// is harmless even if the module mock leaks to sibling files — and those never set
+// NEXT_RUNTIME, so they bypass this branch entirely.
+let capturedKeyParts: unknown;
+let capturedOptions: { revalidate?: number; tags?: readonly string[] } | undefined;
+const unstable_cache = mock(
+	(
+		fn: (...args: unknown[]) => unknown,
+		keyParts: unknown,
+		options: { revalidate?: number; tags?: readonly string[] },
+	) => {
+		capturedKeyParts = keyParts;
+		capturedOptions = options;
+		return (...args: unknown[]) => fn(...args);
+	},
+);
+mock.module('next/cache', () => ({ unstable_cache }));
+
+// Imported after the module mock so the dynamic import('next/cache') resolves to it.
+const { fetchElectionApiJsonCached } = await import('./electionApiFetch');
+
+const ELECTION_URL = 'https://election-api.goodparty.org/v1/positions/1';
+const OK_BODY = { hello: 'world' };
+
+const originalFetch = globalThis.fetch;
+const ORIGINAL_MACHINE_SECRET = process.env['GP_MARKETING_MACHINE_SECRET'];
+const ORIGINAL_RUNTIME = process.env['NEXT_RUNTIME'];
+
+let fetchCalls: number;
+
+beforeEach(() => {
+	unstable_cache.mockClear();
+	capturedKeyParts = undefined;
+	capturedOptions = undefined;
+	fetchCalls = 0;
+	// Fail-soft auth path: unset secret so run() never touches Clerk.
+	delete process.env['GP_MARKETING_MACHINE_SECRET'];
+	__resetElectionApiAuthForTests({ warnedMissingSecret: true });
+	globalThis.fetch = (async () => {
+		fetchCalls += 1;
+		return new Response(JSON.stringify(OK_BODY), {
+			status: 200,
+			headers: { 'content-type': 'application/json' },
+		});
+	}) as unknown as typeof fetch;
+});
+
+afterEach(() => {
+	if (ORIGINAL_MACHINE_SECRET === undefined) {
+		delete process.env['GP_MARKETING_MACHINE_SECRET'];
+	} else {
+		process.env['GP_MARKETING_MACHINE_SECRET'] = ORIGINAL_MACHINE_SECRET;
+	}
+	if (ORIGINAL_RUNTIME === undefined) {
+		delete process.env['NEXT_RUNTIME'];
+	} else {
+		process.env['NEXT_RUNTIME'] = ORIGINAL_RUNTIME;
+	}
+	__resetElectionApiAuthForTests();
+	globalThis.fetch = originalFetch;
+});
+
+describe('fetchElectionApiJsonCached', () => {
+	test('inside the Next runtime, wraps run in unstable_cache keyed by url with 3600 revalidate and forwarded tags', async () => {
+		process.env['NEXT_RUNTIME'] = 'nodejs';
+
+		const result = await fetchElectionApiJsonCached(ELECTION_URL, ['person:abc']);
+
+		expect(unstable_cache).toHaveBeenCalledTimes(1);
+		expect(capturedKeyParts).toEqual(['election-api-json', ELECTION_URL]);
+		expect(capturedOptions?.revalidate).toBe(3600);
+		expect(capturedOptions?.tags).toEqual(['person:abc']);
+		expect(result).toEqual({ status: 200, ok: true, json: OK_BODY });
+	});
+
+	test('inside the Next runtime without tags, omits the tags cache option', async () => {
+		process.env['NEXT_RUNTIME'] = 'nodejs';
+
+		await fetchElectionApiJsonCached(ELECTION_URL);
+
+		expect(unstable_cache).toHaveBeenCalledTimes(1);
+		expect(capturedOptions && 'tags' in capturedOptions).toBe(false);
+		expect(capturedOptions?.revalidate).toBe(3600);
+	});
+
+	test('outside the Next runtime, bypasses unstable_cache and fetches directly', async () => {
+		delete process.env['NEXT_RUNTIME'];
+
+		const result = await fetchElectionApiJsonCached(ELECTION_URL, ['person:abc']);
+
+		expect(unstable_cache).not.toHaveBeenCalled();
+		expect(fetchCalls).toBe(1);
+		expect(result).toEqual({ status: 200, ok: true, json: OK_BODY });
+	});
+});

--- a/src/lib/electionApiFetch.ts
+++ b/src/lib/electionApiFetch.ts
@@ -9,6 +9,20 @@ export type ElectionApiJsonResult = {
 };
 
 /**
+ * A non-ok response that must not be cached. Carries the status so the caller can
+ * tell a retryable 5xx from a deterministic 4xx without re-parsing a message.
+ */
+export class ElectionApiError extends Error {
+	public readonly status: number;
+
+	public constructor(status: number, url: string) {
+		super(`election-api ${status} ${url}`);
+		this.name = 'ElectionApiError';
+		this.status = status;
+	}
+}
+
+/**
  * Authenticated election-api GET that keeps the rotating M2M Authorization header
  * OUT of the Next.js Data Cache key.
  *
@@ -30,7 +44,13 @@ export async function fetchElectionApiJsonCached(
 		const authHeaders = await electionApiAuthHeaders();
 		const res = await fetch(url, { headers: authHeaders, cache: 'no-store' });
 		if (res.status === 404) return { status: 404, ok: false, json: null };
-		if (!res.ok) return { status: res.status, ok: false, json: null };
+		// Anything else non-ok throws rather than returning: unstable_cache stores
+		// whatever the wrapped function *returns*, so a returned failure would be
+		// memoized under this URL for the full hour — and because the caller retries
+		// through this same cached entry, run() would never re-execute. One transient
+		// 5xx would blank the field site-wide until the window elapsed. 404 is the
+		// exception: it is a real, stable answer worth caching.
+		if (!res.ok) throw new ElectionApiError(res.status, url);
 		return { status: res.status, ok: true, json: await res.json() };
 	};
 

--- a/src/lib/electionApiFetch.ts
+++ b/src/lib/electionApiFetch.ts
@@ -1,0 +1,44 @@
+import { electionApiAuthHeaders } from '~/lib/electionApiAuth';
+
+const ELECTION_API_CACHE_SECONDS = 3600;
+
+export type ElectionApiJsonResult = {
+	status: number;
+	ok: boolean;
+	json: unknown;
+};
+
+/**
+ * Authenticated election-api GET that keeps the rotating M2M Authorization header
+ * OUT of the Next.js Data Cache key.
+ *
+ * Next's fetch cache includes Authorization in its key, so minting a fresh token
+ * every ~10 minutes (and per isolate) would bust the shared 1h cache. We mint
+ * inside unstable_cache and key only on the URL; fetch itself uses cache:'no-store'.
+ *
+ * unstable_cache only works inside the Next server runtime. In CLI scripts (bun/tsx)
+ * and unit tests the module still imports, but invoking unstable_cache outside the
+ * runtime hangs/misbehaves — so we gate on NEXT_RUNTIME and fall back to an uncached
+ * fetch there. Inside the Next runtime we do NOT swallow errors: a genuine cache-layer
+ * or run() failure propagates to the caller instead of silently degrading.
+ */
+export async function fetchElectionApiJsonCached(
+	url: string,
+	tags?: readonly string[],
+): Promise<ElectionApiJsonResult> {
+	const run = async (): Promise<ElectionApiJsonResult> => {
+		const authHeaders = await electionApiAuthHeaders();
+		const res = await fetch(url, { headers: authHeaders, cache: 'no-store' });
+		if (res.status === 404) return { status: 404, ok: false, json: null };
+		if (!res.ok) return { status: res.status, ok: false, json: null };
+		return { status: res.status, ok: true, json: await res.json() };
+	};
+
+	if (!process.env['NEXT_RUNTIME']) return run();
+
+	const { unstable_cache } = await import('next/cache');
+	return await unstable_cache(run, ['election-api-json', url], {
+		revalidate: ELECTION_API_CACHE_SECONDS,
+		...(tags && tags.length > 0 ? { tags: [...tags] } : {}),
+	})();
+}

--- a/src/lib/electionsApi.test.ts
+++ b/src/lib/electionsApi.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import type { PlaceItem } from '~/types/elections';
+import { __resetElectionApiAuthForTests } from './electionApiAuth';
 import {
 	getCountyChildPlaces,
 	isStateIndexDistrictPlace,
@@ -14,6 +15,7 @@ type FetchMockResponse = {
 };
 
 const originalFetch = globalThis.fetch;
+const ORIGINAL_MACHINE_SECRET = process.env['GP_MARKETING_MACHINE_SECRET'];
 
 function withFetchMock(responses: FetchMockResponse[]) {
 	globalThis.fetch = (async (input: RequestInfo | URL) => {
@@ -34,10 +36,21 @@ function slugs(items: PlaceItem[]): string[] {
 }
 
 beforeEach(() => {
+	// Fail-soft path: unset secret so election-api reads go out unauthenticated
+	// without touching Clerk (and without mock.module, which can poison sibling tests).
+	delete process.env['GP_MARKETING_MACHINE_SECRET'];
+	// Skip the warn-once log — these tests intentionally exercise the fail-soft path.
+	__resetElectionApiAuthForTests({ warnedMissingSecret: true });
 	globalThis.fetch = originalFetch;
 });
 
 afterEach(() => {
+	if (ORIGINAL_MACHINE_SECRET === undefined) {
+		delete process.env['GP_MARKETING_MACHINE_SECRET'];
+	} else {
+		process.env['GP_MARKETING_MACHINE_SECRET'] = ORIGINAL_MACHINE_SECRET;
+	}
+	__resetElectionApiAuthForTests();
 	globalThis.fetch = originalFetch;
 });
 

--- a/src/lib/electionsApi.ts
+++ b/src/lib/electionsApi.ts
@@ -24,7 +24,7 @@ import {
 	normalizeCandidateLookupName,
 	stripCountySuffix,
 } from '~/lib/electionsHelpers';
-import { fetchElectionApiJsonCached } from '~/lib/electionApiFetch';
+import { ElectionApiError, fetchElectionApiJsonCached } from '~/lib/electionApiFetch';
 
 const ELECTIONS_API_BASE_URL =
 	process.env['ELECTIONS_API_BASE_URL'] ?? 'https://election-api.goodparty.org';
@@ -105,13 +105,15 @@ async function fetchJson<T>(url: string, options?: RequestInit): Promise<T | nul
 			try {
 				const result = await fetchElectionApiJsonCached(url, tags);
 				if (result.status === 404) return null;
-				if (result.ok) return result.json as T;
-				if (result.status > 0 && result.status < 500) {
-					console.error(`[electionsApi] ${result.status} ${url}`);
+				return result.json as T;
+			} catch (err) {
+				// A 4xx is a deterministic answer — retrying just re-asks the same bad
+				// question three times and delays the null by 1.5s. Only 5xx and
+				// transport errors are worth another attempt.
+				if (err instanceof ElectionApiError && err.status < 500) {
+					console.error(`[electionsApi] ${err.status} ${url}`);
 					return null;
 				}
-				console.error(`[electionsApi] ${result.status || 'error'} ${url} (attempt ${attempt + 1})`);
-			} catch (err) {
 				console.error(`[electionsApi] attempt ${attempt + 1}`, err);
 			}
 			if (attempt < FETCH_JSON_MAX_RETRIES) {

--- a/src/lib/electionsApi.ts
+++ b/src/lib/electionsApi.ts
@@ -24,6 +24,7 @@ import {
 	normalizeCandidateLookupName,
 	stripCountySuffix,
 } from '~/lib/electionsHelpers';
+import { fetchElectionApiJsonCached } from '~/lib/electionApiFetch';
 
 const ELECTIONS_API_BASE_URL =
 	process.env['ELECTIONS_API_BASE_URL'] ?? 'https://election-api.goodparty.org';
@@ -94,6 +95,33 @@ async function sleep(ms: number): Promise<void> {
 }
 
 async function fetchJson<T>(url: string, options?: RequestInit): Promise<T | null> {
+	// election-api: auth + URL-keyed unstable_cache (Authorization must not be in the
+	// Next fetch cache key or the shared 1h cache stops hitting across isolates).
+	if (url.startsWith(ELECTIONS_API_BASE_URL)) {
+		// Forward on-demand revalidation tags (e.g. person:<id>) so cache busts
+		// via /api/revalidate-person actually invalidate these cached responses.
+		const tags = (options as { next?: { tags?: readonly string[] } } | undefined)?.next?.tags;
+		for (let attempt = 0; attempt <= FETCH_JSON_MAX_RETRIES; attempt++) {
+			try {
+				const result = await fetchElectionApiJsonCached(url, tags);
+				if (result.status === 404) return null;
+				if (result.ok) return result.json as T;
+				if (result.status > 0 && result.status < 500) {
+					console.error(`[electionsApi] ${result.status} ${url}`);
+					return null;
+				}
+				console.error(`[electionsApi] ${result.status || 'error'} ${url} (attempt ${attempt + 1})`);
+			} catch (err) {
+				console.error(`[electionsApi] attempt ${attempt + 1}`, err);
+			}
+			if (attempt < FETCH_JSON_MAX_RETRIES) {
+				await sleep(500 * (attempt + 1));
+			}
+		}
+		return null;
+	}
+
+	// gp-api and other hosts: no M2M token (election-api-scoped).
 	for (let attempt = 0; attempt <= FETCH_JSON_MAX_RETRIES; attempt++) {
 		try {
 			const res = await fetch(url, options);

--- a/src/lib/peopleProfile.test.ts
+++ b/src/lib/peopleProfile.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 import type { PersonItem, PersonOfficeHolder, PublicPersonProfile } from '~/types/people';
 import {
-	buildBreadcrumb,
+	buildBreadcrumbTrail,
 	buildPersonSlug,
 	composeView,
 	extractPersonId,
@@ -214,6 +214,85 @@ describe('composeView persona resolution', () => {
 			null,
 		);
 		expect(view.persona).toBe('both');
+	});
+
+	test('the hero names the current race, not whichever candidacy the API returns first', () => {
+		const view = composeView(
+			PID,
+			makePerson({
+				fullName: 'Jane Doe',
+				// The API does not order this array, so a past run can come first.
+				Candidacies: [
+					{ id: 'c1', positionName: 'School Board', Race: { electionDate: '2022-11-08' } },
+					{ id: 'c2', positionName: 'Mayor', Race: { electionDate: '2099-11-03' } },
+				],
+			}),
+			null,
+		);
+		expect(view.roleTitle).toBe('Candidate for Mayor');
+		// Section headings ("About …", "Other Candidates for …") read the same name.
+		expect(view.officeName).toBe('Mayor');
+	});
+
+	test('prefers a linkable race so the hero cannot name one race while the links name another', () => {
+		const view = composeView(
+			PID,
+			makePerson({
+				fullName: 'Jane Doe',
+				Candidacies: [
+					// Sooner, but with no slug the rest of the page cannot use it.
+					{ id: 'c1', positionName: 'Mayor', Race: { electionDate: '2099-11-01' } },
+					{ id: 'c2', positionName: 'School Board', slug: 'wy/laramie/school-board', Race: { electionDate: '2099-11-03' } },
+				],
+			}),
+			null,
+		);
+		expect(view.roleTitle).toBe('Candidate for School Board');
+	});
+
+	test('a slug-less candidacy still supplies the office name and party', () => {
+		const view = composeView(
+			PID,
+			makePerson({
+				fullName: 'Jane Doe',
+				Candidacies: [{ id: 'c1', positionName: 'Mayor', party: 'Independent' }],
+			}),
+			null,
+		);
+		expect(view.roleTitle).toBe('Candidate for Mayor');
+		expect(view.party).toBe('Independent');
+	});
+
+	test('an archived candidate falls back to their most recent past race', () => {
+		const view = composeView(
+			PID,
+			makePerson({
+				fullName: 'Jane Doe',
+				Candidacies: [
+					{ id: 'c1', positionName: 'School Board', Race: { electionDate: '2018-11-06' } },
+					{ id: 'c2', positionName: 'Mayor', Race: { electionDate: '2022-11-08' } },
+				],
+			}),
+			null,
+		);
+		expect(view.roleTitle).toBe('Candidate for Mayor');
+	});
+
+	test('both: the second hero line names the seat being sought, not a past run', () => {
+		const view = composeView(
+			PID,
+			makePerson({
+				fullName: 'Jane Doe',
+				Candidacies: [
+					{ id: 'c1', positionName: 'School Board', Race: { electionDate: '2022-11-08' } },
+					{ id: 'c2', positionName: 'Mayor', Race: { electionDate: '2099-11-03' } },
+				],
+				OfficeHolders: [makeOffice({ isCurrent: true, officeTitle: 'City Council' })],
+			}),
+			null,
+		);
+		expect(view.roleTitle).toBe('City Council');
+		expect(view.secondaryRoleTitle).toBe('Candidate for Mayor');
 	});
 
 	test('past: held office before, not current and not running', () => {
@@ -472,9 +551,9 @@ describe('composeView state + empowerment gating', () => {
 	});
 });
 
-describe('buildBreadcrumb', () => {
+describe('buildBreadcrumbTrail', () => {
 	test('degrades to Elections > State > Name without a race slug', async () => {
-		const trail = await buildBreadcrumb({
+		const trail = buildBreadcrumbTrail({
 			displayName: 'Jane Doe',
 			stateCode: 'CA',
 			raceSlug: null,
@@ -486,7 +565,7 @@ describe('buildBreadcrumb', () => {
 	});
 
 	test('degrades to Elections > Name when neither race slug nor state is known', async () => {
-		const trail = await buildBreadcrumb({
+		const trail = buildBreadcrumbTrail({
 			displayName: 'Jane Doe',
 			stateCode: null,
 			raceSlug: null,
@@ -497,7 +576,7 @@ describe('buildBreadcrumb', () => {
 	});
 
 	test('builds Elections > State > ... > Position > Name from a race slug', async () => {
-		const trail = await buildBreadcrumb({
+		const trail = buildBreadcrumbTrail({
 			displayName: 'Jane Doe',
 			stateCode: 'CA',
 			raceSlug: 'ca/los-angeles-county/mayor',

--- a/src/lib/peopleProfile.ts
+++ b/src/lib/peopleProfile.ts
@@ -184,6 +184,11 @@ export interface PersonProfileView {
 	displayName: string;
 	/** Hero line under the name, e.g. "Candidate for Mayor" or "City Council". */
 	roleTitle: string | null;
+	/**
+	 * Second hero line, only for someone serving and running at once (Figma
+	 * state C): `roleTitle` names the seat held, this names the candidacy.
+	 */
+	secondaryRoleTitle: string | null;
 	/** Bare office name for the sidebar "About Office" row. */
 	officeName: string | null;
 	party: string | null;
@@ -316,9 +321,54 @@ function formatTerm(office: PersonOfficeHolder | null): string | null {
 	return null;
 }
 
+/**
+ * Buckets candidacies by how current they are: the soonest upcoming election
+ * first, then the most recent past one, then rows we can't date. The API does
+ * not guarantee an order, so anything that reads "the" candidacy off the array
+ * must go through this or it risks naming a race the person already ran.
+ */
+function candidaciesByRecency(candidacies: PersonCandidacySummary[]): {
+	upcoming: PersonCandidacySummary[];
+	past: PersonCandidacySummary[];
+	undated: PersonCandidacySummary[];
+} {
+	const now = Date.now();
+	const dated: { candidacy: PersonCandidacySummary; time: number }[] = [];
+	const undated: PersonCandidacySummary[] = [];
+	for (const candidacy of candidacies) {
+		const parsed = candidacy.Race?.electionDate ? Date.parse(candidacy.Race.electionDate) : NaN;
+		if (Number.isNaN(parsed)) undated.push(candidacy);
+		else dated.push({ candidacy, time: parsed });
+	}
+	return {
+		upcoming: dated.filter(x => x.time >= now).sort((a, b) => a.time - b.time).map(x => x.candidacy),
+		past: dated.filter(x => x.time < now).sort((a, b) => b.time - a.time).map(x => x.candidacy),
+		undated,
+	};
+}
+
+/**
+ * The race a person is currently running in, else the last one they ran in.
+ *
+ * Prefers a candidacy with a slug, because the rest of the page — position
+ * link, breadcrumb crumb, "About [position]", other candidates — is built from
+ * {@link selectPrimaryCandidacy}, which can only use slugged rows. Without that
+ * preference the hero could name one race while everything under it named
+ * another. Slug-less rows are still a fallback rather than being filtered out:
+ * they carry the office name and party, and dropping them would blank the hero
+ * and, via `classifyPartyFrom`, change which profile state the page renders.
+ */
+function primaryCandidacy(person: PersonItem | null): PersonCandidacySummary | null {
+	const all = person?.Candidacies ?? [];
+	const first = (candidacies: PersonCandidacySummary[]) => {
+		const { upcoming, past, undated } = candidaciesByRecency(candidacies);
+		return upcoming[0] ?? past[0] ?? undated[0] ?? null;
+	};
+	return first(all.filter(c => c.slug)) ?? first(all);
+}
+
 function candidateOfficeName(person: PersonItem | null): string | null {
-	const candidacy = person?.Candidacies?.[0];
-	return candidacy?.positionName ?? null;
+	return primaryCandidacy(person)?.positionName ?? null;
 }
 
 function resolveRoleTitle(
@@ -528,13 +578,13 @@ function humanizeSlugSegment(segment: string): string {
  * (e.g. an office holder with no linked race), the trail degrades to
  * `Elections > State? > Name`.
  */
-export async function buildBreadcrumb(params: {
+export function buildBreadcrumbTrail(params: {
 	displayName: string;
 	stateCode: string | null;
 	raceSlug: string | null;
 	positionLevel: string | null;
 	positionName: string | null;
-}): Promise<ProfileBreadcrumb[]> {
+}): ProfileBreadcrumb[] {
 	const { displayName, stateCode, raceSlug, positionLevel, positionName } = params;
 	const trail: ProfileBreadcrumb[] = [{ href: '/elections', label: 'Elections' }];
 
@@ -626,17 +676,24 @@ export function composeView(
 	// Label and class must share one source precedence, or a "both" persona whose
 	// office and candidacy parties differ would show one party while being gated
 	// (majorParty → I/J empowerment) by the other. Office-first for both.
-	const rawParty = office?.partyNames?.[0] ?? person?.Candidacies?.[0]?.party ?? null;
-	const partyClass = classifyPartyFrom(
-		office?.partyNames?.[0],
-		person?.Candidacies?.[0]?.party,
-	);
+	// Read the party off the CURRENT race, not whichever candidacy the API
+	// happens to return first: someone who ran as a Democrat in 2020 and is now
+	// running as an Independent would otherwise be gated as major-party (I/J)
+	// and lose the empowerment framing they qualify for.
+	const primaryCand = primaryCandidacy(person);
+	const rawParty = office?.partyNames?.[0] ?? primaryCand?.party ?? null;
+	const partyClass = classifyPartyFrom(office?.partyNames?.[0], primaryCand?.party);
 	const majorParty = isMajorParty(partyClass);
 	const state = resolveProfileState(persona, { claimed, removed, partyClass });
 	// Empowerment framing applies to claimed pages and unclaimed non-partisan
 	// pages; it is stripped for major-party (I/J) and removal (K/L) states.
 	const empowered = claimed || (!removed && !majorParty);
 	const roleTitle = resolveRoleTitle(persona, person, office, overlay?.roleTitleOverride ?? null);
+	// Someone serving AND running shows both offices in the hero (Figma C):
+	// `roleTitle` carries the seat held, this carries the candidacy beneath it.
+	const candidacyTarget = primaryCand?.positionName ?? null;
+	const secondaryRoleTitle =
+		persona === 'both' && candidacyTarget ? `Candidate for ${candidacyTarget}` : null;
 	const party = rawParty ?? (partyClass ? PARTY_LABELS[partyClass] : null);
 	const districtLabel = office?.subAreaValue ?? office?.subAreaName ?? null;
 	// Mirror the loader's stateCode (which includes the candidacy fallback) so a
@@ -669,14 +726,11 @@ export function composeView(
 		pledged: !removed && (person?.isPledged ?? false),
 		displayName,
 		roleTitle,
+		secondaryRoleTitle,
 		// Candidate-only people have no held office; fall back to the candidacy's
 		// position so section headings ("About …", "Other Candidates for …") still
 		// name the seat they're running for, matching the Figma candidate frames.
-		officeName:
-			office?.positionName ??
-			office?.officeTitle ??
-			person?.Candidacies?.[0]?.positionName ??
-			null,
+		officeName: office?.positionName ?? office?.officeTitle ?? candidacyTarget,
 		party,
 		avatarUrl,
 		coverImageUrl: removed ? null : (overlay?.coverImageUrl ?? null),
@@ -737,25 +791,15 @@ function selectPrimaryCandidacy(
 	person: PersonItem | null,
 	hasCurrentOffice: boolean,
 ): PersonCandidacySummary | null {
-	const candidacies = (person?.Candidacies ?? []).filter((c) => c.slug);
-	if (candidacies.length === 0) return null;
-	const now = Date.now();
-	const dated = candidacies.map((c) => {
-		const parsed = c.Race?.electionDate ? Date.parse(c.Race.electionDate) : NaN;
-		return { candidacy: c, time: Number.isNaN(parsed) ? null : parsed };
-	});
+	const { upcoming, past, undated } = candidaciesByRecency(
+		(person?.Candidacies ?? []).filter((c) => c.slug),
+	);
 	// (1) Current candidate: earliest upcoming election.
-	const upcoming = dated
-		.filter((x): x is { candidacy: PersonCandidacySummary; time: number } => x.time != null && x.time >= now)
-		.sort((a, b) => a.time - b.time);
-	if (upcoming[0]) return upcoming[0].candidacy;
+	if (upcoming[0]) return upcoming[0];
 	// (2) Elected officeholder not currently running: defer to the office.
 	if (hasCurrentOffice) return null;
 	// (3) Archived: most recent past run wins; undated rows fall back to first.
-	const past = dated
-		.filter((x): x is { candidacy: PersonCandidacySummary; time: number } => x.time != null)
-		.sort((a, b) => b.time - a.time);
-	return past[0]?.candidacy ?? candidacies[0] ?? null;
+	return past[0] ?? undated[0] ?? null;
 }
 
 /** Resolves the primary candidacy detail (with race) used to enrich the page. */
@@ -949,13 +993,13 @@ export async function loadPersonProfile(personId: string): Promise<PersonProfile
 	const composedName = [person?.firstName, person?.lastName].filter(Boolean).join(' ');
 	const displayName = overlay?.displayName ?? person?.fullName ?? (composedName || 'Public Official');
 
-	// Interlink sections + breadcrumb are independent; fetch in parallel. Each
-	// degrades to empty on any miss so the core profile always renders.
+	// The interlink sections are independent; fetch in parallel. Each degrades to
+	// empty on any miss so the core profile always renders.
 	const { tier, countySlug } = deriveElectionsIndexTier(positionHref, positionLevel);
-	const [otherCandidates, nearbyOfficials, breadcrumb, electionsIndex] = await Promise.all([
+	const breadcrumb = buildBreadcrumbTrail({ displayName, stateCode, raceSlug, positionLevel, positionName });
+	const [otherCandidates, nearbyOfficials, electionsIndex] = await Promise.all([
 		loadOtherCandidates(positionId, personId),
 		loadNearbyOfficials(geoId, personId),
-		buildBreadcrumb({ displayName, stateCode, raceSlug, positionLevel, positionName }),
 		loadElectionsIndex({ stateCode, tier, countySlug }),
 	]);
 

--- a/src/lib/sitemap-entries.ts
+++ b/src/lib/sitemap-entries.ts
@@ -13,6 +13,7 @@ import {
 } from '~/lib/electionsHelpers';
 import { buildPersonSlugFromBase } from '~/lib/peopleProfile';
 import { FAQ_BASE_PATH, getFaqSitemapEntries } from '~/lib/faqSlugs';
+import { fetchElectionApiJsonCached } from '~/lib/electionApiFetch';
 import { allFaqsQuery } from '~/sanity/groq';
 
 /** 51 US state/DC codes (50 states + DC) */
@@ -56,8 +57,10 @@ export function getSitemapIds(): { id: number }[] {
 	return ids;
 }
 
+// Server-only base: M2M auth headers are attached to requests against this URL,
+// so it must never be sourced from a client-visible (NEXT_PUBLIC_*) env var.
 const ELECTION_API_BASE =
-	process.env['NEXT_PUBLIC_ELECTION_API_BASE'] ?? process.env['ELECTIONS_API_BASE_URL'] ?? 'https://election-api.goodparty.org';
+	process.env['ELECTIONS_API_BASE_URL'] ?? 'https://election-api.goodparty.org';
 
 const GP_API_BASE =
 	process.env['GP_API_BASE_URL'] ??
@@ -438,12 +441,12 @@ async function fetchElectionJson<T>(
 	const search = new URLSearchParams(params).toString();
 	const url = `${ELECTION_API_BASE.replace(/\/$/, '')}/${path.replace(/^\//, '')}?${search}`;
 	try {
-		const res = await fetch(url, cacheInit(tags));
-		if (!res.ok) {
-			console.error(`[sitemap] Election API ${res.status} ${url}`);
+		const result = await fetchElectionApiJsonCached(url, tags);
+		if (!result.ok) {
+			console.error(`[sitemap] Election API ${result.status} ${url}`);
 			return [];
 		}
-		const data: unknown = await res.json();
+		const data = result.json;
 		if (Array.isArray(data)) return data as T[];
 		if (data && typeof data === 'object' && 'data' in data) {
 			const inner = (data as { data: unknown }).data;

--- a/src/testing/nextCacheMock.ts
+++ b/src/testing/nextCacheMock.ts
@@ -1,0 +1,45 @@
+/**
+ * The one `next/cache` mock for the logic suite.
+ *
+ * bun keeps the first `mock.module` registration for a specifier and ignores
+ * later ones from other files in the same run. Two test files each mocking
+ * `next/cache` with a different subset of exports therefore means whichever
+ * registration loses gets a module missing the export it needs — and because the
+ * loser silently falls through to the real CJS `next/cache`, the failure is an
+ * import-time SyntaxError in an unrelated file rather than anything pointing at
+ * the collision. Every test that needs `next/cache` mocked imports this module
+ * instead, so the registration always carries the union of the exports.
+ *
+ * `unstable_cache` is a faithful passthrough: it records its arguments and runs
+ * the wrapped function immediately, so it stays harmless for files that only
+ * care about `revalidateTag`.
+ */
+import { mock } from 'bun:test';
+
+export type CachedOptions = { revalidate?: number; tags?: readonly string[] };
+
+/** Arguments of the most recent `unstable_cache` call. */
+export const lastCacheCall: { keyParts?: unknown; options?: CachedOptions } = {};
+
+export const unstable_cache = mock(
+	(
+		fn: (...args: unknown[]) => unknown,
+		keyParts: unknown,
+		options: CachedOptions,
+	) => {
+		lastCacheCall.keyParts = keyParts;
+		lastCacheCall.options = options;
+		return (...args: unknown[]) => fn(...args);
+	},
+);
+
+export const revalidateTag = mock((tag: string) => tag);
+
+export function resetNextCacheMock(): void {
+	unstable_cache.mockClear();
+	revalidateTag.mockClear();
+	delete lastCacheCall.keyParts;
+	delete lastCacheCall.options;
+}
+
+void mock.module('next/cache', () => ({ unstable_cache, revalidateTag }));

--- a/src/ui/ProfileContentBlock.tsx
+++ b/src/ui/ProfileContentBlock.tsx
@@ -1,3 +1,4 @@
+import { chunkCardGroups } from './_lib/chunkCardGroups.ts';
 import { cn, tv } from './_lib/utils.ts';
 import { Container } from './Container.tsx';
 import { ElectionsSidebar, type ElectionsSidebarProps } from './ElectionsSidebar.tsx';
@@ -64,21 +65,6 @@ export type ProfileContentBlockProps = {
 	cardLayout?: 'joined' | 'separated';
 };
 
-/** Chunks a flat card list into groups: consecutive same-`group` non-raw cards
- * share a white card; every `raw` card stands alone (self-styled). */
-function chunkCardGroups(cards: ProfileContentCardProps[]): ProfileContentCardProps[][] {
-	const groups: ProfileContentCardProps[][] = [];
-	for (const card of cards) {
-		const last = groups.at(-1);
-		const head = last?.[0];
-		const mergeable =
-			head != null && !card.raw && !head.raw && card.group != null && head.group === card.group;
-		if (mergeable && last) last.push(card);
-		else groups.push([card]);
-	}
-	return groups;
-}
-
 export function ProfileContentBlock(props: ProfileContentBlockProps) {
 	const backgroundColor = props.backgroundColor ?? 'cream';
 	const { base, well, grid, sidebar, sidebarStandalone, content, separatedColumn, separatedCard, title: titleSlot } =
@@ -104,7 +90,12 @@ export function ProfileContentBlock(props: ProfileContentBlockProps) {
 									) : (
 										<div key={gi} className={cn(separatedCard())} data-component='ProfileContentCardGroup'>
 											{group.map((card, ci) => (
-												<ProfileContentCard key={`${gi}-${ci}`} {...card} bare />
+												<ProfileContentCard
+													key={`${gi}-${ci}`}
+													{...card}
+													headingStyle={ci === 0 ? 'section' : 'sub'}
+													bare
+												/>
 											))}
 										</div>
 									),

--- a/src/ui/ProfileContentCard.tsx
+++ b/src/ui/ProfileContentCard.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react';
 import { cn, tv } from './_lib/utils.ts';
-import { Text } from './Text.tsx';
+import { Text, type StyleTypes } from './Text.tsx';
 import { isValidRichText } from './_lib/isValidRichText.ts';
 
 const styles = tv({
@@ -20,6 +20,12 @@ const styles = tv({
 	},
 });
 
+const HEADING_STYLE_TYPE = {
+	section: 'section-heading',
+	sub: 'section-subheading',
+	legacy: 'subtitle-1',
+} as const satisfies Record<string, StyleTypes>;
+
 export type ProfileContentCardProps = {
 	className?: string;
 	cardType?: 'about-me' | 'why-running' | 'top-issues';
@@ -31,6 +37,15 @@ export type ProfileContentCardProps = {
 	 */
 	group?: string;
 	heading?: string;
+	/**
+	 * Heading level within a white card, per the Figma people-profile frames:
+	 * the card's first section is `section` (32/44) and any section stacked
+	 * under it is `sub` (24/32), e.g. "Campaign Issues" beneath "Why I'm
+	 * Running for Office". Supplied by ProfileContentBlock's separated layout
+	 * from the card's position in its group. Left undefined by the joined
+	 * `/candidate` layout, which keeps its own uniform subtitle heading.
+	 */
+	headingStyle?: 'section' | 'sub';
 	content?: ReactNode;
 	/**
 	 * Render `content` verbatim, without the card chrome (bottom divider + the
@@ -52,7 +67,11 @@ export function ProfileContentCard(props: ProfileContentCardProps) {
 	return (
 		<article className={cn(base(), props.className)} data-component='ProfileContentCard'>
 			{props.heading && (
-				<Text as='h2' styleType='subtitle-1' className={heading()}>
+				<Text
+					as={props.headingStyle === 'sub' ? 'h3' : 'h2'}
+					styleType={HEADING_STYLE_TYPE[props.headingStyle ?? 'legacy']}
+					className={heading()}
+				>
 					{props.heading}
 				</Text>
 			)}

--- a/src/ui/ProfileHero.tsx
+++ b/src/ui/ProfileHero.tsx
@@ -50,6 +50,9 @@ const styles = tv({
 		// for merge to collapse it against; color is inherited from the container.
 		tagText: 'font-secondary text-[0.875rem] font-medium',
 		nameOffice: 'flex flex-col gap-1',
+		// Office lines stack flush (Figma sets them on consecutive 32px lines with
+		// no gap) even when a second line is present.
+		officeLines: 'flex flex-col',
 		heading: '',
 		// Figma office line is Outfit Medium (500), not the subtitle-1 default (600).
 		office: 'font-medium',
@@ -102,6 +105,14 @@ export type ProfileHeroProps = {
 	office: string;
 	/** When set, the office line renders as a link to the office/position page. */
 	officeHref?: string;
+	/**
+	 * Second office line, stacked directly under the first with no gap. Used by
+	 * the simultaneous candidate + office-holder frame (Figma state C), which
+	 * shows the seat held above "Candidate for [position]".
+	 */
+	secondaryOffice?: string;
+	/** When set, the secondary office line renders as a link. */
+	secondaryOfficeHref?: string;
 	profileImage?: SanityImage;
 	profileImageUrl?: string;
 	isEmpowered?: boolean;
@@ -117,7 +128,19 @@ export type ProfileHeroProps = {
 export function ProfileHero(props: ProfileHeroProps) {
 	const backgroundColor = props.backgroundColor ?? 'midnight';
 	const resolvedBackgroundColor = backgroundColor === 'white' ? 'cream' : backgroundColor;
-	const { base, backgroundWrapper, band, belowBand, container, imageWrapper, image, badge, content, tagRow, tag, tagText, nameOffice, heading, office, officeLink, attribution, attributionIcon, attributionText, notEndorsed } = styles({ backgroundColor: resolvedBackgroundColor });
+	const { base, backgroundWrapper, band, belowBand, container, imageWrapper, image, badge, content, tagRow, tag, tagText, nameOffice, officeLines, heading, office, officeLink, attribution, attributionIcon, attributionText, notEndorsed } = styles({ backgroundColor: resolvedBackgroundColor });
+
+	const renderOfficeLine = (label: string, href?: string) => (
+		<Text key={label} as="p" styleType="subtitle-1" className={office()}>
+			{href ? (
+				<Anchor href={href} className={officeLink()}>
+					{label}
+				</Anchor>
+			) : (
+				label
+			)}
+		</Text>
+	);
 
 	// `attribution` wins when provided; otherwise fall back to legacy `isEmpowered`.
 	const attributionMode = props.attribution ?? (props.isEmpowered ? 'empowered' : 'none');
@@ -180,15 +203,10 @@ export function ProfileHero(props: ProfileHeroProps) {
 							<Text as="h1" styleType={props.candidateName.length > 28 ? 'heading-md' : 'heading-lg'} className={heading()}>
 								{props.candidateName}
 							</Text>
-							<Text as="p" styleType="subtitle-1" className={office()}>
-								{props.officeHref ? (
-									<Anchor href={props.officeHref} className={officeLink()}>
-										{props.office}
-									</Anchor>
-								) : (
-									props.office
-								)}
-							</Text>
+							<div className={officeLines()}>
+								{renderOfficeLine(props.office, props.officeHref)}
+								{props.secondaryOffice && renderOfficeLine(props.secondaryOffice, props.secondaryOfficeHref)}
+							</div>
 						</div>
 						{attributionMode === 'empowered' && (
 							<div className={attribution()}>

--- a/src/ui/ProfileHero.tsx
+++ b/src/ui/ProfileHero.tsx
@@ -36,32 +36,46 @@ const styles = tv({
 		// fraction of the portrait per Figma (desktop glyph 113x94 on the 416px
 		// avatar; mobile 48x40 on the 144px avatar), so it scales across breakpoints.
 		badge: 'absolute bottom-1 right-1 z-30 drop-shadow-md w-12 h-10 md:w-20 md:h-[66px] lg:w-[113px] lg:h-[94px]',
-		content: 'flex flex-col gap-4 text-left z-10 md:pt-2',
+		// Tighter rhythm than before so the attribution sits higher in the band,
+		// leaving more dark space beneath "Empowered by GoodParty.org" (Figma).
+		content: 'flex flex-col gap-2 text-left z-10 md:pt-2',
 		tagRow: 'flex flex-wrap items-center gap-2',
-		// Pill CONTAINER only (shape + color). The text size lives on an inner span,
-		// NOT here: our tailwind-merge collapses any text-size against a text-color in
-		// the same pass and keeps the color, so size + color must be separate elements.
+		// Pill CONTAINER only (shape + border/text-color). The FILL is applied per
+		// tag in the render (Incumbent → halo-green, Candidate → bright-yellow) and
+		// the text size lives on an inner span, NOT here: our tailwind-merge collapses
+		// any text-size against a text-color in the same pass and keeps the color, so
+		// size + color must be separate elements.
 		tag: 'inline-flex w-fit items-center rounded-[6px] border px-2.5 py-1 shadow-xs',
 		// Inner text span: 14px medium Open Sans (Figma tag). No color here → nothing
 		// for merge to collapse it against; color is inherited from the container.
 		tagText: 'font-secondary text-[0.875rem] font-medium',
-		nameOffice: 'flex flex-col gap-2',
+		nameOffice: 'flex flex-col gap-1',
 		heading: '',
-		office: '',
+		// Figma office line is Outfit Medium (500), not the subtitle-1 default (600).
+		office: 'font-medium',
 		officeLink: 'hover:underline',
-		attribution: 'flex items-center justify-start gap-1.5',
+		// Container carries the text COLOR (via variant); the inner span carries the
+		// size/weight so tailwind-merge can't collapse them into one another.
+		attribution: 'mt-1 flex items-center justify-start gap-1.5',
 		attributionIcon: 'w-[37px] h-[28px]',
-		attributionText: 'text-sm',
+		// Figma "Empowered by GoodParty.org": Outfit SemiBold 20/28.
+		attributionText: 'font-primary text-[1.25rem] font-semibold leading-7',
 		notEndorsed: 'text-sm',
 	},
 	variants: {
 		backgroundColor: {
 			midnight: {
-				band: 'bg-midnight-900',
+				// Figma hero band: a midnight→blue diagonal gradient. Figma's stops
+				// (68.4% / 125.1%) were measured on its full-height hero frame; on our
+				// short dark band those push the bright-blue stop off-canvas so it
+				// reads as one flat color. The stops are re-fit here to transition
+				// within the band (dark top for legibility → blue by the lower edge).
+				// The bright stop is the --goodparty-blue-bright token (colors.css).
+				band: 'bg-[linear-gradient(156.73deg,var(--midnight-900)_30%,var(--goodparty-blue-bright))]',
 				heading: 'text-white',
 				office: 'text-white',
-				attributionText: 'text-white',
-				tag: 'bg-bright-yellow-50 border-gray-300 text-[color:#0a0a0a]',
+				attribution: 'text-white',
+				tag: 'border-gray-300 text-[color:#0a0a0a]',
 				notEndorsed: 'text-gray-400',
 			},
 			cream: {
@@ -69,7 +83,7 @@ const styles = tv({
 				band: 'bg-goodparty-cream',
 				heading: 'text-midnight-900',
 				office: 'text-midnight-900',
-				attributionText: 'text-midnight-900',
+				attribution: 'text-midnight-900',
 				tag: 'bg-white border-gray-300 text-[color:#0a0a0a]',
 				notEndorsed: 'text-gray-500',
 			},
@@ -104,6 +118,10 @@ export function ProfileHero(props: ProfileHeroProps) {
 	// `attribution` wins when provided; otherwise fall back to legacy `isEmpowered`.
 	const attributionMode = props.attribution ?? (props.isEmpowered ? 'empowered' : 'none');
 	const tags = props.tags?.filter(Boolean) ?? [];
+
+	// Per Figma the persona pill is colour-coded by label: an in-office "Incumbent"
+	// reads halo-green, everyone else (Candidate / Former Official) reads bright-yellow.
+	const tagFill = (label: string): string => (label === 'Incumbent' ? 'bg-halo-green-50' : 'bg-bright-yellow-50');
 
 	return (
 		<section className={cn(base(), props.className)} data-component="ProfileHero">
@@ -148,7 +166,7 @@ export function ProfileHero(props: ProfileHeroProps) {
 						{tags.length > 0 && (
 							<div className={tagRow()}>
 								{tags.map((label) => (
-									<span key={label} className={tag()}>
+									<span key={label} className={cn(tag(), tagFill(label))}>
 										<span className={tagText()}>{label}</span>
 									</span>
 								))}
@@ -171,9 +189,7 @@ export function ProfileHero(props: ProfileHeroProps) {
 						{attributionMode === 'empowered' && (
 							<div className={attribution()}>
 								<Logo className={attributionIcon()} />
-								<Text as="span" styleType="body-2" className={attributionText()}>
-									Empowered by GoodParty.org
-								</Text>
+								<span className={attributionText()}>Empowered by GoodParty.org</span>
 							</div>
 						)}
 						{attributionMode === 'notEndorsed' && (

--- a/src/ui/ProfileHero.tsx
+++ b/src/ui/ProfileHero.tsx
@@ -65,13 +65,17 @@ const styles = tv({
 	variants: {
 		backgroundColor: {
 			midnight: {
-				// Figma hero band: a midnight→blue diagonal gradient. Figma's stops
-				// (68.4% / 125.1%) were measured on its full-height hero frame; on our
-				// short dark band those push the bright-blue stop off-canvas so it
-				// reads as one flat color. The stops are re-fit here to transition
-				// within the band (dark top for legibility → blue by the lower edge).
-				// The bright stop is the --goodparty-blue-bright token (colors.css).
-				band: 'bg-[linear-gradient(156.73deg,var(--midnight-900)_30%,var(--goodparty-blue-bright))]',
+				// Figma hero band: a soft blue glow rising from the BOTTOM-CENTER over
+				// a midnight field (not a linear top→bottom ramp — that read wrong at
+				// both the top corners and the edges). This radial is fit by VALUE:
+				// sampling Figma's rendered band on a 5×5 grid and minimizing RGB error
+				// gives an ellipse at 50% 100% sized 90%×93% of the band, blue at the
+				// center fading to midnight by the top, with a 40% interpolation hint
+				// bending the falloff to Figma's ease-in curve (RMSE ~5.6/channel,
+				// bottom-center 36,70,137 vs Figma 37,71,138). % sizing keeps it
+				// correct across viewport widths. Colors are tokens: blue = #26498f
+				// (--goodparty-blue-bright), field = --midnight-900 (colors.css).
+				band: 'bg-[radial-gradient(90%_93%_at_50%_100%,var(--goodparty-blue-bright)_0%,40%,var(--midnight-900)_100%)]',
 				heading: 'text-white',
 				office: 'text-white',
 				attribution: 'text-white',

--- a/src/ui/Text.tsx
+++ b/src/ui/Text.tsx
@@ -34,6 +34,12 @@ export const styles = tv({
 			'heading-xs': {
 				base: 'text-heading-xs',
 			},
+			'section-heading': {
+				base: 'text-section-heading',
+			},
+			'section-subheading': {
+				base: 'text-section-subheading',
+			},
 			'subtitle-1': {
 				base: 'text-subtitle-1',
 			},

--- a/src/ui/_lib/chunkCardGroups.ts
+++ b/src/ui/_lib/chunkCardGroups.ts
@@ -1,0 +1,24 @@
+import type { ProfileContentCardProps } from '../ProfileContentCard.tsx';
+
+/**
+ * Chunks a flat card list into the separated layout's white cards: consecutive
+ * non-raw cards sharing a `group` go in one card; every `raw` card stands alone
+ * (self-styled).
+ *
+ * A card's index within its chunk also decides its heading level — the Figma
+ * people-profile frames give a card's first section a 32/44 heading and anything
+ * stacked under it a 24/32 one — so this lives apart from the component to keep
+ * it testable without a DOM.
+ */
+export function chunkCardGroups(cards: ProfileContentCardProps[]): ProfileContentCardProps[][] {
+	const groups: ProfileContentCardProps[][] = [];
+	for (const card of cards) {
+		const last = groups.at(-1);
+		const head = last?.[0];
+		const mergeable =
+			head != null && !card.raw && !head.raw && card.group != null && head.group === card.group;
+		if (mergeable && last) last.push(card);
+		else groups.push([card]);
+	}
+	return groups;
+}

--- a/src/ui/_styles/colors.css
+++ b/src/ui/_styles/colors.css
@@ -73,6 +73,9 @@
 		--goodparty-red-light: hsl(349 79% 85% / 1);
 		--goodparty-blue: hsl(218 100% 38% / 1);
 		--goodparty-blue-light: hsl(218 80% 80% / 1);
+		/* Lighter, more saturated member of the midnight family (== #26498f).
+		   Used as the bright stop of the person-profile hero gradient. */
+		--goodparty-blue-bright: hsl(220 58% 35% / 1);
 		--goodparty-gold: hsl(43 81% 51% / 1);
 		--goodparty-cream: hsl(33 60% 97% / 1);
 
@@ -221,6 +224,7 @@
 	--color-goodparty-red-light: var(--goodparty-red-light);
 	--color-goodparty-blue: var(--goodparty-blue);
 	--color-goodparty-blue-light: var(--goodparty-blue-light);
+	--color-goodparty-blue-bright: var(--goodparty-blue-bright);
 	--color-goodparty-gold: var(--goodparty-gold);
 	--color-goodparty-cream: var(--goodparty-cream);
 

--- a/src/ui/_styles/typography.css
+++ b/src/ui/_styles/typography.css
@@ -28,6 +28,23 @@
 	--text-heading-xs--letter-spacing: 0;
 	--text-heading-xs--font-weight: 600;
 
+	/*
+	 * Profile section headings. Mirrors the people-profile frames' Figma
+	 * `typography/3xl` (32/44) and `typography/2xl` (24/32) semibold styles.
+	 * Deliberately absent from the stepped @media blocks below: the frames use
+	 * these same two sizes on the mobile and desktop artboards alike, so unlike
+	 * the `heading-*` ramp they must NOT scale with the viewport.
+	 */
+	--text-section-heading: 2rem;
+	--text-section-heading--line-height: 2.75rem;
+	--text-section-heading--letter-spacing: 0;
+	--text-section-heading--font-weight: 600;
+
+	--text-section-subheading: 1.5rem;
+	--text-section-subheading--line-height: 2rem;
+	--text-section-subheading--letter-spacing: 0;
+	--text-section-subheading--font-weight: 600;
+
 	/* Subtitle */
 	--text-subtitle-1: 1.25rem;
 	--text-subtitle-1--line-height: 125%;


### PR DESCRIPTION
Ships the public people profiles work the marketing team has been reviewing on the develop preview. The `/people` route itself is already in production; this release brings it up to the reviewed Figma parity.

## What's in it

- **#197** — Tony and Emily's design feedback: hero, campaign issues, accomplishments, section order.
- **#201** — Figma hero glow (radial, not linear), tightened breadcrumb spacing, roomier Recent Experience rows.
- **#202** — per-persona section ordering driven from data and locked by tests, which is what kept regressing between the officeholder and candidate frames.
- **#190** — server-side election-api reads authenticated with Clerk M2M.
- **#203** — coverage for the gp-api revalidation seam (route integration tests plus a deployed-endpoint e2e).

## Required before this is fully functional in prod

`MARKETING_REVALIDATE_SECRET` is **not set on Vercel production**. Until it is, `POST /api/revalidate-person` returns 503, so a publish or unpublish from the profile editor won't bust the cached page — it will serve stale for up to its one-hour ISR window. The same value has to be present in the `GP_API_PROD` secret bundle in AWS Secrets Manager, since gp-api is the sender.

This does not block the release (the pages render correctly either way; only the freshness of owner edits is affected), but it should be wired before profiles are promoted to candidates.

## Not included

The `/candidate/*` → `/people/*` redirects remain gated off behind `ENABLE_CANDIDATE_PEOPLE_REDIRECT`, deliberately, to keep redirect risk out of this release.

Made with [Cursor](https://cursor.com)