### PR TITLE
fix(sitemap): read the unlisted feed, not the removed one

### DIFF
--- a/src/lib/sitemap-entries.test.ts
+++ b/src/lib/sitemap-entries.test.ts
@@ -68,8 +68,8 @@ describe('fetchPeopleSitemapEntries', () => {
 		candidacies?: Record<string, string[]>;
 		officeholders?: Record<string, string[]>;
 		published?: { personId: string; updatedAt?: string }[];
-		removed?: { personId: string }[];
-		removedStatus?: number;
+		unlisted?: { personId: string }[];
+		unlistedStatus?: number;
 		failPersonsForState?: string;
 	}): string[] {
 		const urls: string[] = [];
@@ -86,9 +86,9 @@ describe('fetchPeopleSitemapEntries', () => {
 			if (url.pathname.endsWith('/public-person-profiles/published')) {
 				return json(opts.published ?? []);
 			}
-			if (url.pathname.endsWith('/public-person-profiles/removed')) {
-				if (opts.removedStatus) return new Response('nope', { status: opts.removedStatus });
-				return json(opts.removed ?? []);
+			if (url.pathname.endsWith('/public-person-profiles/unlisted')) {
+				if (opts.unlistedStatus) return new Response('nope', { status: opts.unlistedStatus });
+				return json(opts.unlisted ?? []);
 			}
 			if (url.pathname.endsWith('/v1/persons')) {
 				if (
@@ -202,15 +202,16 @@ describe('fetchPeopleSitemapEntries', () => {
 		expect(decodeURIComponent(idCalls[0]!)).toContain(`${bobId},${carolId}`);
 	});
 
-	// A removed person's page renders noindex, so advertising it would contradict
-	// the page and point crawlers at someone who asked to be left alone.
-	test('omits people who requested removal', async () => {
+	// gp-api folds two cases into this feed: a privacy removal (page renders
+	// noindex) and an owner-deleted profile (gp-api 410s, so the page 404s). The
+	// band cares only that neither URL should reach a crawler, so it is one set.
+	test('omits people gp-api reports as unlistable', async () => {
 		mockUpstream({
 			persons: [
 				{ id: aliceId, slug: 'alice-smith', state: 'WY' },
 				{ id: bobId, slug: 'bob-jones', state: 'WY' },
 			],
-			removed: [{ personId: bobId }],
+			unlisted: [{ personId: bobId }],
 		});
 
 		const [aShard, bShard] = await Promise.all([
@@ -222,10 +223,10 @@ describe('fetchPeopleSitemapEntries', () => {
 		expect(bShard).toEqual([]);
 	});
 
-	test('matches removal ids case-insensitively, since the id is a uuid from another service', async () => {
+	test('matches unlisted ids case-insensitively, since the id is a uuid from another service', async () => {
 		mockUpstream({
 			persons: [{ id: aliceId, slug: 'alice-smith', state: 'WY' }],
-			removed: [{ personId: aliceId.toUpperCase() }],
+			unlisted: [{ personId: aliceId.toUpperCase() }],
 		});
 
 		expect(await fetchPeopleSitemapEntries(base, 'a')).toEqual([]);
@@ -298,10 +299,10 @@ describe('fetchPeopleSitemapEntries', () => {
 
 	// A rolling deploy where gp-api has not yet shipped the endpoint 404s here.
 	// Failing open would advertise every person who asked to be delisted.
-	test('an unavailable removal list rejects rather than listing removed people', async () => {
+	test('an unavailable exclusion list rejects rather than listing everyone', async () => {
 		mockUpstream({
 			persons: [{ id: aliceId, slug: 'alice-smith', state: 'WY' }],
-			removedStatus: 404,
+			unlistedStatus: 404,
 		});
 
 		await expect(fetchPeopleSitemapEntries(base, 'a')).rejects.toThrow();
@@ -312,7 +313,7 @@ describe('fetchPeopleSitemapEntries', () => {
 	test('recovers on the next call after a failure', async () => {
 		mockUpstream({
 			persons: [{ id: aliceId, slug: 'alice-smith', state: 'WY' }],
-			removedStatus: 503,
+			unlistedStatus: 503,
 		});
 		await expect(fetchPeopleSitemapEntries(base, 'a')).rejects.toThrow();
 

--- a/src/lib/sitemap-entries.ts
+++ b/src/lib/sitemap-entries.ts
@@ -654,8 +654,8 @@ type PeopleSitemapPerson = { id?: string; slug?: string | null };
 type PeopleSitemapData = {
 	/** personId → updatedAt, for the published subset only; also marks "claimed". */
 	updatedByPersonId: Map<string, string | undefined>;
-	/** personIds under a privacy takedown, which must never be advertised. */
-	removedPersonIds: Set<string>;
+	/** personIds whose page must never be advertised — see the loader for why. */
+	unlistedPersonIds: Set<string>;
 	persons: PeopleSitemapPerson[];
 };
 
@@ -793,12 +793,12 @@ export function clearPeopleSitemapCache(): void {
 async function getCachedPeopleSitemapData(): Promise<PeopleSitemapData> {
 	if (!cachedPeopleSitemapData) {
 		const load = (async (): Promise<PeopleSitemapData> => {
-			const [published, removed, persons] = await Promise.all([
+			const [published, unlisted, persons] = await Promise.all([
 				fetchGpApiJsonOrThrow<{ personId?: string; updatedAt?: string }>(
 					'v1/public-person-profiles/published',
 					[PEOPLE_SITEMAP_CACHE_TAG],
 				),
-				fetchGpApiJsonOrThrow<{ personId?: string }>('v1/public-person-profiles/removed', [
+				fetchGpApiJsonOrThrow<{ personId?: string }>('v1/public-person-profiles/unlisted', [
 					PEOPLE_SITEMAP_CACHE_TAG,
 				]),
 				fetchAllPersons(),
@@ -809,12 +809,17 @@ async function getCachedPeopleSitemapData(): Promise<PeopleSitemapData> {
 				if (row.personId) updatedByPersonId.set(row.personId.toLowerCase(), row.updatedAt);
 			}
 
-			const removedPersonIds = new Set<string>();
-			for (const row of removed) {
-				if (row.personId) removedPersonIds.add(row.personId.toLowerCase());
+			// Two different reasons, one consequence: a person with a privacy removal
+			// on record renders noindex, and a person whose owner deleted their
+			// profile gets a 410 from gp-api and so has no page at all. gp-api
+			// collapses both into this feed because the sitemap only cares about the
+			// consequence.
+			const unlistedPersonIds = new Set<string>();
+			for (const row of unlisted) {
+				if (row.personId) unlistedPersonIds.add(row.personId.toLowerCase());
 			}
 
-			return { updatedByPersonId, removedPersonIds, persons };
+			return { updatedByPersonId, unlistedPersonIds, persons };
 		})();
 		cachedPeopleSitemapData = load;
 		// Settle via two-arg `then`, not `finally`: the upstream reads throw now, and
@@ -841,12 +846,14 @@ async function getCachedPeopleSitemapData(): Promise<PeopleSitemapData> {
  * election-api owns the authoritative, unique `Person.slug` that is the
  * canonical URL, so a person with no spine row has no page and is skipped.
  * gp-api contributes the two per-person facts it alone knows: which people have
- * published (worth a higher priority and a real lastmod) and which have
- * requested removal.
+ * published (worth a higher priority and a real lastmod) and which must not be
+ * listed at all.
  *
- * Removed people are dropped rather than downranked. Their page renders `noindex`
- * by design, so listing it would both contradict the page's own directive and
- * point crawlers at someone who asked to be left alone.
+ * Unlisted people are dropped rather than downranked, because in both cases the
+ * URL is one we should not be handing to a crawler: a privacy removal renders
+ * `noindex`, so advertising it contradicts the page's own directive and points
+ * crawlers at someone who asked to be left alone, and an owner-deleted profile
+ * has no page to reach at all — gp-api answers 410 and the route 404s.
  *
  * Upstream fetches are shared across shards via getCachedPeopleSitemapData.
  */
@@ -854,13 +861,13 @@ export async function fetchPeopleSitemapEntries(
 	baseUrl: string,
 	shard?: string,
 ): Promise<MetadataRoute.Sitemap> {
-	const { updatedByPersonId, removedPersonIds, persons } = await getCachedPeopleSitemapData();
+	const { updatedByPersonId, unlistedPersonIds, persons } = await getCachedPeopleSitemapData();
 
 	const entries: MetadataRoute.Sitemap = [];
 	for (const p of persons) {
 		if (!p.id || !p.slug) continue;
 		const personId = p.id.toLowerCase();
-		if (removedPersonIds.has(personId)) continue;
+		if (unlistedPersonIds.has(personId)) continue;
 		// When a shard is requested, only emit people whose slug falls in it. The
 		// canonical URL appends the 8-hex id suffix but shares the base's first
 		// char, so sharding on the base is equivalent.


### PR DESCRIPTION
## Why

The people band 500s on the develop preview. Every shard in it fails:

```
Error: [sitemap] gp-api 404 https://gp-api-dev.goodparty.org/v1/public-person-profiles/removed
```

#210 shipped against `/removed`. That path was renamed to `/unlisted` in [omni #1206](https://github.com/thegoodparty/omni/pull/1206) — merged and now live on dev — after we found that owner-deleted profiles need excluding too, not just privacy removals. gp-api answers 410 for a deleted profile, so its `/people` URL 404s; advertising it hands a crawler a dead page.

## What

Point the loader at `v1/public-person-profiles/unlisted` and rename `removedPersonIds` to `unlistedPersonIds` to match what the feed now means: the deduped union of privacy removals and owner-deleted profiles.

The band's handling of the set is unchanged — it subtracts ids either way, because both cases share the one consequence the sitemap cares about. Everything else here is comments recording why the two cases are one set, and the test double's option names.

## Why this is a follow-up rather than part of #210

The band fails closed on this read, so it could not ship before the endpoint existed without listing everyone who asked to be delisted. The 500 is that guard doing its job during the window between the two deploys.

## Verification

- `bun test src/lib/sitemap-entries.test.ts` — 70 pass
- `bun run typecheck`, `bun run lint` — clean
- `GET https://gp-api-dev.goodparty.org/v1/public-person-profiles/unlisted` → 200, `[{"personId":"…"},{"personId":"…"}]`

Shard 52 on this branch's preview should go 500 → 200. Prod needs the gp-api promote before the master release, for the same reason.

Made with [Cursor](https://cursor.com)