### PR TITLE
Release: election-api M2M token pooling → master (prod) (#217)

### DIFF
--- a/src/lib/electionApiAuth.test.ts
+++ b/src/lib/electionApiAuth.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, mock, setSystemTime, spyOn, te
 
 import {
 	__resetElectionApiAuthForTests,
+	__setCacheModuleForTests,
 	__setCreateTokenForTests,
 	electionApiAuthHeaders,
 	getElectionApiToken,
@@ -176,8 +177,8 @@ describe('getElectionApiToken', () => {
 		// Reproduces the prod bug: Clerk's `expiration` is milliseconds at runtime,
 		// and the old code did `expiration * 1000`, pushing the cache window ~56k
 		// years out so it never renewed and replayed one JWT long past its real
-		// `exp`. The fix anchors the window to the 600s TTL, so renewal must still
-		// happen after ~600s regardless of what `expiration` reports.
+		// `exp`. The fix anchors the window to the 3600s TTL, so renewal must still
+		// happen after ~3600s regardless of what `expiration` reports.
 		createToken.mockImplementation(async () => ({
 			token: 'ttl-anchored',
 			expiration: Date.now() * 1000, // ms-shaped; catastrophic if re-scaled
@@ -188,13 +189,116 @@ describe('getElectionApiToken', () => {
 			await expect(getElectionApiToken()).resolves.toBe('ttl-anchored');
 			expect(createToken).toHaveBeenCalledTimes(1);
 
-			// Just past the 600s TTL: the token must be re-minted, not replayed.
-			setSystemTime(start + 601_000);
+			// Just past the 3600s TTL: the token must be re-minted, not replayed.
+			setSystemTime(start + 3_600_001);
 			await expect(getElectionApiToken()).resolves.toBe('ttl-anchored');
 			expect(createToken).toHaveBeenCalledTimes(2);
 		} finally {
 			setSystemTime();
 		}
+	});
+
+	test('reuses the cached token across the full TTL, not just 10 minutes', async () => {
+		// Guards the #1 change (TTL 600 -> 3600): a token minted now must still be
+		// served ~50 minutes later without re-minting, which is what collapses the
+		// fleet-wide mint volume that was tripping Clerk's M2M quota.
+		const start = Date.now();
+		try {
+			setSystemTime(start);
+			await expect(getElectionApiToken()).resolves.toBe('fresh-token');
+			expect(createToken).toHaveBeenCalledTimes(1);
+
+			// 50 minutes in — old 600s TTL would have re-minted ~5 times by now.
+			setSystemTime(start + 50 * 60_000);
+			await expect(getElectionApiToken()).resolves.toBe('fresh-token');
+			expect(createToken).toHaveBeenCalledTimes(1);
+		} finally {
+			setSystemTime();
+		}
+	});
+
+	test('mint failures back off exponentially, so a Clerk outage is not a retry storm', async () => {
+		// #3: cooldown escalates 30s -> 60s (jitter only shortens by <=1/4, so the
+		// first window is <=30s and the second is >=45s — a clean, non-flaky gap).
+		createToken.mockImplementation(async () => {
+			throw new Error('Clerk throttled');
+		});
+		const errorSpy = spyOn(console, 'error').mockImplementation(() => undefined);
+		const start = Date.now();
+		try {
+			setSystemTime(start);
+			// Failure #1 -> cooldown ends within (start, start+30s].
+			await expect(getElectionApiToken()).resolves.toBeNull();
+			expect(createToken).toHaveBeenCalledTimes(1);
+
+			// Still inside the first cooldown: no new Clerk call.
+			setSystemTime(start + 20_000);
+			await expect(getElectionApiToken()).resolves.toBeNull();
+			expect(createToken).toHaveBeenCalledTimes(1);
+
+			// Past the max first cooldown (30s): failure #2 escalates toward ~60s.
+			setSystemTime(start + 31_000);
+			await expect(getElectionApiToken()).resolves.toBeNull();
+			expect(createToken).toHaveBeenCalledTimes(2);
+
+			// 40s after failure #2: a flat 30s policy would have retried, but the
+			// escalated (>=45s) window must still suppress the Clerk call.
+			setSystemTime(start + 71_000);
+			await expect(getElectionApiToken()).resolves.toBeNull();
+			expect(createToken).toHaveBeenCalledTimes(2);
+		} finally {
+			setSystemTime();
+			errorSpy.mockRestore();
+		}
+	});
+});
+
+describe('token pooling across isolates (L2 Data Cache)', () => {
+	const ORIGINAL_RUNTIME = process.env['NEXT_RUNTIME'];
+
+	afterEach(() => {
+		if (ORIGINAL_RUNTIME === undefined) {
+			delete process.env['NEXT_RUNTIME'];
+		} else {
+			process.env['NEXT_RUNTIME'] = ORIGINAL_RUNTIME;
+		}
+		// Restore the real dynamic import of next/cache.
+		__setCacheModuleForTests(null);
+	});
+
+	test('inside the Next runtime, mints through unstable_cache keyed for fleet-wide reuse', async () => {
+		// Inject a next/cache stand-in via the module's own seam rather than
+		// mock.module: the latter is process-global in bun and would strip
+		// revalidateTag/revalidatePath from sibling test files.
+		let capturedKey: unknown;
+		let capturedOptions: { revalidate?: number } | undefined;
+		const unstable_cache = mock(
+			(fn: (...args: unknown[]) => unknown, key: unknown, options: { revalidate?: number }) => {
+				capturedKey = key;
+				capturedOptions = options;
+				return (...args: unknown[]) => fn(...args);
+			},
+		);
+		__setCacheModuleForTests({ unstable_cache } as never);
+		process.env['NEXT_RUNTIME'] = 'nodejs';
+
+		await expect(getElectionApiToken()).resolves.toBe('fresh-token');
+
+		expect(unstable_cache).toHaveBeenCalledTimes(1);
+		// Single fixed key => one shared entry for the whole fleet.
+		expect(capturedKey).toEqual(['election-api-m2m-token']);
+		// Revalidate strictly inside the 3600s TTL so an edge read still has margin.
+		expect(capturedOptions?.revalidate).toBe(3300);
+	});
+
+	test('outside the Next runtime, mints directly without touching the Data Cache', async () => {
+		// mintPooled short-circuits on !NEXT_RUNTIME before the cache seam, so a
+		// direct mint here (one createToken, no cache module consulted) is the proof.
+		delete process.env['NEXT_RUNTIME'];
+
+		await expect(getElectionApiToken()).resolves.toBe('fresh-token');
+
+		expect(createToken).toHaveBeenCalledTimes(1);
 	});
 });
 

--- a/src/lib/electionApiAuth.ts
+++ b/src/lib/electionApiAuth.ts
@@ -23,11 +23,42 @@ import { createClerkClient } from '@clerk/backend';
  * unauthenticated. That is intentional: it keeps gp-marketing working while
  * election-api is still in observe-only mode. Once ELECTION_API_AUTH_ENFORCED
  * is on, the secret must be present or election-api will return 401.
+ *
+ * Token pooling across serverless isolates
+ * ----------------------------------------
+ * JWT-format M2M tokens are stateless: Clerk does NOT deduplicate them
+ * server-side (`minRemainingTtlSeconds` only pools opaque tokens), so every
+ * `createToken` call mints — and bills for — a brand-new token. On Vercel we
+ * run a large, churning fleet of short-lived isolates; if each mints on its own
+ * (× a short TTL) we generate thousands of creations, blow past Clerk's quota,
+ * and start getting throttled — at which point the fail-soft below drops the
+ * Authorization header and election-api logs "Missing bearer token".
+ *
+ * We therefore pool at two layers:
+ *   L1 — per-isolate in-memory cache (this module's `cachedToken`). Free, but
+ *        only shared within a single warm isolate.
+ *   L2 — cross-isolate cache via the Next Data Cache (`unstable_cache`), which
+ *        is shared across all isolates/regions on Vercel. One minted JWT is
+ *        reused fleet-wide until it nears expiry, collapsing thousands of mints
+ *        into roughly one per revalidate window. This is Clerk's recommended
+ *        "pool tokens at the server" pattern, implemented on our side because
+ *        JWTs can't be pooled by Clerk.
  */
 
-const TOKEN_RENEWAL_BUFFER_MS = 30_000;
-const MINT_COOLDOWN_MS = 30_000;
-const TOKEN_TTL_SECONDS = 600;
+// Renew slightly before expiry so an in-flight request never uses a token that
+// expires mid-call.
+const TOKEN_RENEWAL_BUFFER_MS = 60_000;
+// Long TTL keeps mint volume (and cost) low; the shared cache below reuses each
+// minted token fleet-wide for almost its whole lifetime.
+const TOKEN_TTL_SECONDS = 3600;
+// Cross-isolate cache window. Must stay comfortably inside the JWT's real
+// lifetime so a token read at the edge of the window still has margin over the
+// renewal buffer (3600s life − 300s = 3300s window ⇒ ≥300s remaining).
+const SHARED_TOKEN_REVALIDATE_SECONDS = TOKEN_TTL_SECONDS - 300;
+// Backoff bounds for mint failures (throttling/outage). Exponential with jitter
+// so a fleet-wide Clerk hiccup doesn't turn into a synchronized retry storm.
+const MINT_COOLDOWN_BASE_MS = 30_000;
+const MINT_COOLDOWN_MAX_MS = 300_000;
 
 export type CreateM2MToken = (params: {
 	machineSecretKey: string;
@@ -45,8 +76,27 @@ type ClerkM2MClient = {
 	};
 };
 
+/** A minted token plus the absolute ms timestamp at which it truly expires. */
+type MintedToken = { token: string; expiration: number };
+
+/** Thrown when the machine secret is absent — a config state, not a failure. */
+class MissingMachineSecretError extends Error {}
+
+/** Minimal shape of next/cache we depend on, for the test seam below. */
+type CacheModule = {
+	unstable_cache(
+		fn: () => Promise<MintedToken>,
+		keyParts: string[],
+		options: { revalidate: number },
+	): () => Promise<MintedToken>;
+};
+
 let clerkClient: ClerkM2MClient | null = null;
 let createTokenForTests: CreateM2MToken | null = null;
+// Injected in tests so the L2 path can be exercised without `mock.module`, which
+// is process-global in bun and would strip other next/cache exports (revalidateTag,
+// revalidatePath) that sibling test files import.
+let cacheModuleForTests: CacheModule | null = null;
 
 function getClerkClient(): ClerkM2MClient {
 	if (!clerkClient) {
@@ -72,6 +122,7 @@ let tokenExpiration: number | null = null;
 let pending: Promise<string | null> | null = null;
 let warnedMissingSecret = false;
 let mintCooldownUntil = 0;
+let mintFailureStreak = 0;
 
 /** True when a cached token exists and has not yet reached its real expiry. */
 function isTokenUsable(): boolean {
@@ -88,52 +139,95 @@ function usableCachedToken(): string | null {
 	return isTokenUsable() ? cachedToken : null;
 }
 
+/**
+ * Exponential backoff (capped) with jitter to avoid synchronized retry storms.
+ * The jitter only ever shortens the wait, and by at most a quarter, so each
+ * escalated window stays strictly longer than the previous one's maximum.
+ */
 function enterMintCooldown(): void {
-	mintCooldownUntil = Date.now() + MINT_COOLDOWN_MS;
+	mintFailureStreak += 1;
+	const exponential = MINT_COOLDOWN_BASE_MS * 2 ** (mintFailureStreak - 1);
+	const capped = Math.min(exponential, MINT_COOLDOWN_MAX_MS);
+	const jitter = Math.floor(Math.random() * (capped / 4));
+	mintCooldownUntil = Date.now() + capped - jitter;
 }
 
-async function mint(): Promise<string | null> {
+/**
+ * One real Clerk mint. Throws on any failure so the shared cache never memoizes
+ * a bad result and the caller can fall back to the last-good token.
+ */
+async function mintFromClerk(): Promise<MintedToken> {
 	const machineSecret = process.env['GP_MARKETING_MACHINE_SECRET'];
-	if (!machineSecret) {
-		if (!warnedMissingSecret) {
-			warnedMissingSecret = true;
-			console.error(
-				'[electionApiAuth] GP_MARKETING_MACHINE_SECRET is not set; election-api requests will be unauthenticated',
-			);
-		}
-		return usableCachedToken();
+	if (!machineSecret) throw new MissingMachineSecretError();
+
+	const minted = await createToken({
+		machineSecretKey: machineSecret,
+		tokenFormat: 'jwt',
+		secondsUntilExpiration: TOKEN_TTL_SECONDS,
+	});
+	// A successful mint is signalled by a non-null token. Do NOT gate on
+	// `minted.expiration`: it is not read (the window is derived from the TTL),
+	// and Clerk types it as nullable, so treating null as failure would discard
+	// an otherwise-valid token and 401 downstream.
+	if (!minted.token) throw new Error('Clerk M2M token creation returned no token');
+
+	// Anchor the cache window to the TTL we requested, NOT to `minted.expiration`.
+	// The JWT's real `exp` claim is (mint time + secondsUntilExpiration). Clerk's
+	// returned `expiration` field is typed as seconds but is milliseconds at
+	// runtime, so `* 1000` double-scaled it ~56k years out — the cache then never
+	// renewed and replayed one token long past its real `exp`. Deriving from TTL
+	// is unit-agnostic and keeps the window strictly inside the JWT's lifetime.
+	return { token: minted.token, expiration: Date.now() + TOKEN_TTL_SECONDS * 1000 };
+}
+
+/**
+ * Mint through the cross-isolate (L2) cache when running inside the Next server
+ * runtime; otherwise (CLI scripts, unit tests) mint directly. `unstable_cache`
+ * is only valid inside the Next runtime — invoking it elsewhere hangs — so we
+ * gate on NEXT_RUNTIME exactly as election-api's fetch cache does.
+ */
+async function mintPooled(): Promise<MintedToken> {
+	// Outside the Next runtime, or with no secret to mint from, skip the Data
+	// Cache entirely: there is nothing to pool and mintFromClerk resolves the
+	// direct/error path (throwing MissingMachineSecretError) without a cache hop.
+	if (!process.env['NEXT_RUNTIME'] || !process.env['GP_MARKETING_MACHINE_SECRET']) {
+		return mintFromClerk();
 	}
+
+	const cacheMod =
+		cacheModuleForTests ?? ((await import('next/cache')) as unknown as CacheModule);
+	return cacheMod.unstable_cache(mintFromClerk, ['election-api-m2m-token'], {
+		revalidate: SHARED_TOKEN_REVALIDATE_SECONDS,
+	})();
+}
+
+async function renew(): Promise<string | null> {
 	try {
-		const minted = await createToken({
-			machineSecretKey: machineSecret,
-			tokenFormat: 'jwt',
-			secondsUntilExpiration: TOKEN_TTL_SECONDS,
-		});
-		// A successful mint is signalled by a non-null token. Do NOT gate on
-		// `minted.expiration`: it is no longer read (the cache window is derived from
-		// the TTL below), and Clerk types it as nullable, so treating null expiration
-		// as failure would discard an otherwise-valid token and 401 downstream.
-		if (!minted.token) {
-			enterMintCooldown();
+		const { token, expiration } = await mintPooled();
+		cachedToken = token;
+		tokenExpiration = expiration;
+		mintCooldownUntil = 0;
+		mintFailureStreak = 0;
+		return token;
+	} catch (err) {
+		if (err instanceof MissingMachineSecretError) {
+			if (!warnedMissingSecret) {
+				warnedMissingSecret = true;
+				console.error(
+					'[electionApiAuth] GP_MARKETING_MACHINE_SECRET is not set; election-api requests will be unauthenticated',
+				);
+			}
+			// Config state, not a transient failure: no cooldown/backoff.
 			return usableCachedToken();
 		}
-		cachedToken = minted.token;
-		// Anchor the cache window to the TTL we requested, NOT to `minted.expiration`.
-		// The JWT's real `exp` claim is (mint time + secondsUntilExpiration). Clerk's
-		// returned `expiration` field is typed as seconds but is actually milliseconds
-		// at runtime, so `* 1000` double-scaled it ~56k years into the future — the
-		// cache then never renewed and replayed one token long past its real `exp`,
-		// which election-api rejected as expired. Deriving from TTL is unit-agnostic
-		// and keeps the cache strictly inside the JWT's actual lifetime.
-		tokenExpiration = Date.now() + TOKEN_TTL_SECONDS * 1000;
-		mintCooldownUntil = 0;
-		return minted.token;
-	} catch (err) {
+		// Transient (throttle/outage): back off, but keep serving the last-good
+		// token until its real expiry so a Clerk hiccup never drops auth while a
+		// valid token is still in hand.
+		enterMintCooldown();
 		console.error(
 			'[electionApiAuth] failed to mint M2M token',
 			err instanceof Error ? err.message : String(err),
 		);
-		enterMintCooldown();
 		return usableCachedToken();
 	}
 }
@@ -143,7 +237,7 @@ export async function getElectionApiToken(): Promise<string | null> {
 	if (!needsRenewal()) return cachedToken;
 	if (Date.now() < mintCooldownUntil) return usableCachedToken();
 	if (pending) return pending;
-	const promise = mint();
+	const promise = renew();
 	pending = promise;
 	try {
 		return await promise;
@@ -163,6 +257,11 @@ export function __setCreateTokenForTests(fn: CreateM2MToken | null): void {
 	createTokenForTests = fn;
 }
 
+/** Test-only: inject a next/cache stand-in (null restores the real dynamic import). */
+export function __setCacheModuleForTests(mod: CacheModule | null): void {
+	cacheModuleForTests = mod;
+}
+
 /** Test-only: reset module cache / cooldown state (and optionally seed a token). */
 export function __resetElectionApiAuthForTests(seed?: {
 	cachedToken?: string | null;
@@ -174,7 +273,9 @@ export function __resetElectionApiAuthForTests(seed?: {
 	tokenExpiration = seed?.tokenExpiration ?? null;
 	mintCooldownUntil = seed?.mintCooldownUntil ?? 0;
 	warnedMissingSecret = seed?.warnedMissingSecret ?? false;
+	mintFailureStreak = 0;
 	pending = null;
 	clerkClient = null;
 	createTokenForTests = null;
+	cacheModuleForTests = null;
 }

--- a/src/lib/electionApiFetch.ts
+++ b/src/lib/electionApiFetch.ts
@@ -23,12 +23,14 @@ export class ElectionApiError extends Error {
 }
 
 /**
- * Authenticated election-api GET that keeps the rotating M2M Authorization header
- * OUT of the Next.js Data Cache key.
+ * Authenticated election-api GET, keyed only on the URL so the shared 1h Data
+ * Cache hits across isolates.
  *
- * Next's fetch cache includes Authorization in its key, so minting a fresh token
- * every ~10 minutes (and per isolate) would bust the shared 1h cache. We mint
- * inside unstable_cache and key only on the URL; fetch itself uses cache:'no-store'.
+ * The M2M Authorization header is acquired OUTSIDE this URL cache. It has its
+ * own cross-isolate pool (see electionApiAuth), so this is cheap on the hot path
+ * (an in-memory hit) and only mints on the rare renewal — and keeping it out of
+ * the wrapped function avoids nesting unstable_cache calls. fetch itself uses
+ * cache:'no-store', so the token never enters the URL cache key regardless.
  *
  * unstable_cache only works inside the Next server runtime. In CLI scripts (bun/tsx)
  * and unit tests the module still imports, but invoking unstable_cache outside the
@@ -40,8 +42,8 @@ export async function fetchElectionApiJsonCached(
 	url: string,
 	tags?: readonly string[],
 ): Promise<ElectionApiJsonResult> {
+	const authHeaders = await electionApiAuthHeaders();
 	const run = async (): Promise<ElectionApiJsonResult> => {
-		const authHeaders = await electionApiAuthHeaders();
 		const res = await fetch(url, { headers: authHeaders, cache: 'no-store' });
 		if (res.status === 404) return { status: 404, ok: false, json: null };
 		// Anything else non-ok throws rather than returning: unstable_cache stores


### PR DESCRIPTION
Promotes #217 to production.

gp-marketing prod currently mints a fresh Clerk JWT M2M token per serverless isolate on a 600s TTL. Because JWT-format M2M tokens are stateless and are never deduplicated by Clerk, that fan-out trips Clerk's metered token-creation quota; when a mint is throttled, the fail-soft path drops the Authorization header and election-api logs a sustained "Missing bearer token" on /v1/places, /v1/candidacies and /v1/races — which would 401 those pages the moment election-api enforcement is turned on.

This release pools one JWT fleet-wide via the Next Data Cache, raises the TTL to 1h, and hardens the mint-failure path (exponential backoff + last-good token). Only the three election-api-auth files change; delegate-approved and CI-green on #217.

After promotion + Vercel prod deploy, we re-soak election-api prod logs until app-endpoint "Missing bearer token" drains to ~0. Enforcement stays OFF.

Made with [Cursor](https://cursor.com)