### PR TITLE
fix(election-api-auth): don't treat null Clerk expiration as a mint failure

### DIFF
--- a/src/lib/electionApiAuth.test.ts
+++ b/src/lib/electionApiAuth.test.ts
@@ -59,6 +59,20 @@ describe('getElectionApiToken', () => {
 		expect(createToken).toHaveBeenCalledTimes(1);
 	});
 
+	test('accepts a successful mint even when Clerk returns a null expiration', async () => {
+		// `expiration` is nullable in Clerk's type and unused for timing, so a
+		// non-null token must be treated as success — not discarded into cooldown.
+		createToken.mockImplementation(async () => ({
+			token: 'token-no-exp',
+			expiration: null,
+		}));
+
+		await expect(getElectionApiToken()).resolves.toBe('token-no-exp');
+		// Cached and reused: the TTL-derived window is valid despite null expiration.
+		await expect(getElectionApiToken()).resolves.toBe('token-no-exp');
+		expect(createToken).toHaveBeenCalledTimes(1);
+	});
+
 	test('remints when the cached token is fully expired', async () => {
 		__resetElectionApiAuthForTests({
 			cachedToken: 'stale-token',

--- a/src/lib/electionApiAuth.ts
+++ b/src/lib/electionApiAuth.ts
@@ -109,7 +109,11 @@ async function mint(): Promise<string | null> {
 			tokenFormat: 'jwt',
 			secondsUntilExpiration: TOKEN_TTL_SECONDS,
 		});
-		if (!minted.token || minted.expiration == null) {
+		// A successful mint is signalled by a non-null token. Do NOT gate on
+		// `minted.expiration`: it is no longer read (the cache window is derived from
+		// the TTL below), and Clerk types it as nullable, so treating null expiration
+		// as failure would discard an otherwise-valid token and 401 downstream.
+		if (!minted.token) {
 			enterMintCooldown();
 			return usableCachedToken();
 		}


### PR DESCRIPTION
## Summary
Follow-up to the token-expiry fix (#211). After anchoring the cache window to the requested TTL, `minted.expiration` is no longer read — so gating mint-success on `minted.expiration == null` (a field Clerk types as nullable) is wrong: if Clerk returns `{ token, expiration: null }`, the guard would discard a perfectly valid token, enter cooldown, and hand back a stale/null cached token → a 401 downstream once enforcement is on.

Gate on `!minted.token` only, and add a test for the null-expiration success path.

This mirrors the fix already shipped to `master` via the isolated prod release (#214); this PR keeps `develop` consistent so the next `develop → master` promote doesn't regress it. gp-api's equivalent service already only checks `!minted.token`, so it needs no change.

Made with [Cursor](https://cursor.com)