### PR TITLE
fix: anchor election-api M2M token cache to TTL (stop expired-JWT replays)

### DIFF
--- a/src/lib/electionApiAuth.test.ts
+++ b/src/lib/electionApiAuth.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, mock, setSystemTime, spyOn, test } from 'bun:test';
 
 import {
 	__resetElectionApiAuthForTests,
@@ -7,7 +7,9 @@ import {
 	getElectionApiToken,
 } from './electionApiAuth';
 
-// Clerk's createToken returns `expiration` as a Unix timestamp in seconds.
+// mint() only reads `minted.expiration` to detect a failed mint (null => failure);
+// the cache window is anchored to the requested TTL, not to this field. Any
+// non-null value works here — its unit/magnitude is intentionally irrelevant.
 const expirationInSeconds = (secondsFromNow: number): number =>
 	Math.floor(Date.now() / 1000) + secondsFromNow;
 
@@ -154,6 +156,31 @@ describe('getElectionApiToken', () => {
 
 		await expect(getElectionApiToken()).resolves.toBe('cached-during-cooldown');
 		expect(createToken).toHaveBeenCalledTimes(0);
+	});
+
+	test('renews on the requested TTL even when Clerk returns a huge expiration (regression: ms double-scale)', async () => {
+		// Reproduces the prod bug: Clerk's `expiration` is milliseconds at runtime,
+		// and the old code did `expiration * 1000`, pushing the cache window ~56k
+		// years out so it never renewed and replayed one JWT long past its real
+		// `exp`. The fix anchors the window to the 600s TTL, so renewal must still
+		// happen after ~600s regardless of what `expiration` reports.
+		createToken.mockImplementation(async () => ({
+			token: 'ttl-anchored',
+			expiration: Date.now() * 1000, // ms-shaped; catastrophic if re-scaled
+		}));
+		const start = Date.now();
+		try {
+			setSystemTime(start);
+			await expect(getElectionApiToken()).resolves.toBe('ttl-anchored');
+			expect(createToken).toHaveBeenCalledTimes(1);
+
+			// Just past the 600s TTL: the token must be re-minted, not replayed.
+			setSystemTime(start + 601_000);
+			await expect(getElectionApiToken()).resolves.toBe('ttl-anchored');
+			expect(createToken).toHaveBeenCalledTimes(2);
+		} finally {
+			setSystemTime();
+		}
 	});
 });
 

--- a/src/lib/electionApiAuth.ts
+++ b/src/lib/electionApiAuth.ts
@@ -114,10 +114,14 @@ async function mint(): Promise<string | null> {
 			return usableCachedToken();
 		}
 		cachedToken = minted.token;
-		// Clerk returns `expiration` as a Unix timestamp in seconds; the cache
-		// checks compare against Date.now() in ms, so convert here or the token
-		// is treated as already expired and re-minted on every request.
-		tokenExpiration = minted.expiration * 1000;
+		// Anchor the cache window to the TTL we requested, NOT to `minted.expiration`.
+		// The JWT's real `exp` claim is (mint time + secondsUntilExpiration). Clerk's
+		// returned `expiration` field is typed as seconds but is actually milliseconds
+		// at runtime, so `* 1000` double-scaled it ~56k years into the future — the
+		// cache then never renewed and replayed one token long past its real `exp`,
+		// which election-api rejected as expired. Deriving from TTL is unit-agnostic
+		// and keeps the cache strictly inside the JWT's actual lifetime.
+		tokenExpiration = Date.now() + TOKEN_TTL_SECONDS * 1000;
 		mintCooldownUntil = 0;
 		return minted.token;
 	} catch (err) {


### PR DESCRIPTION
## Summary
- Prod `election-api` (observe-only) is logging ~200/min **"JWT is expired"** warnings, all from gp-marketing server-side reads (`/v1/candidacies`, `/v1/races`, `/v1/places`, `/v1/positions`).
- Root cause: Clerk's `createToken` returns `expiration` **in milliseconds at runtime** (its type says seconds). Our code did `tokenExpiration = minted.expiration * 1000`, pushing the cache expiry **~56,000 years** into the future. The token cache therefore **never renewed** — each server isolate replayed its very first JWT indefinitely, long past the JWT's real 600s `exp`, so election-api rejected those reads as expired.
- Fix: anchor the cache window to the **requested TTL** (`Date.now() + TOKEN_TTL_SECONDS * 1000`), which is exactly what the JWT's `exp` claim is built from and is unit-agnostic.

### Evidence
Minting a real dev JWT (600s TTL):
```
now (unix s):      1786378649
minted.expiration: 1786379249597   <-- milliseconds (= JWT exp x 1000)
JWT exp:           1786379249      <-- seconds, = now + 600
```
And a prod sample: a token with `exp` 14:50:41 was still being sent at 16:03:34 (1h23m after expiry).

> Note: this **reverses** the earlier `* 1000` change from #190 (delegate-requested "seconds→ms"). That assumed the field was seconds; the runtime value is ms, so the multiply was the wrong direction. TTL-anchoring sidesteps the unit question entirely.

## Test plan
- [x] `bun test src/lib/electionApiAuth.test.ts` — 12 pass, incl. new regression test that fails if a large/ms-shaped `expiration` re-extends the cache past the TTL
- [x] `bun run typecheck`
- [x] `next lint` clean
- [ ] After merge + prod promote: confirm prod observe-only "JWT is expired" warnings drop to ~0

Made with [Cursor](https://cursor.com)