### PR TITLE
fix(people): stop doubling the id suffix in person profile URLs

### DIFF
--- a/src/lib/peopleProfile.test.ts
+++ b/src/lib/peopleProfile.test.ts
@@ -3,6 +3,7 @@ import type { PersonItem, PersonOfficeHolder, PublicPersonProfile } from '~/type
 import {
 	buildBreadcrumbTrail,
 	buildPersonSlug,
+	buildPersonSlugFromBase,
 	composeView,
 	extractPersonId,
 	resolveProfileState,
@@ -178,6 +179,36 @@ describe('buildPersonSlug', () => {
 
 	test('falls back to just the id suffix when the name has no slug chars', () => {
 		expect(buildPersonSlug('!!!', PID)).toBe(ID8);
+	});
+});
+
+describe('buildPersonSlugFromBase', () => {
+	const ID8 = '11111111';
+
+	test('appends the suffix to a name-derived base', () => {
+		expect(buildPersonSlugFromBase('jane-doe', PID)).toBe(`jane-doe-${ID8}`);
+	});
+
+	// The election-api mart mints `Person.slug` with the suffix already on it. This
+	// is the case that shipped doubled (`jane-doe-11111111-11111111`) and put a
+	// redirect hop in front of every clean person URL.
+	test('leaves a mart slug that already carries the suffix alone', () => {
+		expect(buildPersonSlugFromBase(`jane-doe-${ID8}`, PID)).toBe(`jane-doe-${ID8}`);
+	});
+
+	test('is idempotent under repeated application', () => {
+		const once = buildPersonSlugFromBase('jane-doe', PID);
+		expect(buildPersonSlugFromBase(once, PID)).toBe(once);
+	});
+
+	// A base that slugified away to nothing yields the bare suffix; feeding that
+	// back in must not produce `11111111-11111111`.
+	test('does not double a base that is only the suffix', () => {
+		expect(buildPersonSlugFromBase(ID8, PID)).toBe(ID8);
+	});
+
+	test('still appends when the base merely contains the suffix mid-string', () => {
+		expect(buildPersonSlugFromBase(`${ID8}-jane`, PID)).toBe(`${ID8}-jane-${ID8}`);
 	});
 });
 
@@ -403,11 +434,13 @@ describe('composeView issues, links, labels', () => {
 	test('canonicalSlug uses the spine base slug + id8 suffix, not the overlay display name', () => {
 		const view = composeView(
 			PID,
-			makePerson({ slug: 'jane-doe', fullName: 'Jane Doe' }),
+			makePerson({ slug: 'jane-doe-11111111', fullName: 'Jane Doe' }),
 			makeOverlay({ displayName: 'Councilmember Doe' }),
 		);
-		// Base comes from election-api Person.slug; the 8-hex id suffix is appended
-		// so the URL resolves to exactly one person.
+		// election-api mints Person.slug with the 8-hex id suffix already on it, so
+		// the canonical is that slug verbatim. Fixturing an unsuffixed base here is
+		// what let the doubled-suffix bug (`jane-doe-11111111-11111111`) reach prod:
+		// the assertion held either way.
 		expect(view.canonicalSlug).toBe('jane-doe-11111111');
 		expect(view.initials).toBe('CD');
 	});

--- a/src/lib/peopleProfile.ts
+++ b/src/lib/peopleProfile.ts
@@ -53,10 +53,22 @@ export function personIdSuffix(personId: string): string {
 	return personId.replace(/-/g, '').slice(0, 8).toLowerCase();
 }
 
-/** Builds the public `<base>-<id8>` slug from an already-slugified base. */
+/**
+ * Builds the public `<base>-<id8>` slug from an already-slugified base.
+ *
+ * Idempotent, because the two kinds of base this is called with disagree about
+ * whether the suffix is already there: a name-derived base (`slugifyName`) never
+ * carries it, while the election-api mart's `Person.slug` already ends in it.
+ * Appending unconditionally produced `jane-doe-11111111-11111111` for every
+ * person sourced from the spine — pages still resolved (the resolver reads the
+ * *trailing* 8 hex either way), but the canonical URL, the og:url, the sitemap
+ * entries and every inter-profile link carried the doubled suffix, and the clean
+ * URL cost a redirect hop to reach it.
+ */
 export function buildPersonSlugFromBase(base: string, personId: string): string {
 	const suffix = personIdSuffix(personId);
-	return base ? `${base}-${suffix}` : suffix;
+	if (!base || base === suffix) return suffix;
+	return base.endsWith(`-${suffix}`) ? base : `${base}-${suffix}`;
 }
 
 /** Builds the public `first-last-<id8>` slug for a person from a display name. */
@@ -706,10 +718,11 @@ export function composeView(
 
 	return {
 		personId,
-		// Public URL is /people/<base>-<id8>. The election-api mart mints the base
-		// (`first-last`, non-unique); we always append the 8-hex id suffix so the
-		// URL resolves to exactly one person. Fall back to a name-derived base only
-		// when the spine is absent (e.g. an overlay-only edge case).
+		// Public URL is /people/<base>-<id8>, where the 8-hex id suffix is what makes
+		// a non-unique `first-last` base resolve to exactly one person. The mart's
+		// `Person.slug` already ends in that suffix, so it passes through unchanged;
+		// the name-derived fallback (for the overlay-only edge case, where there is
+		// no spine row) gets the suffix appended.
 		canonicalSlug: buildPersonSlugFromBase(
 			person?.slug ?? slugifyName(nameFromPerson ?? displayName),
 			personId,


### PR DESCRIPTION
## What

`buildPersonSlugFromBase` appended the 8-hex id suffix unconditionally. The two kinds of base it receives disagree about whether that suffix is already there:

- a name-derived base (`slugifyName`) never carries it
- election-api's `Person.slug` is minted **with** it (`ali-dunford-abe7b5a6`)

So every person sourced from the civics spine canonicalized to `/people/<name>-<id8>-<id8>`.

## Why it matters

Confirmed live in prod on three separate people:

```
/people/ali-dunford-abe7b5a6      -> 307 -> /people/ali-dunford-abe7b5a6-abe7b5a6
/people/aaron-appelhans-8207ea94  -> 307 -> /people/aaron-appelhans-8207ea94-8207ea94
/people/aaron-walsh-18e52578      -> 307 -> /people/aaron-walsh-18e52578-18e52578
```

Nothing was down — the resolver reads the *trailing* 8 hex either way, so the doubled URL renders 200 and is self-consistent. But the clean URL cost a redirect hop, and `<link rel="canonical">`, `og:url`, the people sitemap entries and every inter-profile link all carried the doubled form.

## The fix

An idempotent guard: pass a base through unchanged when it already ends in `-<id8>`. This fixes all four call sites at once (canonical slug, sitemap entries, "Other candidates", "Nearby Officials").

Because it is idempotent in the other direction too, already-crawled doubled URLs now redirect *to* the clean one rather than being the destination, so this self-heals without a redirect rule.

## Why the tests didn't catch it

The existing `composeView` assertion fixtured `Person.slug` as `jane-doe` — unsuffixed, which is not what the mart mints. That assertion held identically before and after the bug. It now uses a realistic mart slug, and there are direct idempotency tests alongside.

Mutation-checked: reverting the one-line guard fails 4 tests, including the corrected fixture.

## Test plan

- [x] `bun run test:logic` — 645 pass
- [x] `bun run test:dom` — 5 pass
- [x] `bun run typecheck` clean
- [x] `bun run lint` — only pre-existing warnings in unrelated files
- [ ] After release: `curl -sL -o /dev/null -w '%{num_redirects}' https://goodparty.org/people/ali-dunford-abe7b5a6` returns `0`

Made with [Cursor](https://cursor.com)