### PR TITLE
Release: develop → master (election-api M2M token expiry fix + person-page sitemap)

### DIFF
--- a/scripts/generate-sitemaps.ts
+++ b/scripts/generate-sitemaps.ts
@@ -2,7 +2,7 @@
 /**
  * Offline sitemap generation for validation and auditing. Writes XML to .reports/sitemaps/static/.
  * NOT used for production serving -- the Next.js dynamic routes handle that.
- * Usage: npx tsx scripts/generate-sitemaps.ts [--main-only] [--candidates-only] [--validate] [--redirect-handling remove|replace|keep] [--max-redirects N] [--no-follow-redirects]
+ * Usage: npx tsx scripts/generate-sitemaps.ts [--main-only] [--people-only] [--validate] [--redirect-handling remove|replace|keep] [--max-redirects N] [--no-follow-redirects]
  */
 
 import { mkdir, writeFile } from 'node:fs/promises';
@@ -13,7 +13,8 @@ import { formatLastmod, splitUrlsIntoChunks, writeSitemapFile } from './lib/site
 import {
 	fetchMainSitemapEntries,
 	fetchStateElectionSitemapEntries,
-	fetchCandidateSitemapEntries,
+	fetchPeopleSitemapEntries,
+	PEOPLE_SITEMAP_SHARDS,
 	US_STATE_CODES,
 } from '../src/lib/sitemap-entries';
 
@@ -23,7 +24,7 @@ const SITEMAPS_DIR = join(OUTPUT_DIR, 'sitemaps');
 
 interface CliArgs {
 	mainOnly: boolean;
-	candidatesOnly: boolean;
+	peopleOnly: boolean;
 	validate: boolean;
 	redirectHandling: 'remove' | 'replace' | 'keep';
 	maxRedirects: number;
@@ -34,7 +35,7 @@ function parseArgs(): CliArgs {
 	const args = process.argv.slice(2);
 	const result: CliArgs = {
 		mainOnly: false,
-		candidatesOnly: false,
+		peopleOnly: false,
 		validate: false,
 		redirectHandling: 'remove',
 		maxRedirects: 5,
@@ -44,7 +45,7 @@ function parseArgs(): CliArgs {
 	for (let i = 0; i < args.length; i++) {
 		const arg = args[i];
 		if (arg === '--main-only') result.mainOnly = true;
-		else if (arg === '--candidates-only') result.candidatesOnly = true;
+		else if (arg === '--people-only') result.peopleOnly = true;
 		else if (arg === '--validate') result.validate = true;
 		else if (arg === '--redirect-handling' && args[i + 1]) {
 			const v = args[++i] as string;
@@ -54,8 +55,8 @@ function parseArgs(): CliArgs {
 		} else if (arg === '--no-follow-redirects') result.noFollowRedirects = true;
 	}
 
-	if (result.mainOnly && result.candidatesOnly) {
-		console.error('--main-only and --candidates-only are mutually exclusive');
+	if (result.mainOnly && result.peopleOnly) {
+		console.error('--main-only and --people-only are mutually exclusive');
 		process.exit(1);
 	}
 
@@ -89,9 +90,9 @@ async function fetchStateElectionEntries(stateCode: string): Promise<SitemapEntr
 	return entries.map(toSitemapEntry);
 }
 
-async function fetchCandidateEntries(stateCode: string): Promise<SitemapEntry[]> {
+async function fetchPeopleEntries(shard: string): Promise<SitemapEntry[]> {
 	const base = getBaseUrl();
-	const entries = await fetchCandidateSitemapEntries(stateCode, base);
+	const entries = await fetchPeopleSitemapEntries(base, shard);
 	return entries.map(toSitemapEntry);
 }
 
@@ -110,7 +111,7 @@ async function main(): Promise<void> {
 
 	console.log(`Generating sitemaps (base: ${base})...`);
 	if (args.mainOnly) console.log('Mode: main-only');
-	if (args.candidatesOnly) console.log('Mode: candidates-only');
+	if (args.peopleOnly) console.log('Mode: people-only');
 
 	await mkdir(SITEMAPS_DIR, { recursive: true });
 
@@ -119,7 +120,7 @@ async function main(): Promise<void> {
 	const stats: { category: string; urls: number; files: number }[] = [];
 
 	// Main content sitemap
-	if (!args.candidatesOnly) {
+	if (!args.peopleOnly) {
 		const mainEntries = await fetchMainContentEntries();
 		const chunks = splitUrlsIntoChunks(mainEntries);
 		const lastmod = formatLastmod();
@@ -143,7 +144,7 @@ async function main(): Promise<void> {
 	// State sitemaps
 	let stateFileCount = 0;
 	let stateUrlCount = 0;
-	if (!args.mainOnly && !args.candidatesOnly) {
+	if (!args.mainOnly && !args.peopleOnly) {
 		for (const state of US_STATE_CODES) {
 			const entries = await fetchStateElectionEntries(state);
 			if (entries.length === 0) continue;
@@ -165,29 +166,28 @@ async function main(): Promise<void> {
 		stats.push({ category: 'state', urls: stateUrlCount, files: stateFileCount });
 	}
 
-	// Candidate sitemaps
-	let candFileCount = 0;
-	let candUrlCount = 0;
+	// People sitemaps, sharded alphabetically to mirror the served band.
+	let peopleFileCount = 0;
+	let peopleUrlCount = 0;
 	if (!args.mainOnly) {
-		for (const state of US_STATE_CODES) {
-			const entries = await fetchCandidateEntries(state);
+		for (const shard of PEOPLE_SITEMAP_SHARDS) {
+			const entries = await fetchPeopleEntries(shard);
 			if (entries.length === 0) continue;
 
-			candUrlCount += entries.length;
+			peopleUrlCount += entries.length;
 			const chunks = splitUrlsIntoChunks(entries);
 			const lastmod = formatLastmod();
-			const stateLower = state.toLowerCase();
 
 			for (let i = 0; i < chunks.length; i++) {
 				const filename = chunks.length === 1 ? 'index.xml' : `index-${i + 1}.xml`;
-				const path = `sitemaps/candidates/${stateLower}/sitemap/${filename}`;
+				const path = `sitemaps/people/${shard}/sitemap/${filename}`;
 				await writeSitemapFile(OUTPUT_DIR, path, convertToXML(chunks[i]!));
 				indexEntries.push({ loc: `${base}/${path}`, lastmod });
 				allGeneratedUrls.push(...chunks[i]!.map((e) => e.loc));
-				candFileCount++;
+				peopleFileCount++;
 			}
 		}
-		stats.push({ category: 'candidates', urls: candUrlCount, files: candFileCount });
+		stats.push({ category: 'people', urls: peopleUrlCount, files: peopleFileCount });
 	}
 
 	// Root index

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -3,13 +3,28 @@ import { getBaseUrl } from '~/lib/url';
 import {
 	fetchMainSitemapEntries,
 	fetchStateElectionSitemapEntries,
-	fetchCandidateSitemapEntries,
 	fetchPeopleSitemapEntries,
 	getSitemapIds,
 	PEOPLE_SITEMAP_BAND_START,
 	PEOPLE_SITEMAP_SHARDS,
 	US_STATE_CODES,
 } from '~/lib/sitemap-entries';
+
+/**
+ * Rendered per request instead of prerendered at build.
+ *
+ * The people band is a live enumeration of ~216k pages across ~150 election-api
+ * calls plus two gp-api reads, and those reads now fail closed so a wrong
+ * sitemap can't be published. Prerendering makes that failure a *build* failure:
+ * one blip in either upstream, or a gp-api deploy that hasn't landed yet, and
+ * the entire marketing site stops shipping over a file only crawlers read.
+ *
+ * Dynamic keeps the strictness where it belongs — a bad upstream fails the
+ * sitemap request, not the deploy — and costs nothing, because the underlying
+ * fetches are still served from the tagged 1h data cache and this route is hit
+ * by crawlers rather than users.
+ */
+export const dynamic = 'force-dynamic';
 
 export function generateSitemaps() {
 	return getSitemapIds();
@@ -25,11 +40,6 @@ export default async function sitemap({ id }: { id: number }): Promise<MetadataR
 	if (n >= 1 && n <= US_STATE_CODES.length) {
 		const code = US_STATE_CODES[n - 1];
 		if (code) return fetchStateElectionSitemapEntries(code, base);
-	}
-	const candidateIdx = n - US_STATE_CODES.length - 1;
-	if (candidateIdx >= 0 && candidateIdx < US_STATE_CODES.length) {
-		const code = US_STATE_CODES[candidateIdx];
-		if (code) return fetchCandidateSitemapEntries(code, base);
 	}
 	const peopleIdx = n - PEOPLE_SITEMAP_BAND_START;
 	if (peopleIdx >= 0 && peopleIdx < PEOPLE_SITEMAP_SHARDS.length) {

--- a/src/lib/electionApiAuth.test.ts
+++ b/src/lib/electionApiAuth.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, mock, setSystemTime, spyOn, test } from 'bun:test';
 
 import {
 	__resetElectionApiAuthForTests,
@@ -7,7 +7,9 @@ import {
 	getElectionApiToken,
 } from './electionApiAuth';
 
-// Clerk's createToken returns `expiration` as a Unix timestamp in seconds.
+// mint() only reads `minted.expiration` to detect a failed mint (null => failure);
+// the cache window is anchored to the requested TTL, not to this field. Any
+// non-null value works here — its unit/magnitude is intentionally irrelevant.
 const expirationInSeconds = (secondsFromNow: number): number =>
 	Math.floor(Date.now() / 1000) + secondsFromNow;
 
@@ -154,6 +156,31 @@ describe('getElectionApiToken', () => {
 
 		await expect(getElectionApiToken()).resolves.toBe('cached-during-cooldown');
 		expect(createToken).toHaveBeenCalledTimes(0);
+	});
+
+	test('renews on the requested TTL even when Clerk returns a huge expiration (regression: ms double-scale)', async () => {
+		// Reproduces the prod bug: Clerk's `expiration` is milliseconds at runtime,
+		// and the old code did `expiration * 1000`, pushing the cache window ~56k
+		// years out so it never renewed and replayed one JWT long past its real
+		// `exp`. The fix anchors the window to the 600s TTL, so renewal must still
+		// happen after ~600s regardless of what `expiration` reports.
+		createToken.mockImplementation(async () => ({
+			token: 'ttl-anchored',
+			expiration: Date.now() * 1000, // ms-shaped; catastrophic if re-scaled
+		}));
+		const start = Date.now();
+		try {
+			setSystemTime(start);
+			await expect(getElectionApiToken()).resolves.toBe('ttl-anchored');
+			expect(createToken).toHaveBeenCalledTimes(1);
+
+			// Just past the 600s TTL: the token must be re-minted, not replayed.
+			setSystemTime(start + 601_000);
+			await expect(getElectionApiToken()).resolves.toBe('ttl-anchored');
+			expect(createToken).toHaveBeenCalledTimes(2);
+		} finally {
+			setSystemTime();
+		}
 	});
 });
 

--- a/src/lib/electionApiAuth.ts
+++ b/src/lib/electionApiAuth.ts
@@ -114,10 +114,14 @@ async function mint(): Promise<string | null> {
 			return usableCachedToken();
 		}
 		cachedToken = minted.token;
-		// Clerk returns `expiration` as a Unix timestamp in seconds; the cache
-		// checks compare against Date.now() in ms, so convert here or the token
-		// is treated as already expired and re-minted on every request.
-		tokenExpiration = minted.expiration * 1000;
+		// Anchor the cache window to the TTL we requested, NOT to `minted.expiration`.
+		// The JWT's real `exp` claim is (mint time + secondsUntilExpiration). Clerk's
+		// returned `expiration` field is typed as seconds but is actually milliseconds
+		// at runtime, so `* 1000` double-scaled it ~56k years into the future — the
+		// cache then never renewed and replayed one token long past its real `exp`,
+		// which election-api rejected as expired. Deriving from TTL is unit-agnostic
+		// and keeps the cache strictly inside the JWT's actual lifetime.
+		tokenExpiration = Date.now() + TOKEN_TTL_SECONDS * 1000;
 		mintCooldownUntil = 0;
 		return minted.token;
 	} catch (err) {

--- a/src/lib/sitemap-entries.test.ts
+++ b/src/lib/sitemap-entries.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, describe, expect, test } from 'bun:test';
+import { afterAll, afterEach, describe, expect, test } from 'bun:test';
 import {
 	buildCountyLookups,
 	buildRaceEntries,
@@ -30,126 +30,305 @@ describe('people sitemap shards', () => {
 		expect(peopleShardForSlug('')).toBe('other');
 	});
 
-	test('there are 27 shards (a–z + other) starting after the candidate band', () => {
+	// The candidate band used to sit between the state elections and the people
+	// band. Retiring it moved the people band down by one state-band's width; if
+	// this drifts from src/app/sitemap.ts's arithmetic the shards silently serve
+	// each other's content.
+	test('there are 27 shards (a–z + other) starting straight after the state band', () => {
 		expect(PEOPLE_SITEMAP_SHARDS).toHaveLength(27);
 		expect(PEOPLE_SITEMAP_SHARDS[26]).toBe('other');
-		expect(PEOPLE_SITEMAP_BAND_START).toBe(1 + 2 * US_STATE_CODES.length);
+		expect(PEOPLE_SITEMAP_BAND_START).toBe(1 + US_STATE_CODES.length);
 	});
 
-	test('getSitemapIds includes main + 2 state bands + the people band, contiguously', () => {
+	test('getSitemapIds includes main + the state band + the people band, contiguously', () => {
 		const ids = getSitemapIds().map((i) => i.id);
-		const expectedLength = 1 + 2 * US_STATE_CODES.length + PEOPLE_SITEMAP_SHARDS.length;
+		const expectedLength = 1 + US_STATE_CODES.length + PEOPLE_SITEMAP_SHARDS.length;
 		expect(ids).toHaveLength(expectedLength);
-		// The set is a contiguous 0..last with no gaps or dupes (ids are emitted
-		// interleaved by band, so compare the sorted set).
+		// The set is a contiguous 0..last with no gaps or dupes.
 		expect([...ids].sort((a, b) => a - b)).toEqual([...Array(expectedLength).keys()]);
 	});
 });
 
-describe('fetchPeopleSitemapEntries cache', () => {
+describe('fetchPeopleSitemapEntries', () => {
 	const originalFetch = globalThis.fetch;
+	const base = 'https://goodparty.org';
 	const aliceId = 'aaaaaaaa-1111-2222-3333-444444444444';
 	const bobId = 'bbbbbbbb-1111-2222-3333-444444444444';
-	const base = 'https://goodparty.org';
+	const carolId = 'cccccccc-1111-2222-3333-444444444444';
+
+	type MockPerson = { id: string; slug: string; state: string | null };
+
+	/**
+	 * Stands in for the four upstream feeds the band reads. `state: null` models
+	 * the ~8% of the real table that no `?state=` sweep can reach, which is the
+	 * whole reason the candidacy/officeholder union exists.
+	 */
+	function mockUpstream(opts: {
+		persons: MockPerson[];
+		candidacies?: Record<string, string[]>;
+		officeholders?: Record<string, string[]>;
+		published?: { personId: string; updatedAt?: string }[];
+		removed?: { personId: string }[];
+		removedStatus?: number;
+		failPersonsForState?: string;
+	}): string[] {
+		const urls: string[] = [];
+		globalThis.fetch = (async (input: RequestInfo | URL) => {
+			const raw = String(input);
+			urls.push(raw);
+			const url = new URL(raw);
+			const json = (body: unknown) =>
+				new Response(JSON.stringify(body), {
+					status: 200,
+					headers: { 'content-type': 'application/json' },
+				});
+
+			if (url.pathname.endsWith('/public-person-profiles/published')) {
+				return json(opts.published ?? []);
+			}
+			if (url.pathname.endsWith('/public-person-profiles/removed')) {
+				if (opts.removedStatus) return new Response('nope', { status: opts.removedStatus });
+				return json(opts.removed ?? []);
+			}
+			if (url.pathname.endsWith('/v1/persons')) {
+				if (
+					opts.failPersonsForState &&
+					url.searchParams.get('state') === opts.failPersonsForState
+				) {
+					return new Response('boom', { status: 503 });
+				}
+				const ids = url.searchParams.get('ids');
+				const matches = ids
+					? ((): MockPerson[] => {
+							const want = new Set(ids.split(','));
+							return opts.persons.filter((p) => want.has(p.id));
+						})()
+					: opts.persons.filter((p) => p.state === url.searchParams.get('state'));
+				return json(matches.map(({ id, slug }) => ({ id, slug })));
+			}
+			if (url.pathname.endsWith('/v1/candidacies')) {
+				const state = url.searchParams.get('state') ?? '';
+				return json((opts.candidacies?.[state] ?? []).map((personId) => ({ personId })));
+			}
+			if (url.pathname.endsWith('/v1/officeholders')) {
+				const state = url.searchParams.get('state') ?? '';
+				return json((opts.officeholders?.[state] ?? []).map((personId) => ({ personId })));
+			}
+			return json([]);
+		}) as typeof fetch;
+		return urls;
+	}
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+		clearPeopleSitemapCache();
+	});
 
 	afterAll(() => {
 		globalThis.fetch = originalFetch;
 		clearPeopleSitemapCache();
 	});
 
-	test('empty upstream is not poisoned; concurrent shards then share one warm fetch', async () => {
-		clearPeopleSitemapCache();
-		const urls: string[] = [];
-		let serveEmpty = true;
-		globalThis.fetch = (async (input: RequestInfo | URL) => {
-			const url = String(input);
-			urls.push(url);
-			if (url.includes('public-person-profiles/published')) {
-				const body = serveEmpty
-					? []
-					: [
-							{ personId: aliceId, updatedAt: '2026-01-15T00:00:00.000Z' },
-							{ personId: bobId, updatedAt: '2026-02-01T00:00:00.000Z' },
-						];
-				return new Response(JSON.stringify(body), {
-					status: 200,
-					headers: { 'content-type': 'application/json' },
-				});
-			}
-			if (url.includes('/v1/persons')) {
-				return new Response(
-					JSON.stringify([
-						{ id: aliceId, slug: 'alice-smith' },
-						{ id: bobId, slug: 'bob-jones' },
-					]),
-					{ status: 200, headers: { 'content-type': 'application/json' } },
-				);
-			}
-			return new Response(JSON.stringify([]), { status: 200 });
-		}) as typeof fetch;
+	// The band's whole purpose after the /candidate retirement: an unclaimed
+	// programmatic page is the destination now, so it has to be listed even
+	// though gp-api knows nothing about it.
+	test('lists people who have never been claimed', async () => {
+		mockUpstream({ persons: [{ id: aliceId, slug: 'alice-smith', state: 'WY' }] });
 
-		const empty = await fetchPeopleSitemapEntries(base, 'a');
-		expect(empty).toEqual([]);
-		expect(urls.filter((u) => u.includes('public-person-profiles/published'))).toHaveLength(1);
-		expect(urls.filter((u) => u.includes('/v1/persons'))).toHaveLength(0);
+		const entries = await fetchPeopleSitemapEntries(base, 'a');
 
-		serveEmpty = false;
-		urls.length = 0;
+		expect(entries.map((e) => e.url)).toEqual([`${base}/people/alice-smith-aaaaaaaa`]);
+	});
+
+	test('recovers people no state sweep can see, via the candidacy and officeholder feeds', async () => {
+		mockUpstream({
+			persons: [
+				{ id: aliceId, slug: 'alice-smith', state: 'WY' },
+				{ id: bobId, slug: 'bob-jones', state: null },
+				{ id: carolId, slug: 'carol-diaz', state: null },
+			],
+			candidacies: { WY: [bobId] },
+			officeholders: { MT: [carolId] },
+		});
+
+		const urls = await Promise.all([
+			fetchPeopleSitemapEntries(base, 'a'),
+			fetchPeopleSitemapEntries(base, 'b'),
+			fetchPeopleSitemapEntries(base, 'c'),
+		]);
+
+		expect(urls.flat().map((e) => e.url)).toEqual([
+			`${base}/people/alice-smith-aaaaaaaa`,
+			`${base}/people/bob-jones-bbbbbbbb`,
+			`${base}/people/carol-diaz-cccccccc`,
+		]);
+	});
+
+	// election-api advertises a 500-id cap on `?ids=`, but the gateway 414s on the
+	// ~19.5KB query string that many uuids produce, so the real ceiling is the
+	// request line, not the documented count. Batching to the advertised cap
+	// silently dropped every recovered person until this was measured against the
+	// live API.
+	test('keeps each ids lookup under the request-line limit', async () => {
+		const many = Array.from(
+			{ length: 400 },
+			(_, i) => `${i.toString(16).padStart(8, '0')}-1111-2222-3333-444444444444`,
+		);
+		const urls = mockUpstream({
+			persons: many.map((id) => ({ id, slug: `zed-${id.slice(0, 8)}`, state: null })),
+			candidacies: { WY: many },
+		});
+
+		const entries = await fetchPeopleSitemapEntries(base, 'z');
+
+		expect(entries).toHaveLength(many.length);
+		const idCalls = urls.filter((u) => u.includes('ids='));
+		expect(idCalls.length).toBeGreaterThan(1);
+		for (const url of idCalls) expect(url.length).toBeLessThan(8000);
+	});
+	test('resolves the recovered ids through the batch filter, not one call each', async () => {
+		const urls = mockUpstream({
+			persons: [
+				{ id: bobId, slug: 'bob-jones', state: null },
+				{ id: carolId, slug: 'carol-diaz', state: null },
+			],
+			candidacies: { WY: [bobId, carolId] },
+		});
+
+		await fetchPeopleSitemapEntries(base, 'b');
+
+		const idCalls = urls.filter((u) => u.includes('ids='));
+		expect(idCalls).toHaveLength(1);
+		expect(decodeURIComponent(idCalls[0]!)).toContain(`${bobId},${carolId}`);
+	});
+
+	// A removed person's page renders noindex, so advertising it would contradict
+	// the page and point crawlers at someone who asked to be left alone.
+	test('omits people who requested removal', async () => {
+		mockUpstream({
+			persons: [
+				{ id: aliceId, slug: 'alice-smith', state: 'WY' },
+				{ id: bobId, slug: 'bob-jones', state: 'WY' },
+			],
+			removed: [{ personId: bobId }],
+		});
 
 		const [aShard, bShard] = await Promise.all([
 			fetchPeopleSitemapEntries(base, 'a'),
 			fetchPeopleSitemapEntries(base, 'b'),
 		]);
 
-		expect(urls.filter((u) => u.includes('public-person-profiles/published'))).toHaveLength(1);
-		expect(urls.filter((u) => u.includes('/v1/persons'))).toHaveLength(1);
 		expect(aShard.map((e) => e.url)).toEqual([`${base}/people/alice-smith-aaaaaaaa`]);
-		expect(bShard.map((e) => e.url)).toEqual([`${base}/people/bob-jones-bbbbbbbb`]);
+		expect(bShard).toEqual([]);
 	});
 
-	test('empty election-api persons is not poisoned while published ids exist', async () => {
+	test('matches removal ids case-insensitively, since the id is a uuid from another service', async () => {
+		mockUpstream({
+			persons: [{ id: aliceId, slug: 'alice-smith', state: 'WY' }],
+			removed: [{ personId: aliceId.toUpperCase() }],
+		});
+
+		expect(await fetchPeopleSitemapEntries(base, 'a')).toEqual([]);
+	});
+
+	test('a claimed page carries its publish date and outranks an unclaimed one', async () => {
+		mockUpstream({
+			persons: [
+				{ id: aliceId, slug: 'alice-smith', state: 'WY' },
+				{ id: bobId, slug: 'bob-jones', state: 'WY' },
+			],
+			published: [{ personId: aliceId, updatedAt: '2026-01-15T00:00:00.000Z' }],
+		});
+
+		const [claimed] = await fetchPeopleSitemapEntries(base, 'a');
+		const [unclaimed] = await fetchPeopleSitemapEntries(base, 'b');
+
+		expect(claimed).toMatchObject({ priority: 0.7, lastModified: '2026-01-15' });
+		expect(unclaimed).toMatchObject({ priority: 0.5 });
+		// Not merely absent-ish: stamping today on a page nobody has touched would
+		// tell crawlers the entire unclaimed corpus changes every rebuild.
+		expect(unclaimed).not.toHaveProperty('lastModified');
+	});
+
+	test('concurrent shards share one sweep instead of each re-walking the table', async () => {
+		const urls = mockUpstream({
+			persons: [
+				{ id: aliceId, slug: 'alice-smith', state: 'WY' },
+				{ id: bobId, slug: 'bob-jones', state: 'WY' },
+			],
+		});
+
+		await Promise.all([
+			fetchPeopleSitemapEntries(base, 'a'),
+			fetchPeopleSitemapEntries(base, 'b'),
+		]);
+
+		expect(urls.filter((u) => u.includes('public-person-profiles/published'))).toHaveLength(1);
+		expect(urls.filter((u) => u.includes('state=WY') && u.includes('/v1/persons'))).toHaveLength(
+			1,
+		);
+	});
+
+	// The in-flight promise clears once it settles, so an upstream that was empty
+	// (or failing) at build time must not pin the band empty for the process.
+	test('an empty sweep is not cached for the life of the process', async () => {
+		mockUpstream({ persons: [] });
+		expect(await fetchPeopleSitemapEntries(base, 'a')).toEqual([]);
+
 		clearPeopleSitemapCache();
-		const urls: string[] = [];
-		let servePersons = false;
-		globalThis.fetch = (async (input: RequestInfo | URL) => {
-			const url = String(input);
-			urls.push(url);
-			if (url.includes('public-person-profiles/published')) {
-				return new Response(
-					JSON.stringify([
-						{ personId: aliceId, updatedAt: '2026-01-15T00:00:00.000Z' },
-						{ personId: bobId, updatedAt: '2026-02-01T00:00:00.000Z' },
-					]),
-					{ status: 200, headers: { 'content-type': 'application/json' } },
-				);
-			}
-			if (url.includes('/v1/persons')) {
-				const body = servePersons
-					? [
-							{ id: aliceId, slug: 'alice-smith' },
-							{ id: bobId, slug: 'bob-jones' },
-						]
-					: [];
-				return new Response(JSON.stringify(body), {
-					status: 200,
-					headers: { 'content-type': 'application/json' },
-				});
-			}
-			return new Response(JSON.stringify([]), { status: 200 });
-		}) as typeof fetch;
+		mockUpstream({ persons: [{ id: aliceId, slug: 'alice-smith', state: 'WY' }] });
 
-		const empty = await fetchPeopleSitemapEntries(base, 'a');
-		expect(empty).toEqual([]);
-		expect(urls.filter((u) => u.includes('public-person-profiles/published'))).toHaveLength(1);
-		expect(urls.filter((u) => u.includes('/v1/persons'))).toHaveLength(1);
+		expect((await fetchPeopleSitemapEntries(base, 'a')).map((e) => e.url)).toEqual([
+			`${base}/people/alice-smith-aaaaaaaa`,
+		]);
+	});
 
-		servePersons = true;
-		urls.length = 0;
+	// Both of the following cover the same class of bug: an upstream that answers
+	// "nothing" on failure is indistinguishable from one that answers "no rows",
+	// and for these two inputs the wrong answer is silent and shipped.
 
-		const recovered = await fetchPeopleSitemapEntries(base, 'a');
-		expect(urls.filter((u) => u.includes('public-person-profiles/published'))).toHaveLength(1);
-		expect(urls.filter((u) => u.includes('/v1/persons'))).toHaveLength(1);
-		expect(recovered.map((e) => e.url)).toEqual([`${base}/people/alice-smith-aaaaaaaa`]);
+	test('a failed state sweep rejects rather than publishing a partial corpus', async () => {
+		mockUpstream({
+			persons: [{ id: aliceId, slug: 'alice-smith', state: 'WY' }],
+			failPersonsForState: 'CA',
+		});
+
+		await expect(fetchPeopleSitemapEntries(base, 'a')).rejects.toThrow();
+	});
+
+	// A rolling deploy where gp-api has not yet shipped the endpoint 404s here.
+	// Failing open would advertise every person who asked to be delisted.
+	test('an unavailable removal list rejects rather than listing removed people', async () => {
+		mockUpstream({
+			persons: [{ id: aliceId, slug: 'alice-smith', state: 'WY' }],
+			removedStatus: 404,
+		});
+
+		await expect(fetchPeopleSitemapEntries(base, 'a')).rejects.toThrow();
+	});
+
+	// The band must not stay broken after a blip: the module slot has to clear on
+	// the rejected load too, or the first failure pins every later shard.
+	test('recovers on the next call after a failure', async () => {
+		mockUpstream({
+			persons: [{ id: aliceId, slug: 'alice-smith', state: 'WY' }],
+			removedStatus: 503,
+		});
+		await expect(fetchPeopleSitemapEntries(base, 'a')).rejects.toThrow();
+
+		mockUpstream({ persons: [{ id: aliceId, slug: 'alice-smith', state: 'WY' }] });
+
+		expect((await fetchPeopleSitemapEntries(base, 'a')).map((e) => e.url)).toEqual([
+			`${base}/people/alice-smith-aaaaaaaa`,
+		]);
+	});
+
+	test('skips a person with no slug, since there is no URL to point at', async () => {
+		mockUpstream({
+			persons: [{ id: aliceId, slug: '', state: 'WY' }],
+		});
+
+		expect(await fetchPeopleSitemapEntries(base, 'a')).toEqual([]);
 	});
 });
 
@@ -162,7 +341,7 @@ describe('chunkArray', () => {
 		expect(chunkArray([], 500)).toEqual([]);
 	});
 
-	test('splits into batches of at most `size` (people sitemap 500-id cap)', () => {
+	test('splits into batches of at most `size` (generic batching helper)', () => {
 		const ids = Array.from({ length: 1201 }, (_, i) => i);
 		const batches = chunkArray(ids, 500);
 		expect(batches.map((b) => b.length)).toEqual([500, 500, 201]);

--- a/src/lib/sitemap-entries.ts
+++ b/src/lib/sitemap-entries.ts
@@ -40,16 +40,20 @@ export function peopleShardForSlug(slug: string): string {
 }
 
 /**
- * The first people shard id sits immediately after the state-election and
- * candidate bands (id 0 = main, 1..N = state elections, N+1..2N = candidates).
+ * The first people shard id sits immediately after the state-election band
+ * (id 0 = main, 1..N = state elections).
+ *
+ * There used to be a second per-state band listing every /candidate/<slug>.
+ * It was retired when /candidate started permanently redirecting to /people:
+ * a sitemap should advertise destinations, not redirects, and leaving ~248k
+ * 308s in it spent crawl budget re-walking the migration on every pass.
  */
-export const PEOPLE_SITEMAP_BAND_START = 1 + 2 * US_STATE_CODES.length;
+export const PEOPLE_SITEMAP_BAND_START = 1 + US_STATE_CODES.length;
 
 export function getSitemapIds(): { id: number }[] {
 	const ids: { id: number }[] = [{ id: 0 }];
 	for (let i = 0; i < US_STATE_CODES.length; i++) {
 		ids.push({ id: i + 1 });
-		ids.push({ id: i + 1 + US_STATE_CODES.length });
 	}
 	for (let i = 0; i < PEOPLE_SITEMAP_SHARDS.length; i++) {
 		ids.push({ id: PEOPLE_SITEMAP_BAND_START + i });
@@ -110,16 +114,27 @@ export function chunkArray<T>(items: T[], size: number): T[][] {
 	return chunks;
 }
 
+/**
+ * `lastModified` distinguishes "unknown" from "absent": `undefined` stamps today
+ * (the long-standing default for pages whose freshness we can't source), while
+ * an explicit `null` omits the key entirely. The /people band needs the latter —
+ * we have no per-person modification date for a page nobody has claimed, and
+ * dating 200k+ of them "today" on every hourly rebuild would tell crawlers the
+ * whole corpus changes continuously, which is both false and the fastest way to
+ * get lastmod ignored site-wide.
+ */
 function toEntry(
 	baseUrl: string,
 	path: string,
 	priority: number,
 	changeFrequency: MetadataRoute.Sitemap[0]['changeFrequency'],
-	lastModified?: string,
+	lastModified?: string | null,
 ): MetadataRoute.Sitemap[0] {
 	return {
 		url: `${baseUrl}${path.startsWith('/') ? path : `/${path}`}`,
-		lastModified: lastModified ?? new Date().toISOString().slice(0, 10),
+		...(lastModified === null
+			? {}
+			: { lastModified: lastModified ?? new Date().toISOString().slice(0, 10) }),
 		changeFrequency,
 		priority,
 	};
@@ -417,20 +432,44 @@ export async function getCachedElectionRouteParams(): Promise<{
 	return cachedElectionRouteParams;
 }
 
-async function fetchGpApiJson<T>(path: string, tags?: readonly string[]): Promise<T[]> {
+/**
+ * Strict variants for the /people band.
+ *
+ * The soft helpers above degrade a failed upstream to `[]`, which is right for a
+ * band whose worst case is a few missing election URLs. It is wrong here. This
+ * band's inputs are a whole-table enumeration and a privacy exclusion list, and
+ * an empty-on-failure read of either is indistinguishable from a real answer:
+ * one transient 5xx on a single state sweep would publish a sitemap missing that
+ * state's people while claiming to be complete, and a non-200 from the removal
+ * list would advertise every person who asked to be delisted. Both failures are
+ * silent and both look exactly like success.
+ *
+ * So these throw. The shard then fails rather than serving a wrong answer, which
+ * is the recoverable direction: a crawler retries, and the previous good sitemap
+ * stays cached until it does.
+ */
+async function fetchGpApiJsonOrThrow<T>(path: string, tags?: readonly string[]): Promise<T[]> {
 	const url = `${GP_API_BASE.replace(/\/$/, '')}/${path.replace(/^\//, '')}`;
-	try {
-		const res = await fetch(url, cacheInit(tags));
-		if (!res.ok) {
-			console.error(`[sitemap] gp-api ${res.status} ${url}`);
-			return [];
-		}
-		const data: unknown = await res.json();
-		return Array.isArray(data) ? (data as T[]) : [];
-	} catch (err) {
-		console.error('[sitemap] gp-api fetch failed', url, err instanceof Error ? err.message : String(err));
-		return [];
+	const res = await fetch(url, cacheInit(tags));
+	if (!res.ok) throw new Error(`[sitemap] gp-api ${res.status} ${url}`);
+	const data: unknown = await res.json();
+	if (!Array.isArray(data)) throw new Error(`[sitemap] gp-api non-array body ${url}`);
+	return data as T[];
+}
+
+async function fetchElectionJsonOrThrow<T>(
+	path: string,
+	params: Record<string, string>,
+	tags?: readonly string[],
+): Promise<T[]> {
+	const search = new URLSearchParams(params).toString();
+	const url = `${ELECTION_API_BASE.replace(/\/$/, '')}/${path.replace(/^\//, '')}?${search}`;
+	const result = await fetchElectionApiJsonCached(url, tags);
+	if (!result.ok) throw new Error(`[sitemap] Election API ${result.status} ${url}`);
+	if (!Array.isArray(result.json)) {
+		throw new Error(`[sitemap] Election API non-array body ${url}`);
 	}
+	return result.json as T[];
 }
 
 async function fetchElectionJson<T>(
@@ -613,9 +652,126 @@ export async function fetchStateElectionSitemapEntries(
 type PeopleSitemapPerson = { id?: string; slug?: string | null };
 
 type PeopleSitemapData = {
+	/** personId → updatedAt, for the published subset only; also marks "claimed". */
 	updatedByPersonId: Map<string, string | undefined>;
+	/** personIds under a privacy takedown, which must never be advertised. */
+	removedPersonIds: Set<string>;
 	persons: PeopleSitemapPerson[];
 };
+
+/**
+ * Ids per `?ids=` lookup.
+ *
+ * election-api's own documented cap is 500, but that is unreachable: the filter
+ * is a query parameter, and 500 comma-encoded uuids is a ~19.5KB query string,
+ * which the gateway rejects with a 414 before the service ever sees it (measured
+ * — 300 ids / ~11.8KB still answers 200). This sits under the classic 8KB
+ * request-line limit so it survives any proxy in front of the API, at the cost
+ * of more, smaller round trips.
+ */
+const PERSON_ID_BATCH = 150;
+
+/**
+ * Cap on concurrent upstream requests while enumerating the person table.
+ * A full sweep is ~150 calls; firing them at once buys nothing (each returns in
+ * well under a second) and risks starving the same election-api that is serving
+ * live page renders.
+ */
+const ENUMERATION_CONCURRENCY = 8;
+
+async function mapWithConcurrency<T, R>(
+	items: readonly T[],
+	limit: number,
+	fn: (item: T) => Promise<R>,
+): Promise<R[]> {
+	const results: R[] = new Array(items.length) as R[];
+	let next = 0;
+	const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
+		for (let i = next++; i < items.length; i = next++) {
+			results[i] = await fn(items[i] as T);
+		}
+	});
+	await Promise.all(workers);
+	return results;
+}
+
+/**
+ * Every person with a public /people page.
+ *
+ * election-api offers no pagination and no count on `GET /v1/persons` — the
+ * query schema is strict, so `limit`/`offset` are 400s — which leaves `state`
+ * as the only bounded way to walk the table. A state sweep alone is NOT
+ * complete: `Person.state` is nullable, and the people carrying no state are
+ * unreachable through it (~8% of the corpus, 17k of 216k when this was written)
+ * because there is no way to ask for `state IS NULL`.
+ *
+ * The upstream mart defines the Person table as "people with a candidacy or
+ * office term", so the candidacy and officeholder feeds between them name every
+ * person that exists — and both DO carry a usable state. Unioning their
+ * personIds and resolving anything the sweep missed back through the 500-id
+ * batch filter closes the gap exactly, rather than approximately.
+ *
+ * If election-api ever grows a cursor or a dedicated enumeration feed, this
+ * whole dance collapses into a single paged read.
+ */
+async function fetchAllPersons(): Promise<PeopleSitemapPerson[]> {
+	const tags = [PEOPLE_SITEMAP_CACHE_TAG];
+	const states = [...US_STATE_CODES];
+	const byId = new Map<string, PeopleSitemapPerson>();
+
+	const sweeps = await mapWithConcurrency(states, ENUMERATION_CONCURRENCY, async (state) =>
+		fetchElectionJsonOrThrow<PeopleSitemapPerson>(
+			'v1/persons',
+			{ state, columns: 'id,slug' },
+			tags,
+		),
+	);
+	for (const rows of sweeps) {
+		for (const person of rows) {
+			if (person.id) byId.set(person.id.toLowerCase(), person);
+		}
+	}
+
+	const linkedFeeds: { path: string; state: string }[] = states.flatMap((state) => [
+		{ path: 'v1/candidacies', state },
+		{ path: 'v1/officeholders', state },
+	]);
+	const linked = await mapWithConcurrency(
+		linkedFeeds,
+		ENUMERATION_CONCURRENCY,
+		async ({ path, state }) =>
+			fetchElectionJsonOrThrow<{ personId?: string }>(
+				path,
+				{ state, columns: 'personId' },
+				tags,
+			),
+	);
+	const unseen = new Set<string>();
+	for (const rows of linked) {
+		for (const row of rows) {
+			const id = row.personId?.toLowerCase();
+			if (id && !byId.has(id)) unseen.add(id);
+		}
+	}
+
+	const batches = await mapWithConcurrency(
+		chunkArray([...unseen], PERSON_ID_BATCH),
+		ENUMERATION_CONCURRENCY,
+		async (ids) =>
+			fetchElectionJsonOrThrow<PeopleSitemapPerson>(
+				'v1/persons',
+				{ ids: ids.join(','), columns: 'id,slug' },
+				tags,
+			),
+	);
+	for (const rows of batches) {
+		for (const person of rows) {
+			if (person.id) byId.set(person.id.toLowerCase(), person);
+		}
+	}
+
+	return [...byId.values()];
+}
 
 let cachedPeopleSitemapData: Promise<PeopleSitemapData> | null = null;
 
@@ -637,57 +793,60 @@ export function clearPeopleSitemapCache(): void {
 async function getCachedPeopleSitemapData(): Promise<PeopleSitemapData> {
 	if (!cachedPeopleSitemapData) {
 		const load = (async (): Promise<PeopleSitemapData> => {
-			const published = await fetchGpApiJson<{ personId?: string; updatedAt?: string }>(
-				'v1/public-person-profiles/published',
-				[PEOPLE_SITEMAP_CACHE_TAG],
-			);
+			const [published, removed, persons] = await Promise.all([
+				fetchGpApiJsonOrThrow<{ personId?: string; updatedAt?: string }>(
+					'v1/public-person-profiles/published',
+					[PEOPLE_SITEMAP_CACHE_TAG],
+				),
+				fetchGpApiJsonOrThrow<{ personId?: string }>('v1/public-person-profiles/removed', [
+					PEOPLE_SITEMAP_CACHE_TAG,
+				]),
+				fetchAllPersons(),
+			]);
+
 			const updatedByPersonId = new Map<string, string | undefined>();
 			for (const row of published) {
 				if (row.personId) updatedByPersonId.set(row.personId.toLowerCase(), row.updatedAt);
 			}
 
-			if (updatedByPersonId.size === 0) {
-				return { updatedByPersonId, persons: [] };
+			const removedPersonIds = new Set<string>();
+			for (const row of removed) {
+				if (row.personId) removedPersonIds.add(row.personId.toLowerCase());
 			}
 
-			const ids = [...updatedByPersonId.keys()];
-			// election-api caps the `ids` filter at 500 (a larger list is rejected and
-			// returns []), so batch to avoid silently dropping published people.
-			const idBatches = chunkArray(ids, 500);
-			const persons = (
-				await Promise.all(
-					idBatches.map(async (batch) =>
-						fetchElectionJson<PeopleSitemapPerson>(
-							'v1/persons',
-							{
-								ids: batch.join(','),
-								columns: 'id,slug',
-							},
-							[PEOPLE_SITEMAP_CACHE_TAG],
-						),
-					),
-				)
-			).flat();
-
-			return { updatedByPersonId, persons };
+			return { updatedByPersonId, removedPersonIds, persons };
 		})();
 		cachedPeopleSitemapData = load;
-		void load.finally(() => {
+		// Settle via two-arg `then`, not `finally`: the upstream reads throw now, and
+		// `finally` returns a promise that re-raises the rejection with nobody
+		// attached to it — an unhandled rejection that can take the server down
+		// depending on the runtime's policy. Handling both arms here keeps the
+		// rejection observable only to the shard awaiting it, which is where it
+		// belongs. Clearing the slot on failure also means a transient outage costs
+		// one failed shard rather than pinning the band broken.
+		const settle = (): void => {
 			if (cachedPeopleSitemapData === load) {
 				cachedPeopleSitemapData = null;
 			}
-		});
+		};
+		load.then(settle, settle);
 	}
 	return cachedPeopleSitemapData;
 }
 
 /**
- * Fetches public /people profile sitemap entries.
+ * Sitemap entries for the public /people band — every person with a page, not
+ * just the claimed ones.
  *
- * Two-hop join across the service boundary: gp-api owns the publish gate (which
- * personIds are live), election-api owns the authoritative, unique, clean
- * `Person.slug` that is the canonical URL. Anything gp-api reports as published
- * but that has no election-api Person yet is skipped (no slug → no page).
+ * election-api owns the authoritative, unique `Person.slug` that is the
+ * canonical URL, so a person with no spine row has no page and is skipped.
+ * gp-api contributes the two per-person facts it alone knows: which people have
+ * published (worth a higher priority and a real lastmod) and which have
+ * requested removal.
+ *
+ * Removed people are dropped rather than downranked. Their page renders `noindex`
+ * by design, so listing it would both contradict the page's own directive and
+ * point crawlers at someone who asked to be left alone.
  *
  * Upstream fetches are shared across shards via getCachedPeopleSitemapData.
  */
@@ -695,39 +854,32 @@ export async function fetchPeopleSitemapEntries(
 	baseUrl: string,
 	shard?: string,
 ): Promise<MetadataRoute.Sitemap> {
-	const { updatedByPersonId, persons } = await getCachedPeopleSitemapData();
+	const { updatedByPersonId, removedPersonIds, persons } = await getCachedPeopleSitemapData();
 
 	const entries: MetadataRoute.Sitemap = [];
 	for (const p of persons) {
 		if (!p.id || !p.slug) continue;
+		const personId = p.id.toLowerCase();
+		if (removedPersonIds.has(personId)) continue;
 		// When a shard is requested, only emit people whose slug falls in it. The
 		// canonical URL appends the 8-hex id suffix but shares the base's first
 		// char, so sharding on the base is equivalent.
 		if (shard && peopleShardForSlug(p.slug) !== shard) continue;
 		const canonicalSlug = buildPersonSlugFromBase(p.slug, p.id);
-		const updatedAt = updatedByPersonId.get(p.id.toLowerCase());
+		const published = updatedByPersonId.has(personId);
 		entries.push(
-			toEntry(baseUrl, `/people/${canonicalSlug}`, 0.7, 'weekly', updatedAt?.slice(0, 10)),
+			toEntry(
+				baseUrl,
+				`/people/${canonicalSlug}`,
+				// A claimed page carries owner-authored content; an unclaimed one is
+				// the civics spine alone. The split tells crawlers which half of the
+				// corpus to spend budget on first.
+				published ? 0.7 : 0.5,
+				'weekly',
+				published ? (updatedByPersonId.get(personId)?.slice(0, 10) ?? null) : null,
+			),
 		);
 	}
 	return dedupeByUrl(entries);
 }
 
-/**
- * Fetches candidate sitemap entries from Election API.
- */
-export async function fetchCandidateSitemapEntries(
-	stateCode: string,
-	baseUrl: string,
-): Promise<MetadataRoute.Sitemap> {
-	const code = stateCode.toUpperCase();
-	const candidacies = await fetchElectionJson<{ slug?: string }>('v1/candidacies', {
-		state: code,
-		columns: 'slug',
-	});
-	const entries: MetadataRoute.Sitemap = [];
-	for (const c of candidacies) {
-		if (c.slug) entries.push(toEntry(baseUrl, `/candidate/${c.slug}`, 0.7, 'weekly'));
-	}
-	return dedupeByUrl(entries);
-}


### PR DESCRIPTION
## Summary
Promotes `develop` to `master` (prod). Carries two commits:

- **#211 fix(election-api-auth): anchor M2M token cache to TTL** — the important one. Prod `election-api` (observe-only) is logging ~200/min "JWT is expired" from gp-marketing server-side reads because the token cache never renewed (Clerk's `expiration` is ms at runtime; a `* 1000` pushed cache expiry ~56k years out, so each isolate replayed its first JWT forever). This anchors the cache window to the requested TTL so tokens refresh on schedule. Once this hits prod the "JWT is expired" warnings should drop to ~0.
- **#210 feat(sitemap): list every person page and retire the /candidate band** — unrelated product change already merged to develop; rides along in this promote.

Enforcement (`ELECTION_API_AUTH_ENFORCED`) stays **off** — this only makes gp-marketing send fresh, valid tokens; the observe-only guard rejects nothing.

Made with [Cursor](https://cursor.com)