### PR TITLE
fix(election-api): don't cache failed responses for an hour

### DIFF
--- a/src/lib/electionApiFetch.test.ts
+++ b/src/lib/electionApiFetch.test.ts
@@ -79,4 +79,30 @@ describe('fetchElectionApiJsonCached', () => {
 		expect(fetchCalls).toBe(1);
 		expect(result).toEqual({ status: 200, ok: true, json: OK_BODY });
 	});
+
+	test('returns 404 rather than throwing, so a missing record stays cacheable', async () => {
+		globalThis.fetch = (async () => {
+			fetchCalls += 1;
+			return new Response(null, { status: 404 });
+		}) as unknown as typeof fetch;
+
+		const result = await fetchElectionApiJsonCached(ELECTION_URL);
+
+		expect(result).toEqual({ status: 404, ok: false, json: null });
+	});
+
+	// The throw is what keeps unstable_cache from storing the failure: it caches what
+	// the wrapped function returns, so a returned 5xx would pin this URL to an error
+	// for the full hour and the caller's retries — which go back through this same
+	// cache entry — would never re-run the fetch.
+	test.each([500, 502, 503, 401, 400])('throws on %s so the failure is never cached', async (status) => {
+		globalThis.fetch = (async () => {
+			fetchCalls += 1;
+			return new Response(null, { status });
+		}) as unknown as typeof fetch;
+
+		const promise = fetchElectionApiJsonCached(ELECTION_URL);
+
+		await expect(promise).rejects.toMatchObject({ name: 'ElectionApiError', status });
+	});
 });

--- a/src/lib/electionApiFetch.ts
+++ b/src/lib/electionApiFetch.ts
@@ -9,6 +9,20 @@ export type ElectionApiJsonResult = {
 };
 
 /**
+ * A non-ok response that must not be cached. Carries the status so the caller can
+ * tell a retryable 5xx from a deterministic 4xx without re-parsing a message.
+ */
+export class ElectionApiError extends Error {
+	public readonly status: number;
+
+	public constructor(status: number, url: string) {
+		super(`election-api ${status} ${url}`);
+		this.name = 'ElectionApiError';
+		this.status = status;
+	}
+}
+
+/**
  * Authenticated election-api GET that keeps the rotating M2M Authorization header
  * OUT of the Next.js Data Cache key.
  *
@@ -30,7 +44,13 @@ export async function fetchElectionApiJsonCached(
 		const authHeaders = await electionApiAuthHeaders();
 		const res = await fetch(url, { headers: authHeaders, cache: 'no-store' });
 		if (res.status === 404) return { status: 404, ok: false, json: null };
-		if (!res.ok) return { status: res.status, ok: false, json: null };
+		// Anything else non-ok throws rather than returning: unstable_cache stores
+		// whatever the wrapped function *returns*, so a returned failure would be
+		// memoized under this URL for the full hour — and because the caller retries
+		// through this same cached entry, run() would never re-execute. One transient
+		// 5xx would blank the field site-wide until the window elapsed. 404 is the
+		// exception: it is a real, stable answer worth caching.
+		if (!res.ok) throw new ElectionApiError(res.status, url);
 		return { status: res.status, ok: true, json: await res.json() };
 	};
 

--- a/src/lib/electionsApi.ts
+++ b/src/lib/electionsApi.ts
@@ -24,7 +24,7 @@ import {
 	normalizeCandidateLookupName,
 	stripCountySuffix,
 } from '~/lib/electionsHelpers';
-import { fetchElectionApiJsonCached } from '~/lib/electionApiFetch';
+import { ElectionApiError, fetchElectionApiJsonCached } from '~/lib/electionApiFetch';
 
 const ELECTIONS_API_BASE_URL =
 	process.env['ELECTIONS_API_BASE_URL'] ?? 'https://election-api.goodparty.org';
@@ -105,13 +105,15 @@ async function fetchJson<T>(url: string, options?: RequestInit): Promise<T | nul
 			try {
 				const result = await fetchElectionApiJsonCached(url, tags);
 				if (result.status === 404) return null;
-				if (result.ok) return result.json as T;
-				if (result.status > 0 && result.status < 500) {
-					console.error(`[electionsApi] ${result.status} ${url}`);
+				return result.json as T;
+			} catch (err) {
+				// A 4xx is a deterministic answer — retrying just re-asks the same bad
+				// question three times and delays the null by 1.5s. Only 5xx and
+				// transport errors are worth another attempt.
+				if (err instanceof ElectionApiError && err.status < 500) {
+					console.error(`[electionsApi] ${err.status} ${url}`);
 					return null;
 				}
-				console.error(`[electionsApi] ${result.status || 'error'} ${url} (attempt ${attempt + 1})`);
-			} catch (err) {
 				console.error(`[electionsApi] attempt ${attempt + 1}`, err);
 			}
 			if (attempt < FETCH_JSON_MAX_RETRIES) {


### PR DESCRIPTION
Delegate caught this on the release PR, and it's a real bug rather than a style point.

`fetchElectionApiJsonCached` wraps its fetch in `unstable_cache`, which stores whatever the wrapped function *returns*. Returning `{ ok: false, status: 500 }` therefore memoized the failure under that URL for the full hour. The retry loop in `fetchJson` re-enters through the same cache entry, so it was reading the stored error rather than re-running the fetch — the retries could never have worked.

The practical effect: one transient 5xx from election-api would blank that data across every server instance until the cache window elapsed. Candidate names, office titles, nearby officials — all silently missing on a page that still returns 200.

Non-ok responses now throw, which the cache layer doesn't store, so the retry loop actually retries. Two deliberate exceptions:

- **404 still returns** rather than throwing. "No such record" is a real, stable answer, and caching it is the point.
- **4xx short-circuits.** Delegate's suggested fix threw on every non-ok status, which would have sent a deterministic 400 or 401 through three attempts and 1.5s of backoff to reach the same answer. The error carries its status so the caller can tell the two apart.

This is worth landing before the release goes out, since the M2M auth change in that release makes a transient 401 more plausible than it used to be.

Made with [Cursor](https://cursor.com)