### PR TITLE
Release: election-api M2M token expiry fix → master (prod)

### DIFF
--- a/src/lib/electionApiAuth.test.ts
+++ b/src/lib/electionApiAuth.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, mock, setSystemTime, spyOn, test } from 'bun:test';
 
 import {
 	__resetElectionApiAuthForTests,
@@ -7,7 +7,9 @@ import {
 	getElectionApiToken,
 } from './electionApiAuth';
 
-// Clerk's createToken returns `expiration` as a Unix timestamp in seconds.
+// mint() only reads `minted.expiration` to detect a failed mint (null => failure);
+// the cache window is anchored to the requested TTL, not to this field. Any
+// non-null value works here — its unit/magnitude is intentionally irrelevant.
 const expirationInSeconds = (secondsFromNow: number): number =>
 	Math.floor(Date.now() / 1000) + secondsFromNow;
 
@@ -154,6 +156,31 @@ describe('getElectionApiToken', () => {
 
 		await expect(getElectionApiToken()).resolves.toBe('cached-during-cooldown');
 		expect(createToken).toHaveBeenCalledTimes(0);
+	});
+
+	test('renews on the requested TTL even when Clerk returns a huge expiration (regression: ms double-scale)', async () => {
+		// Reproduces the prod bug: Clerk's `expiration` is milliseconds at runtime,
+		// and the old code did `expiration * 1000`, pushing the cache window ~56k
+		// years out so it never renewed and replayed one JWT long past its real
+		// `exp`. The fix anchors the window to the 600s TTL, so renewal must still
+		// happen after ~600s regardless of what `expiration` reports.
+		createToken.mockImplementation(async () => ({
+			token: 'ttl-anchored',
+			expiration: Date.now() * 1000, // ms-shaped; catastrophic if re-scaled
+		}));
+		const start = Date.now();
+		try {
+			setSystemTime(start);
+			await expect(getElectionApiToken()).resolves.toBe('ttl-anchored');
+			expect(createToken).toHaveBeenCalledTimes(1);
+
+			// Just past the 600s TTL: the token must be re-minted, not replayed.
+			setSystemTime(start + 601_000);
+			await expect(getElectionApiToken()).resolves.toBe('ttl-anchored');
+			expect(createToken).toHaveBeenCalledTimes(2);
+		} finally {
+			setSystemTime();
+		}
 	});
 });
 

--- a/src/lib/electionApiAuth.test.ts
+++ b/src/lib/electionApiAuth.test.ts
@@ -59,6 +59,20 @@ describe('getElectionApiToken', () => {
 		expect(createToken).toHaveBeenCalledTimes(1);
 	});
 
+	test('accepts a successful mint even when Clerk returns a null expiration', async () => {
+		// `expiration` is nullable in Clerk's type and unused for timing, so a
+		// non-null token must be treated as success — not discarded into cooldown.
+		createToken.mockImplementation(async () => ({
+			token: 'token-no-exp',
+			expiration: null,
+		}));
+
+		await expect(getElectionApiToken()).resolves.toBe('token-no-exp');
+		// Cached and reused: the TTL-derived window is valid despite null expiration.
+		await expect(getElectionApiToken()).resolves.toBe('token-no-exp');
+		expect(createToken).toHaveBeenCalledTimes(1);
+	});
+
 	test('remints when the cached token is fully expired', async () => {
 		__resetElectionApiAuthForTests({
 			cachedToken: 'stale-token',

--- a/src/lib/electionApiAuth.ts
+++ b/src/lib/electionApiAuth.ts
@@ -114,10 +114,14 @@ async function mint(): Promise<string | null> {
 			return usableCachedToken();
 		}
 		cachedToken = minted.token;
-		// Clerk returns `expiration` as a Unix timestamp in seconds; the cache
-		// checks compare against Date.now() in ms, so convert here or the token
-		// is treated as already expired and re-minted on every request.
-		tokenExpiration = minted.expiration * 1000;
+		// Anchor the cache window to the TTL we requested, NOT to `minted.expiration`.
+		// The JWT's real `exp` claim is (mint time + secondsUntilExpiration). Clerk's
+		// returned `expiration` field is typed as seconds but is actually milliseconds
+		// at runtime, so `* 1000` double-scaled it ~56k years into the future — the
+		// cache then never renewed and replayed one token long past its real `exp`,
+		// which election-api rejected as expired. Deriving from TTL is unit-agnostic
+		// and keeps the cache strictly inside the JWT's actual lifetime.
+		tokenExpiration = Date.now() + TOKEN_TTL_SECONDS * 1000;
 		mintCooldownUntil = 0;
 		return minted.token;
 	} catch (err) {

--- a/src/lib/electionApiAuth.ts
+++ b/src/lib/electionApiAuth.ts
@@ -109,7 +109,11 @@ async function mint(): Promise<string | null> {
 			tokenFormat: 'jwt',
 			secondsUntilExpiration: TOKEN_TTL_SECONDS,
 		});
-		if (!minted.token || minted.expiration == null) {
+		// A successful mint is signalled by a non-null token. Do NOT gate on
+		// `minted.expiration`: it is no longer read (the cache window is derived from
+		// the TTL below), and Clerk types it as nullable, so treating null expiration
+		// as failure would discard an otherwise-valid token and 401 downstream.
+		if (!minted.token) {
 			enterMintCooldown();
 			return usableCachedToken();
 		}


### PR DESCRIPTION
## Summary
Isolated prod release of the election-api M2M token-expiry fix (#211), cherry-picked onto `master` so it ships **without** the unrelated #210 sitemap change (which has open delegate blockers, including a potential 1h people-sitemap outage, and stays on `develop` until its author addresses them).

Prod `election-api` (observe-only) is logging ~200/min "JWT is expired" from gp-marketing server-side reads: Clerk's `createToken` returns `expiration` in milliseconds at runtime (typed as seconds), so `minted.expiration * 1000` pushed the cache expiry ~56k years out. The token cache therefore never renewed — each server isolate replayed its first JWT indefinitely, long past the real 600s `exp`. This anchors the cache window to the requested TTL so tokens refresh on schedule; once in prod, the warnings should drop to ~0.

Enforcement (`ELECTION_API_AUTH_ENFORCED`) stays **off** — this only makes gp-marketing send fresh, valid tokens; the observe-only guard rejects nothing.

Made with [Cursor](https://cursor.com)