### PR TITLE
fix(election-api-auth): static long-lived M2M token instead of runtime minting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,15 +25,14 @@ SANITY_REVALIDATE_SECRET=
 # (election-api -> gp-api). Override with GP_API_BASE_URL if needed.
 ELECTIONS_API_BASE_URL=
 
-# Clerk M2M auth for election-api (SERVER-ONLY — never expose as NEXT_PUBLIC_).
-# gp-marketing mints a machine token with GP_MARKETING_MACHINE_SECRET and sends
-# it on server-side election-api reads (Server Components, sitemap/build
-# scripts). The gp-marketing machine must be connected to the election-api
-# machine in the Clerk dashboard. If unset, election-api requests go out
-# unauthenticated (fine only while election-api is in observe-only mode).
-CLERK_SECRET_KEY=
-CLERK_PUBLISHABLE_KEY=
-GP_MARKETING_MACHINE_SECRET=
+# Clerk M2M bearer for election-api (SERVER-ONLY — never expose as NEXT_PUBLIC_).
+# A long-lived Clerk JWT minted out-of-band for the gp-marketing machine (scoped
+# to election-api). It is sent on server-side election-api reads (Server
+# Components, sitemap/build scripts); election-api verifies it networkless. We no
+# longer mint at runtime — a static token avoids per-isolate mint fan-out on
+# Vercel. If unset, election-api requests go out unauthenticated (fine only while
+# election-api is in observe-only mode). Rotate before its ~90-day expiry.
+ELECTION_API_M2M_TOKEN=
 
 # Shared secret gp-api sends (header x-revalidate-secret) to POST /api/revalidate-person
 # to on-demand cache-bust a public /people/* page after publish/unpublish/delete/edit.

--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,6 @@
       "dependencies": {
         "@amplitude/experiment-js-client": "^1.20.3",
         "@amplitude/experiment-node-server": "^1.13.4",
-        "@clerk/backend": "^2.29.7",
         "@csstools/postcss-global-data": "^3.1.0",
         "@deck.gl/aggregation-layers": "^9.3.6",
         "@deck.gl/core": "^9.3.6",
@@ -424,12 +423,6 @@
     "@babel/traverse": ["@babel/traverse@7.28.5", "", { "dependencies": { "@babel/code-frame": "^7.27.1", "@babel/generator": "^7.28.5", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.28.5", "@babel/template": "^7.27.2", "@babel/types": "^7.28.5", "debug": "^4.3.1" } }, "sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ=="],
 
     "@babel/types": ["@babel/types@7.28.5", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA=="],
-
-    "@clerk/backend": ["@clerk/backend@2.33.6", "", { "dependencies": { "@clerk/shared": "^3.47.8", "@clerk/types": "^4.101.26", "standardwebhooks": "^1.0.0", "tslib": "2.8.1" } }, "sha512-5foMmTHEQFt4mDv7AN0RDwUHZhGcg/JYe5hnl9SU/LFS8ZHY29Z2HDtIBmzKgjRfOJTMKj1AM81LgK2UFsGm9Q=="],
-
-    "@clerk/shared": ["@clerk/shared@3.47.8", "", { "dependencies": { "csstype": "3.1.3", "dequal": "2.0.3", "glob-to-regexp": "0.4.1", "js-cookie": "3.0.7", "std-env": "^3.9.0", "swr": "2.3.4" }, "peerDependencies": { "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0", "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0" }, "optionalPeers": ["react", "react-dom"] }, "sha512-cPURU1it/Eal4uXO9SOcHzw9sfE6Opi21W8EJUg+Ri80Q6JKtK8qBmyOpIyqgf09EanexhTzS4xrmYlvn2p7Iw=="],
-
-    "@clerk/types": ["@clerk/types@4.101.26", "", { "dependencies": { "@clerk/shared": "^3.47.8" } }, "sha512-tUeiElAZoXu9Dxom9t6IjkEfsfP7aWSVf5x5mCoHnSr2w+wV4EtEwoLl9vexT5LL0di4qidROSfcrOnorzczIQ=="],
 
     "@codemirror/autocomplete": ["@codemirror/autocomplete@6.20.0", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.17.0", "@lezer/common": "^1.0.0" } }, "sha512-bOwvTOIJcG5FVo5gUUupiwYh8MioPLQ4UcqbcRf7UQ98X90tCa9E1kZ3Z7tqwpZxYyOvh1YTYbmZE9RTfTp5hg=="],
 
@@ -1388,8 +1381,6 @@
     "@sentry/core": ["@sentry/core@8.55.0", "", {}, "sha512-6g7jpbefjHYs821Z+EBJ8r4Z7LT5h80YSWRJaylGS4nW5W5Z2KXzpdnyFarv37O7QjauzVC2E+PABmpkw5/JGA=="],
 
     "@sentry/react": ["@sentry/react@8.55.0", "", { "dependencies": { "@sentry/browser": "8.55.0", "@sentry/core": "8.55.0", "hoist-non-react-statics": "^3.3.2" }, "peerDependencies": { "react": "^16.14.0 || 17.x || 18.x || 19.x" } }, "sha512-/qNBvFLpvSa/Rmia0jpKfJdy16d4YZaAnH/TuKLAtm0BWlsPQzbXCU4h8C5Hsst0Do0zG613MEtEmWpWrVOqWA=="],
-
-    "@stablelib/base64": ["@stablelib/base64@1.0.1", "", {}, "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ=="],
 
     "@standard-schema/spec": ["@standard-schema/spec@1.0.0", "", {}, "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA=="],
 
@@ -2389,8 +2380,6 @@
 
     "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="],
 
-    "fast-sha256": ["fast-sha256@1.3.0", "", {}, "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ=="],
-
     "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
 
     "fastq": ["fastq@1.19.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ=="],
@@ -2770,8 +2759,6 @@
     "jotai": ["jotai@2.16.0", "", { "peerDependencies": { "@babel/core": ">=7.0.0", "@babel/template": ">=7.0.0", "@types/react": ">=17.0.0", "react": ">=17.0.0" }, "optionalPeers": ["@babel/core", "@babel/template", "@types/react", "react"] }, "sha512-NmkwPBet0SHQ28GBfEb10sqnbVOYyn6DL4iazZgGRDUKxSWL0iqcm+IK4TqTSFC2ixGk+XX2e46Wbv364a3cKg=="],
 
     "js-base64": ["js-base64@3.7.8", "", {}, "sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow=="],
-
-    "js-cookie": ["js-cookie@3.0.7", "", {}, "sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw=="],
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
@@ -3559,8 +3546,6 @@
 
     "stackframe": ["stackframe@1.3.4", "", {}, "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw=="],
 
-    "standardwebhooks": ["standardwebhooks@1.0.0", "", { "dependencies": { "@stablelib/base64": "^1.0.0", "fast-sha256": "^1.3.0" } }, "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg=="],
-
     "std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
 
     "stdin-discarder": ["stdin-discarder@0.2.2", "", {}, "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ=="],
@@ -3966,10 +3951,6 @@
     "@babel/register/find-cache-dir": ["find-cache-dir@2.1.0", "", { "dependencies": { "commondir": "^1.0.1", "make-dir": "^2.0.0", "pkg-dir": "^3.0.0" } }, "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ=="],
 
     "@babel/register/make-dir": ["make-dir@2.1.0", "", { "dependencies": { "pify": "^4.0.1", "semver": "^5.6.0" } }, "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA=="],
-
-    "@clerk/shared/csstype": ["csstype@3.1.3", "", {}, "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="],
-
-    "@clerk/shared/swr": ["swr@2.3.4", "", { "dependencies": { "dequal": "^2.0.3", "use-sync-external-store": "^1.4.0" }, "peerDependencies": { "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-bYd2lrhc+VarcpkgWclcUi92wYCpOgMws9Sd1hG1ntAu0NEy+14CbotuFjshBU2kt9rYj9TSmDcybpxpeTU1fg=="],
 
     "@csstools/selector-resolve-nested/postcss-selector-parser": ["postcss-selector-parser@7.1.1", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg=="],
 

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
   "dependencies": {
     "@amplitude/experiment-js-client": "^1.20.3",
     "@amplitude/experiment-node-server": "^1.13.4",
-    "@clerk/backend": "^2.29.7",
     "@csstools/postcss-global-data": "^3.1.0",
     "@deck.gl/aggregation-layers": "^9.3.6",
     "@deck.gl/core": "^9.3.6",

--- a/scripts/validate-election-pages.ts
+++ b/scripts/validate-election-pages.ts
@@ -100,7 +100,7 @@ async function fetchElectionJson<T>(path: string, params: Record<string, string>
 	const search = new URLSearchParams(params).toString();
 	const url = `${ELECTION_API_BASE.replace(/\/$/, '')}/${path.replace(/^\//, '')}?${search}`;
 	try {
-		const authHeaders = await electionApiAuthHeaders();
+		const authHeaders = electionApiAuthHeaders();
 		const res = await fetch(url, { headers: authHeaders });
 		if (!res.ok) return [];
 		const data: unknown = await res.json();

--- a/src/lib/electionApiAuth.test.ts
+++ b/src/lib/electionApiAuth.test.ts
@@ -1,319 +1,65 @@
-import { afterEach, beforeEach, describe, expect, mock, setSystemTime, spyOn, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, spyOn, test } from 'bun:test';
 
 import {
 	__resetElectionApiAuthForTests,
-	__setCacheModuleForTests,
-	__setCreateTokenForTests,
 	electionApiAuthHeaders,
 	getElectionApiToken,
 } from './electionApiAuth';
 
-// mint() only reads `minted.expiration` to detect a failed mint (null => failure);
-// the cache window is anchored to the requested TTL, not to this field. Any
-// non-null value works here — its unit/magnitude is intentionally irrelevant.
-const expirationInSeconds = (secondsFromNow: number): number =>
-	Math.floor(Date.now() / 1000) + secondsFromNow;
-
-const createToken = mock(
-	async (): Promise<{ token: string | null; expiration: number | null }> => ({
-		token: 'fresh-token',
-		expiration: expirationInSeconds(600),
-	}),
-);
-
-const ORIGINAL_SECRET = process.env['GP_MARKETING_MACHINE_SECRET'];
+const ORIGINAL_TOKEN = process.env['ELECTION_API_M2M_TOKEN'];
 
 beforeEach(() => {
-	createToken.mockClear();
-	createToken.mockImplementation(async () => ({
-		token: 'fresh-token',
-		expiration: expirationInSeconds(600),
-	}));
-	process.env['GP_MARKETING_MACHINE_SECRET'] = 'test-machine-secret';
+	process.env['ELECTION_API_M2M_TOKEN'] = 'static-jwt';
 	__resetElectionApiAuthForTests();
-	__setCreateTokenForTests(createToken);
 });
 
 afterEach(() => {
-	if (ORIGINAL_SECRET === undefined) {
-		delete process.env['GP_MARKETING_MACHINE_SECRET'];
+	if (ORIGINAL_TOKEN === undefined) {
+		delete process.env['ELECTION_API_M2M_TOKEN'];
 	} else {
-		process.env['GP_MARKETING_MACHINE_SECRET'] = ORIGINAL_SECRET;
+		process.env['ELECTION_API_M2M_TOKEN'] = ORIGINAL_TOKEN;
 	}
 	__resetElectionApiAuthForTests();
 });
 
 describe('getElectionApiToken', () => {
-	test('returns cached token when outside the renewal buffer', async () => {
-		__resetElectionApiAuthForTests({
-			cachedToken: 'cached-token',
-			tokenExpiration: Date.now() + 120_000,
-		});
-		__setCreateTokenForTests(createToken);
-
-		await expect(getElectionApiToken()).resolves.toBe('cached-token');
-		expect(createToken).toHaveBeenCalledTimes(0);
+	test('returns the injected static token', () => {
+		expect(getElectionApiToken()).toBe('static-jwt');
 	});
 
-	test('remints when no token is cached', async () => {
-		await expect(getElectionApiToken()).resolves.toBe('fresh-token');
-		expect(createToken).toHaveBeenCalledTimes(1);
+	test('re-reads process.env so a rotated value is picked up without a restart', () => {
+		// There is no cache: the value is read straight from the env on every call,
+		// so rotating ELECTION_API_M2M_TOKEN (a new deploy/env update) takes effect
+		// immediately rather than being pinned by a module-level cache.
+		process.env['ELECTION_API_M2M_TOKEN'] = 'rotated-jwt';
+		expect(getElectionApiToken()).toBe('rotated-jwt');
 	});
 
-	test('accepts a successful mint even when Clerk returns a null expiration', async () => {
-		// `expiration` is nullable in Clerk's type and unused for timing, so a
-		// non-null token must be treated as success — not discarded into cooldown.
-		createToken.mockImplementation(async () => ({
-			token: 'token-no-exp',
-			expiration: null,
-		}));
-
-		await expect(getElectionApiToken()).resolves.toBe('token-no-exp');
-		// Cached and reused: the TTL-derived window is valid despite null expiration.
-		await expect(getElectionApiToken()).resolves.toBe('token-no-exp');
-		expect(createToken).toHaveBeenCalledTimes(1);
-	});
-
-	test('remints when the cached token is fully expired', async () => {
-		__resetElectionApiAuthForTests({
-			cachedToken: 'stale-token',
-			tokenExpiration: Date.now() - 1_000,
-		});
-		__setCreateTokenForTests(createToken);
-
-		await expect(getElectionApiToken()).resolves.toBe('fresh-token');
-		expect(createToken).toHaveBeenCalledTimes(1);
-	});
-
-	test('remints when the cached token is within the 30s renewal buffer', async () => {
-		__resetElectionApiAuthForTests({
-			cachedToken: 'near-expiry-token',
-			tokenExpiration: Date.now() + 10_000,
-		});
-		__setCreateTokenForTests(createToken);
-
-		await expect(getElectionApiToken()).resolves.toBe('fresh-token');
-		expect(createToken).toHaveBeenCalledTimes(1);
-	});
-
-	test('dedupes concurrent calls into a single mint', async () => {
-		let resolveMint!: (value: { token: string; expiration: number }) => void;
-		createToken.mockImplementation(
-			async () =>
-				await new Promise<{ token: string; expiration: number }>(resolve => {
-					resolveMint = resolve;
-				}),
-		);
-
-		const first = getElectionApiToken();
-		const second = getElectionApiToken();
-
-		expect(createToken).toHaveBeenCalledTimes(1);
-
-		resolveMint({ token: 'shared-token', expiration: expirationInSeconds(600) });
-		await expect(Promise.all([first, second])).resolves.toEqual(['shared-token', 'shared-token']);
-		expect(createToken).toHaveBeenCalledTimes(1);
-	});
-
-	test('missing machine secret returns null and logs once across two calls', async () => {
-		delete process.env['GP_MARKETING_MACHINE_SECRET'];
+	test('returns null and logs exactly once when the token is unset', () => {
+		delete process.env['ELECTION_API_M2M_TOKEN'];
 		const errorSpy = spyOn(console, 'error').mockImplementation(() => undefined);
 
-		await expect(getElectionApiToken()).resolves.toBeNull();
-		await expect(getElectionApiToken()).resolves.toBeNull();
+		expect(getElectionApiToken()).toBeNull();
+		expect(getElectionApiToken()).toBeNull();
 
-		expect(createToken).toHaveBeenCalledTimes(0);
-		expect(errorSpy.mock.calls.filter(call => String(call[0]).includes('GP_MARKETING_MACHINE_SECRET'))).toHaveLength(
-			1,
-		);
+		expect(
+			errorSpy.mock.calls.filter((call) => String(call[0]).includes('ELECTION_API_M2M_TOKEN')),
+		).toHaveLength(1);
 
 		errorSpy.mockRestore();
-	});
-
-	test('mint failure returns the still-valid cached token', async () => {
-		__resetElectionApiAuthForTests({
-			cachedToken: 'still-valid',
-			tokenExpiration: Date.now() + 10_000,
-		});
-		__setCreateTokenForTests(createToken);
-		createToken.mockImplementation(async () => {
-			throw new Error('Clerk unavailable');
-		});
-		const errorSpy = spyOn(console, 'error').mockImplementation(() => undefined);
-
-		await expect(getElectionApiToken()).resolves.toBe('still-valid');
-		expect(createToken).toHaveBeenCalledTimes(1);
-
-		errorSpy.mockRestore();
-	});
-
-	test('mint failure enters a cooldown that skips further Clerk calls', async () => {
-		createToken.mockImplementation(async () => {
-			throw new Error('Clerk unavailable');
-		});
-		const errorSpy = spyOn(console, 'error').mockImplementation(() => undefined);
-
-		await expect(getElectionApiToken()).resolves.toBeNull();
-		await expect(getElectionApiToken()).resolves.toBeNull();
-
-		expect(createToken).toHaveBeenCalledTimes(1);
-
-		errorSpy.mockRestore();
-	});
-
-	test('cooldown still serves a usable cached token without reminting', async () => {
-		__resetElectionApiAuthForTests({
-			cachedToken: 'cached-during-cooldown',
-			tokenExpiration: Date.now() + 10_000,
-			mintCooldownUntil: Date.now() + 30_000,
-		});
-		__setCreateTokenForTests(createToken);
-
-		await expect(getElectionApiToken()).resolves.toBe('cached-during-cooldown');
-		expect(createToken).toHaveBeenCalledTimes(0);
-	});
-
-	test('renews on the requested TTL even when Clerk returns a huge expiration (regression: ms double-scale)', async () => {
-		// Reproduces the prod bug: Clerk's `expiration` is milliseconds at runtime,
-		// and the old code did `expiration * 1000`, pushing the cache window ~56k
-		// years out so it never renewed and replayed one JWT long past its real
-		// `exp`. The fix anchors the window to the 3600s TTL, so renewal must still
-		// happen after ~3600s regardless of what `expiration` reports.
-		createToken.mockImplementation(async () => ({
-			token: 'ttl-anchored',
-			expiration: Date.now() * 1000, // ms-shaped; catastrophic if re-scaled
-		}));
-		const start = Date.now();
-		try {
-			setSystemTime(start);
-			await expect(getElectionApiToken()).resolves.toBe('ttl-anchored');
-			expect(createToken).toHaveBeenCalledTimes(1);
-
-			// Just past the 3600s TTL: the token must be re-minted, not replayed.
-			setSystemTime(start + 3_600_001);
-			await expect(getElectionApiToken()).resolves.toBe('ttl-anchored');
-			expect(createToken).toHaveBeenCalledTimes(2);
-		} finally {
-			setSystemTime();
-		}
-	});
-
-	test('reuses the cached token across the full TTL, not just 10 minutes', async () => {
-		// Guards the #1 change (TTL 600 -> 3600): a token minted now must still be
-		// served ~50 minutes later without re-minting, which is what collapses the
-		// fleet-wide mint volume that was tripping Clerk's M2M quota.
-		const start = Date.now();
-		try {
-			setSystemTime(start);
-			await expect(getElectionApiToken()).resolves.toBe('fresh-token');
-			expect(createToken).toHaveBeenCalledTimes(1);
-
-			// 50 minutes in — old 600s TTL would have re-minted ~5 times by now.
-			setSystemTime(start + 50 * 60_000);
-			await expect(getElectionApiToken()).resolves.toBe('fresh-token');
-			expect(createToken).toHaveBeenCalledTimes(1);
-		} finally {
-			setSystemTime();
-		}
-	});
-
-	test('mint failures back off exponentially, so a Clerk outage is not a retry storm', async () => {
-		// #3: cooldown escalates 30s -> 60s (jitter only shortens by <=1/4, so the
-		// first window is <=30s and the second is >=45s — a clean, non-flaky gap).
-		createToken.mockImplementation(async () => {
-			throw new Error('Clerk throttled');
-		});
-		const errorSpy = spyOn(console, 'error').mockImplementation(() => undefined);
-		const start = Date.now();
-		try {
-			setSystemTime(start);
-			// Failure #1 -> cooldown ends within (start, start+30s].
-			await expect(getElectionApiToken()).resolves.toBeNull();
-			expect(createToken).toHaveBeenCalledTimes(1);
-
-			// Still inside the first cooldown: no new Clerk call.
-			setSystemTime(start + 20_000);
-			await expect(getElectionApiToken()).resolves.toBeNull();
-			expect(createToken).toHaveBeenCalledTimes(1);
-
-			// Past the max first cooldown (30s): failure #2 escalates toward ~60s.
-			setSystemTime(start + 31_000);
-			await expect(getElectionApiToken()).resolves.toBeNull();
-			expect(createToken).toHaveBeenCalledTimes(2);
-
-			// 40s after failure #2: a flat 30s policy would have retried, but the
-			// escalated (>=45s) window must still suppress the Clerk call.
-			setSystemTime(start + 71_000);
-			await expect(getElectionApiToken()).resolves.toBeNull();
-			expect(createToken).toHaveBeenCalledTimes(2);
-		} finally {
-			setSystemTime();
-			errorSpy.mockRestore();
-		}
-	});
-});
-
-describe('token pooling across isolates (L2 Data Cache)', () => {
-	const ORIGINAL_RUNTIME = process.env['NEXT_RUNTIME'];
-
-	afterEach(() => {
-		if (ORIGINAL_RUNTIME === undefined) {
-			delete process.env['NEXT_RUNTIME'];
-		} else {
-			process.env['NEXT_RUNTIME'] = ORIGINAL_RUNTIME;
-		}
-		// Restore the real dynamic import of next/cache.
-		__setCacheModuleForTests(null);
-	});
-
-	test('inside the Next runtime, mints through unstable_cache keyed for fleet-wide reuse', async () => {
-		// Inject a next/cache stand-in via the module's own seam rather than
-		// mock.module: the latter is process-global in bun and would strip
-		// revalidateTag/revalidatePath from sibling test files.
-		let capturedKey: unknown;
-		let capturedOptions: { revalidate?: number } | undefined;
-		const unstable_cache = mock(
-			(fn: (...args: unknown[]) => unknown, key: unknown, options: { revalidate?: number }) => {
-				capturedKey = key;
-				capturedOptions = options;
-				return (...args: unknown[]) => fn(...args);
-			},
-		);
-		__setCacheModuleForTests({ unstable_cache } as never);
-		process.env['NEXT_RUNTIME'] = 'nodejs';
-
-		await expect(getElectionApiToken()).resolves.toBe('fresh-token');
-
-		expect(unstable_cache).toHaveBeenCalledTimes(1);
-		// Single fixed key => one shared entry for the whole fleet.
-		expect(capturedKey).toEqual(['election-api-m2m-token']);
-		// Revalidate strictly inside the 3600s TTL so an edge read still has margin.
-		expect(capturedOptions?.revalidate).toBe(3300);
-	});
-
-	test('outside the Next runtime, mints directly without touching the Data Cache', async () => {
-		// mintPooled short-circuits on !NEXT_RUNTIME before the cache seam, so a
-		// direct mint here (one createToken, no cache module consulted) is the proof.
-		delete process.env['NEXT_RUNTIME'];
-
-		await expect(getElectionApiToken()).resolves.toBe('fresh-token');
-
-		expect(createToken).toHaveBeenCalledTimes(1);
 	});
 });
 
 describe('electionApiAuthHeaders', () => {
-	test('returns Authorization when a token is available', async () => {
-		await expect(electionApiAuthHeaders()).resolves.toEqual({
-			Authorization: 'Bearer fresh-token',
-		});
+	test('returns a Bearer Authorization header when the token is set', () => {
+		expect(electionApiAuthHeaders()).toEqual({ Authorization: 'Bearer static-jwt' });
 	});
 
-	test('returns an empty object when no token is available', async () => {
-		delete process.env['GP_MARKETING_MACHINE_SECRET'];
+	test('returns an empty object (fail-soft) when the token is unset', () => {
+		delete process.env['ELECTION_API_M2M_TOKEN'];
 		const errorSpy = spyOn(console, 'error').mockImplementation(() => undefined);
 
-		await expect(electionApiAuthHeaders()).resolves.toEqual({});
+		expect(electionApiAuthHeaders()).toEqual({});
 
 		errorSpy.mockRestore();
 	});

--- a/src/lib/electionApiAuth.ts
+++ b/src/lib/electionApiAuth.ts
@@ -1,281 +1,58 @@
-import { createClerkClient } from '@clerk/backend';
-
 /**
- * Server-only Clerk JWT-format M2M token minter for calling election-api.
+ * Server-only Authorization header for election-api requests.
  *
- * gp-marketing is a caller: it mints tokens with its own machine secret
- * (GP_MARKETING_MACHINE_SECRET); election-api verifies as the recipient
- * (networkless, since the token is a JWT). The gp-marketing machine must be
- * connected to the election-api machine in the Clerk dashboard.
+ * gp-marketing runs on a large, churning fleet of short-lived Vercel isolates.
+ * Minting a Clerk JWT M2M token per isolate — even pooled through the Next Data
+ * Cache — still fanned out enough `createToken` calls to trip Clerk's
+ * token-creation limit, at which point the fail-soft path dropped the
+ * Authorization header and election-api logged "Missing bearer token". JWT M2M
+ * tokens are stateless, so Clerk cannot deduplicate them for us; the only way to
+ * stop the fan-out is to stop minting at request time.
  *
- * NEVER import this from client components — GP_MARKETING_MACHINE_SECRET and
- * CLERK_SECRET_KEY are server-only. All election-api reads already run
- * server-side (Server Components, route handlers, sitemap/build scripts).
+ * So we no longer mint at runtime. A single long-lived JWT — minted out-of-band
+ * for the gp-marketing machine, scoped to election-api (see the rotation
+ * runbook) — is injected as ELECTION_API_M2M_TOKEN. Every isolate reads that one
+ * static token: no minting, no shared cache, no stampede. election-api verifies
+ * the JWT networkless, exactly as before.
  *
- * Deliberately does NOT `import 'server-only'`: this module is also imported by
- * offline CLI scripts (`scripts/validate-election-pages.ts`, and
- * `scripts/generate-sitemaps.ts` via `sitemap-entries.ts`). Under bun/tsx the
- * `server-only` package's default export throws, so the sentinel would break
- * those tools. Client-bundle safety still holds because no Client Component
- * imports this file (and `@clerk/backend` is Node-only).
+ * Server-only: never import this from a Client Component. The value is a bearer
+ * credential and must stay out of the client bundle. (We deliberately do NOT
+ * `import 'server-only'` so the offline CLI scripts that import this module under
+ * bun/tsx — scripts/validate-election-pages.ts, and scripts/generate-sitemaps.ts
+ * via sitemap-entries.ts — keep working; the `server-only` default export throws
+ * outside a bundler.)
  *
- * If the machine secret is unset, minting is skipped and requests go out
- * unauthenticated. That is intentional: it keeps gp-marketing working while
- * election-api is still in observe-only mode. Once ELECTION_API_AUTH_ENFORCED
- * is on, the secret must be present or election-api will return 401.
- *
- * Token pooling across serverless isolates
- * ----------------------------------------
- * JWT-format M2M tokens are stateless: Clerk does NOT deduplicate them
- * server-side (`minRemainingTtlSeconds` only pools opaque tokens), so every
- * `createToken` call mints — and bills for — a brand-new token. On Vercel we
- * run a large, churning fleet of short-lived isolates; if each mints on its own
- * (× a short TTL) we generate thousands of creations, blow past Clerk's quota,
- * and start getting throttled — at which point the fail-soft below drops the
- * Authorization header and election-api logs "Missing bearer token".
- *
- * We therefore pool at two layers:
- *   L1 — per-isolate in-memory cache (this module's `cachedToken`). Free, but
- *        only shared within a single warm isolate.
- *   L2 — cross-isolate cache via the Next Data Cache (`unstable_cache`), which
- *        is shared across all isolates/regions on Vercel. One minted JWT is
- *        reused fleet-wide until it nears expiry, collapsing thousands of mints
- *        into roughly one per revalidate window. This is Clerk's recommended
- *        "pool tokens at the server" pattern, implemented on our side because
- *        JWTs can't be pooled by Clerk.
+ * If ELECTION_API_M2M_TOKEN is unset, requests go out unauthenticated. That is
+ * intentional while election-api is in observe-only mode; once
+ * ELECTION_API_AUTH_ENFORCED=true, the token must be present or election-api
+ * returns 401. Rotate before the token's ~90-day expiry (runbook).
  */
 
-// Renew slightly before expiry so an in-flight request never uses a token that
-// expires mid-call.
-const TOKEN_RENEWAL_BUFFER_MS = 60_000;
-// Long TTL keeps mint volume (and cost) low; the shared cache below reuses each
-// minted token fleet-wide for almost its whole lifetime.
-const TOKEN_TTL_SECONDS = 3600;
-// Cross-isolate cache window. Must stay comfortably inside the JWT's real
-// lifetime so a token read at the edge of the window still has margin over the
-// renewal buffer (3600s life − 300s = 3300s window ⇒ ≥300s remaining).
-const SHARED_TOKEN_REVALIDATE_SECONDS = TOKEN_TTL_SECONDS - 300;
-// Backoff bounds for mint failures (throttling/outage). Exponential with jitter
-// so a fleet-wide Clerk hiccup doesn't turn into a synchronized retry storm.
-const MINT_COOLDOWN_BASE_MS = 30_000;
-const MINT_COOLDOWN_MAX_MS = 300_000;
+// Latched so a misconfigured deploy logs once per process, not once per request.
+let warnedMissingToken = false;
 
-export type CreateM2MToken = (params: {
-	machineSecretKey: string;
-	secondsUntilExpiration: number;
-	tokenFormat?: 'jwt';
-}) => Promise<{ token?: string | null; expiration?: number | null }>;
-
-type ClerkM2MClient = {
-	m2m: {
-		createToken(params: {
-			machineSecretKey: string;
-			secondsUntilExpiration: number;
-			tokenFormat?: 'jwt';
-		}): Promise<{ token?: string | null; expiration?: number | null }>;
-	};
-};
-
-/** A minted token plus the absolute ms timestamp at which it truly expires. */
-type MintedToken = { token: string; expiration: number };
-
-/** Thrown when the machine secret is absent — a config state, not a failure. */
-class MissingMachineSecretError extends Error {}
-
-/** Minimal shape of next/cache we depend on, for the test seam below. */
-type CacheModule = {
-	unstable_cache(
-		fn: () => Promise<MintedToken>,
-		keyParts: string[],
-		options: { revalidate: number },
-	): () => Promise<MintedToken>;
-};
-
-let clerkClient: ClerkM2MClient | null = null;
-let createTokenForTests: CreateM2MToken | null = null;
-// Injected in tests so the L2 path can be exercised without `mock.module`, which
-// is process-global in bun and would strip other next/cache exports (revalidateTag,
-// revalidatePath) that sibling test files import.
-let cacheModuleForTests: CacheModule | null = null;
-
-function getClerkClient(): ClerkM2MClient {
-	if (!clerkClient) {
-		clerkClient = createClerkClient({
-			secretKey: process.env['CLERK_SECRET_KEY'],
-			publishableKey: process.env['CLERK_PUBLISHABLE_KEY'],
-		}) as ClerkM2MClient;
-	}
-	return clerkClient;
-}
-
-async function createToken(params: {
-	machineSecretKey: string;
-	secondsUntilExpiration: number;
-	tokenFormat?: 'jwt';
-}): Promise<{ token?: string | null; expiration?: number | null }> {
-	if (createTokenForTests) return createTokenForTests(params);
-	return getClerkClient().m2m.createToken(params);
-}
-
-let cachedToken: string | null = null;
-let tokenExpiration: number | null = null;
-let pending: Promise<string | null> | null = null;
-let warnedMissingSecret = false;
-let mintCooldownUntil = 0;
-let mintFailureStreak = 0;
-
-/** True when a cached token exists and has not yet reached its real expiry. */
-function isTokenUsable(): boolean {
-	return cachedToken != null && tokenExpiration != null && Date.now() < tokenExpiration;
-}
-
-/** True when there is no usable cached token, or it is within the renewal buffer. */
-function needsRenewal(): boolean {
-	if (!cachedToken || tokenExpiration == null) return true;
-	return Date.now() >= tokenExpiration - TOKEN_RENEWAL_BUFFER_MS;
-}
-
-function usableCachedToken(): string | null {
-	return isTokenUsable() ? cachedToken : null;
-}
-
-/**
- * Exponential backoff (capped) with jitter to avoid synchronized retry storms.
- * The jitter only ever shortens the wait, and by at most a quarter, so each
- * escalated window stays strictly longer than the previous one's maximum.
- */
-function enterMintCooldown(): void {
-	mintFailureStreak += 1;
-	const exponential = MINT_COOLDOWN_BASE_MS * 2 ** (mintFailureStreak - 1);
-	const capped = Math.min(exponential, MINT_COOLDOWN_MAX_MS);
-	const jitter = Math.floor(Math.random() * (capped / 4));
-	mintCooldownUntil = Date.now() + capped - jitter;
-}
-
-/**
- * One real Clerk mint. Throws on any failure so the shared cache never memoizes
- * a bad result and the caller can fall back to the last-good token.
- */
-async function mintFromClerk(): Promise<MintedToken> {
-	const machineSecret = process.env['GP_MARKETING_MACHINE_SECRET'];
-	if (!machineSecret) throw new MissingMachineSecretError();
-
-	const minted = await createToken({
-		machineSecretKey: machineSecret,
-		tokenFormat: 'jwt',
-		secondsUntilExpiration: TOKEN_TTL_SECONDS,
-	});
-	// A successful mint is signalled by a non-null token. Do NOT gate on
-	// `minted.expiration`: it is not read (the window is derived from the TTL),
-	// and Clerk types it as nullable, so treating null as failure would discard
-	// an otherwise-valid token and 401 downstream.
-	if (!minted.token) throw new Error('Clerk M2M token creation returned no token');
-
-	// Anchor the cache window to the TTL we requested, NOT to `minted.expiration`.
-	// The JWT's real `exp` claim is (mint time + secondsUntilExpiration). Clerk's
-	// returned `expiration` field is typed as seconds but is milliseconds at
-	// runtime, so `* 1000` double-scaled it ~56k years out — the cache then never
-	// renewed and replayed one token long past its real `exp`. Deriving from TTL
-	// is unit-agnostic and keeps the window strictly inside the JWT's lifetime.
-	return { token: minted.token, expiration: Date.now() + TOKEN_TTL_SECONDS * 1000 };
-}
-
-/**
- * Mint through the cross-isolate (L2) cache when running inside the Next server
- * runtime; otherwise (CLI scripts, unit tests) mint directly. `unstable_cache`
- * is only valid inside the Next runtime — invoking it elsewhere hangs — so we
- * gate on NEXT_RUNTIME exactly as election-api's fetch cache does.
- */
-async function mintPooled(): Promise<MintedToken> {
-	// Outside the Next runtime, or with no secret to mint from, skip the Data
-	// Cache entirely: there is nothing to pool and mintFromClerk resolves the
-	// direct/error path (throwing MissingMachineSecretError) without a cache hop.
-	if (!process.env['NEXT_RUNTIME'] || !process.env['GP_MARKETING_MACHINE_SECRET']) {
-		return mintFromClerk();
-	}
-
-	const cacheMod =
-		cacheModuleForTests ?? ((await import('next/cache')) as unknown as CacheModule);
-	return cacheMod.unstable_cache(mintFromClerk, ['election-api-m2m-token'], {
-		revalidate: SHARED_TOKEN_REVALIDATE_SECONDS,
-	})();
-}
-
-async function renew(): Promise<string | null> {
-	try {
-		const { token, expiration } = await mintPooled();
-		cachedToken = token;
-		tokenExpiration = expiration;
-		mintCooldownUntil = 0;
-		mintFailureStreak = 0;
-		return token;
-	} catch (err) {
-		if (err instanceof MissingMachineSecretError) {
-			if (!warnedMissingSecret) {
-				warnedMissingSecret = true;
-				console.error(
-					'[electionApiAuth] GP_MARKETING_MACHINE_SECRET is not set; election-api requests will be unauthenticated',
-				);
-			}
-			// Config state, not a transient failure: no cooldown/backoff.
-			return usableCachedToken();
+/** The static election-api M2M bearer, or null if unconfigured (warns once). */
+export function getElectionApiToken(): string | null {
+	const token = process.env['ELECTION_API_M2M_TOKEN'];
+	if (!token) {
+		if (!warnedMissingToken) {
+			warnedMissingToken = true;
+			console.error(
+				'[electionApiAuth] ELECTION_API_M2M_TOKEN is not set; election-api requests will be unauthenticated',
+			);
 		}
-		// Transient (throttle/outage): back off, but keep serving the last-good
-		// token until its real expiry so a Clerk hiccup never drops auth while a
-		// valid token is still in hand.
-		enterMintCooldown();
-		console.error(
-			'[electionApiAuth] failed to mint M2M token',
-			err instanceof Error ? err.message : String(err),
-		);
-		return usableCachedToken();
+		return null;
 	}
-}
-
-/** Returns a cached M2M token, minting/renewing as needed. Null if unavailable. */
-export async function getElectionApiToken(): Promise<string | null> {
-	if (!needsRenewal()) return cachedToken;
-	if (Date.now() < mintCooldownUntil) return usableCachedToken();
-	if (pending) return pending;
-	const promise = renew();
-	pending = promise;
-	try {
-		return await promise;
-	} finally {
-		if (pending === promise) pending = null;
-	}
+	return token;
 }
 
 /** Authorization header for an election-api request (empty if no token). */
-export async function electionApiAuthHeaders(): Promise<Record<string, string>> {
-	const token = await getElectionApiToken();
+export function electionApiAuthHeaders(): Record<string, string> {
+	const token = getElectionApiToken();
 	return token ? { Authorization: `Bearer ${token}` } : {};
 }
 
-/** Test-only: inject a createToken implementation (null restores Clerk). */
-export function __setCreateTokenForTests(fn: CreateM2MToken | null): void {
-	createTokenForTests = fn;
-}
-
-/** Test-only: inject a next/cache stand-in (null restores the real dynamic import). */
-export function __setCacheModuleForTests(mod: CacheModule | null): void {
-	cacheModuleForTests = mod;
-}
-
-/** Test-only: reset module cache / cooldown state (and optionally seed a token). */
-export function __resetElectionApiAuthForTests(seed?: {
-	cachedToken?: string | null;
-	tokenExpiration?: number | null;
-	mintCooldownUntil?: number;
-	warnedMissingSecret?: boolean;
-}): void {
-	cachedToken = seed?.cachedToken ?? null;
-	tokenExpiration = seed?.tokenExpiration ?? null;
-	mintCooldownUntil = seed?.mintCooldownUntil ?? 0;
-	warnedMissingSecret = seed?.warnedMissingSecret ?? false;
-	mintFailureStreak = 0;
-	pending = null;
-	clerkClient = null;
-	createTokenForTests = null;
-	cacheModuleForTests = null;
+/** Test-only: reset the warn-once latch (optionally pre-latched to stay quiet). */
+export function __resetElectionApiAuthForTests(seed?: { warnedMissingToken?: boolean }): void {
+	warnedMissingToken = seed?.warnedMissingToken ?? false;
 }

--- a/src/lib/electionApiFetch.test.ts
+++ b/src/lib/electionApiFetch.test.ts
@@ -20,9 +20,12 @@ let fetchCalls: number;
 beforeEach(() => {
 	resetNextCacheMock();
 	fetchCalls = 0;
-	// Fail-soft auth path: unset the static token so run() sends no bearer.
-	delete process.env['ELECTION_API_M2M_TOKEN'];
-	__resetElectionApiAuthForTests({ warnedMissingToken: true });
+	// Authenticated by default — this is the representative production path: the
+	// static token is present, so run() attaches the bearer. Tests that assert cache
+	// behavior are header-agnostic; the forwarding itself is asserted explicitly in
+	// the "forwards the static M2M token" test below.
+	process.env['ELECTION_API_M2M_TOKEN'] = 'test-m2m-token';
+	__resetElectionApiAuthForTests();
 	globalThis.fetch = (async () => {
 		fetchCalls += 1;
 		return new Response(JSON.stringify(OK_BODY), {

--- a/src/lib/electionApiFetch.test.ts
+++ b/src/lib/electionApiFetch.test.ts
@@ -12,7 +12,7 @@ const ELECTION_URL = 'https://election-api.goodparty.org/v1/positions/1';
 const OK_BODY = { hello: 'world' };
 
 const originalFetch = globalThis.fetch;
-const ORIGINAL_MACHINE_SECRET = process.env['GP_MARKETING_MACHINE_SECRET'];
+const ORIGINAL_M2M_TOKEN = process.env['ELECTION_API_M2M_TOKEN'];
 const ORIGINAL_RUNTIME = process.env['NEXT_RUNTIME'];
 
 let fetchCalls: number;
@@ -20,9 +20,9 @@ let fetchCalls: number;
 beforeEach(() => {
 	resetNextCacheMock();
 	fetchCalls = 0;
-	// Fail-soft auth path: unset secret so run() never touches Clerk.
-	delete process.env['GP_MARKETING_MACHINE_SECRET'];
-	__resetElectionApiAuthForTests({ warnedMissingSecret: true });
+	// Fail-soft auth path: unset the static token so run() sends no bearer.
+	delete process.env['ELECTION_API_M2M_TOKEN'];
+	__resetElectionApiAuthForTests({ warnedMissingToken: true });
 	globalThis.fetch = (async () => {
 		fetchCalls += 1;
 		return new Response(JSON.stringify(OK_BODY), {
@@ -33,10 +33,10 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-	if (ORIGINAL_MACHINE_SECRET === undefined) {
-		delete process.env['GP_MARKETING_MACHINE_SECRET'];
+	if (ORIGINAL_M2M_TOKEN === undefined) {
+		delete process.env['ELECTION_API_M2M_TOKEN'];
 	} else {
-		process.env['GP_MARKETING_MACHINE_SECRET'] = ORIGINAL_MACHINE_SECRET;
+		process.env['ELECTION_API_M2M_TOKEN'] = ORIGINAL_M2M_TOKEN;
 	}
 	if (ORIGINAL_RUNTIME === undefined) {
 		delete process.env['NEXT_RUNTIME'];

--- a/src/lib/electionApiFetch.test.ts
+++ b/src/lib/electionApiFetch.test.ts
@@ -105,4 +105,28 @@ describe('fetchElectionApiJsonCached', () => {
 
 		await expect(promise).rejects.toMatchObject({ name: 'ElectionApiError', status });
 	});
+
+	test('forwards the static M2M token to fetch as a Bearer Authorization header', async () => {
+		// The whole point of this module: prove the token flows into the request.
+		// Without this, deleting the `headers` argument in electionApiFetch would
+		// leave every other test green (they all run the no-token fail-soft path).
+		delete process.env['NEXT_RUNTIME']; // direct fetch path, no cache wrapper
+		process.env['ELECTION_API_M2M_TOKEN'] = 'static-jwt-abc';
+		__resetElectionApiAuthForTests();
+
+		let capturedHeaders: HeadersInit | undefined;
+		globalThis.fetch = (async (_url: RequestInfo | URL, init?: RequestInit) => {
+			fetchCalls += 1;
+			capturedHeaders = init?.headers;
+			return new Response(JSON.stringify(OK_BODY), {
+				status: 200,
+				headers: { 'content-type': 'application/json' },
+			});
+		}) as unknown as typeof fetch;
+
+		await fetchElectionApiJsonCached(ELECTION_URL);
+
+		expect(fetchCalls).toBe(1);
+		expect(capturedHeaders).toEqual({ Authorization: 'Bearer static-jwt-abc' });
+	});
 });

--- a/src/lib/electionApiFetch.ts
+++ b/src/lib/electionApiFetch.ts
@@ -26,11 +26,10 @@ export class ElectionApiError extends Error {
  * Authenticated election-api GET, keyed only on the URL so the shared 1h Data
  * Cache hits across isolates.
  *
- * The M2M Authorization header is acquired OUTSIDE this URL cache. It has its
- * own cross-isolate pool (see electionApiAuth), so this is cheap on the hot path
- * (an in-memory hit) and only mints on the rare renewal — and keeping it out of
- * the wrapped function avoids nesting unstable_cache calls. fetch itself uses
- * cache:'no-store', so the token never enters the URL cache key regardless.
+ * The M2M Authorization header is acquired OUTSIDE this URL cache: it is a static
+ * env-injected token (see electionApiAuth), so reading it is free, and keeping it
+ * out of the wrapped function means the bearer never enters the URL cache key
+ * (fetch also uses cache:'no-store').
  *
  * unstable_cache only works inside the Next server runtime. In CLI scripts (bun/tsx)
  * and unit tests the module still imports, but invoking unstable_cache outside the
@@ -42,7 +41,7 @@ export async function fetchElectionApiJsonCached(
 	url: string,
 	tags?: readonly string[],
 ): Promise<ElectionApiJsonResult> {
-	const authHeaders = await electionApiAuthHeaders();
+	const authHeaders = electionApiAuthHeaders();
 	const run = async (): Promise<ElectionApiJsonResult> => {
 		const res = await fetch(url, { headers: authHeaders, cache: 'no-store' });
 		if (res.status === 404) return { status: 404, ok: false, json: null };

--- a/src/lib/electionsApi.test.ts
+++ b/src/lib/electionsApi.test.ts
@@ -15,7 +15,7 @@ type FetchMockResponse = {
 };
 
 const originalFetch = globalThis.fetch;
-const ORIGINAL_MACHINE_SECRET = process.env['GP_MARKETING_MACHINE_SECRET'];
+const ORIGINAL_M2M_TOKEN = process.env['ELECTION_API_M2M_TOKEN'];
 
 function withFetchMock(responses: FetchMockResponse[]) {
 	globalThis.fetch = (async (input: RequestInfo | URL) => {
@@ -36,19 +36,19 @@ function slugs(items: PlaceItem[]): string[] {
 }
 
 beforeEach(() => {
-	// Fail-soft path: unset secret so election-api reads go out unauthenticated
-	// without touching Clerk (and without mock.module, which can poison sibling tests).
-	delete process.env['GP_MARKETING_MACHINE_SECRET'];
+	// Fail-soft path: unset the static token so election-api reads go out
+	// unauthenticated (these tests don't assert on auth headers).
+	delete process.env['ELECTION_API_M2M_TOKEN'];
 	// Skip the warn-once log — these tests intentionally exercise the fail-soft path.
-	__resetElectionApiAuthForTests({ warnedMissingSecret: true });
+	__resetElectionApiAuthForTests({ warnedMissingToken: true });
 	globalThis.fetch = originalFetch;
 });
 
 afterEach(() => {
-	if (ORIGINAL_MACHINE_SECRET === undefined) {
-		delete process.env['GP_MARKETING_MACHINE_SECRET'];
+	if (ORIGINAL_M2M_TOKEN === undefined) {
+		delete process.env['ELECTION_API_M2M_TOKEN'];
 	} else {
-		process.env['GP_MARKETING_MACHINE_SECRET'] = ORIGINAL_MACHINE_SECRET;
+		process.env['ELECTION_API_M2M_TOKEN'] = ORIGINAL_M2M_TOKEN;
 	}
 	__resetElectionApiAuthForTests();
 	globalThis.fetch = originalFetch;


### PR DESCRIPTION
## Why

gp-marketing runs on a large, churning fleet of short-lived Vercel isolates. Our previous approach minted a Clerk **JWT** M2M token at request time and pooled it through the Next Data Cache (#217). But JWT M2M tokens are **stateless** — Clerk cannot deduplicate them — so cold isolates kept calling `createToken` on their first request. As traffic ramped, that fan-out tripped Clerk's token-creation limit; the fail-soft path then dropped the `Authorization` header and election-api logged a rising wall of **`Missing bearer token`** (places / candidacies / races). The pooling in #217 reduced but did **not** eliminate the stampede.

The only way to stop request-time minting is to not mint at request time.

## What

- Replace the minting / pooling / exponential-backoff machinery in `electionApiAuth.ts` with a single read of a static **`ELECTION_API_M2M_TOKEN`** env var (−567 / +89 lines).
  - The token is a long-lived (90-day) Clerk **JWT** minted out-of-band for the **gp-marketing** machine, scoped to **election-api**. election-api verifies it **networkless** — the exact `clerkClient.m2m.verify(...)` path already used for gp-api's tokens — so **election-api needs no change**.
  - Every isolate reads one static token: **no minting, no shared cache, no stampede.**
- Fail-soft preserved: if the var is unset, requests go out unauthenticated (fine while election-api is observe-only; logs a single warn, not per-request).
- `electionApiAuthHeaders()` / `getElectionApiToken()` are now synchronous; the two callers (`electionApiFetch.ts`, `scripts/validate-election-pages.ts`) drop their `await`.

## Verification (proven end-to-end before shipping)

- Minted a 90-day JWT from the **prod** gp-marketing machine and verified it through election-api's exact guard call (`m2m.verify({ token, machineSecretKey: ELECTION_API_MACHINE_SECRET })`) → `revoked:false, expired:false`, subject = gp-marketing machine. Same round-trip proven on the dev instance.
- Confirmed the AWS `ELECTION_API_MACHINE_SECRET` (prod) matches Clerk exactly — no drift.

## Secrets (already set)

`ELECTION_API_M2M_TOKEN` set in Vercel **Production + Preview (Sensitive)** and **Development**. All three Vercel environments target prod election-api (`ELECTIONS_API_BASE_URL` is unset everywhere → defaults to `election-api.goodparty.org`), so all three use the prod token.

## Rollout / rotation

- election-api stays **observe-only** (`ELECTION_API_AUTH_ENFORCED` unset). This change is safe to deploy without flipping enforcement.
- After deploy: re-soak `places` / `candidacies` / `races` → `Missing bearer` should drain to ~0.
- **Rotation:** the token expires in ~90 days. Mint a new one and update the Vercel var before then (runbook to follow). Token is scoped + revocable via Clerk if needed.

## Test plan

- [x] `bun run typecheck` — 0 errors
- [x] `bun run lint` — exit 0
- [x] `bun run test:logic` — 650 pass / 0 fail
- [ ] Post-deploy soak on prod election-api logs

Made with [Cursor](https://cursor.com)