### PR TITLE
test(revalidate-person): cover the unconfigured 503 branch

### DIFF
--- a/src/app/api/revalidate-person/route.unconfigured.test.ts
+++ b/src/app/api/revalidate-person/route.unconfigured.test.ts
@@ -1,0 +1,57 @@
+/**
+ * The 503 "not configured" branch, which cannot be covered from route.test.ts.
+ *
+ * `~/lib/env` reads process.env at module scope and the route binds the secret at
+ * import, so a single file can only ever exercise one side of the guard. This file
+ * gets its own module registry, so it can bind the same route against an absent
+ * secret.
+ *
+ * The mock spreads the real exports rather than returning a bare object: other
+ * modules pulled in through this import graph read other env values, and replacing
+ * the whole module with a single key would strand them on undefined.
+ *
+ * Worth guarding because the failure mode is silent. If the branch is ever dropped,
+ * a deployment missing MARKETING_REVALIDATE_SECRET stops announcing itself and
+ * instead compares against an undefined secret — which is a 500 at best, and at
+ * worst degrades into accepting whatever the caller sent.
+ */
+import { describe, expect, mock, test } from 'bun:test';
+
+const realEnv = await import('~/lib/env');
+mock.module('~/lib/env', () => ({ ...realEnv, personRevalidateSecret: undefined }));
+
+const { POST } = await import('./route');
+
+const PERSON_ID = '74eee01a-1111-4222-8333-444444444444';
+
+async function post(secret: string | null): Promise<Response> {
+	const headers = new Headers({ 'content-type': 'application/json' });
+	if (secret != null) headers.set('x-revalidate-secret', secret);
+	const req = new Request('https://marketing.test/api/revalidate-person', {
+		method: 'POST',
+		headers,
+		body: JSON.stringify({ personId: PERSON_ID }),
+	});
+	// The handler only touches the standard Request surface (headers + json()).
+	return POST(req as never);
+}
+
+describe('POST /api/revalidate-person — secret not configured', () => {
+	test('answers 503 rather than comparing against an absent secret', async () => {
+		const res = await post('any-secret');
+
+		expect(res.status).toBe(503);
+	});
+
+	// The guard has to precede the header check: an unconfigured deployment is a
+	// deployment problem, and reporting it as 401 would send whoever is debugging
+	// it hunting for a secret mismatch that doesn't exist.
+	test('reports the misconfiguration even when no secret is sent', async () => {
+		const res = await post(null);
+
+		expect(res.status).toBe(503);
+		expect(await res.json()).toMatchObject({
+			error: expect.stringContaining('MARKETING_REVALIDATE_SECRET'),
+		});
+	});
+});


### PR DESCRIPTION
Delegate flagged this on the release PR. The guard that reports a missing `MARKETING_REVALIDATE_SECRET` had no test behind it, and that's the branch most likely to actually fire — production doesn't currently have the secret set.

It can't be covered from `route.test.ts`: `~/lib/env` reads `process.env` at module scope and the route binds the secret at import, so a single file can only ever exercise one side of the guard. A second file with its own module registry covers the other. I verified the two files coexist rather than fighting over the mocked module, and the full logic suite is green at 640.

I checked the test actually has teeth rather than passing for free — deleting the guard fails exactly these two tests and nothing else. That mattered here, because the secret is unset in a local run anyway, so a careless version of this test would pass whether or not the guard existed.

One deviation from delegate's suggested patch: it replaced `~/lib/env` with a bare object containing only `personRevalidateSecret`. Other modules in this import graph read other env values, so that would strand them on undefined. Mine spreads the real exports and overrides the single key.

The second test pins the guard's *ordering* — it has to precede the header check, because answering 401 for an unconfigured deployment sends whoever is debugging it hunting for a secret mismatch that doesn't exist.

Made with [Cursor](https://cursor.com)