### PR TITLE
fix(people): stop telling a candidate we'll notify them about themselves

### DIFF
--- a/src/components/people/PersonClaimCTABand.tsx
+++ b/src/components/people/PersonClaimCTABand.tsx
@@ -27,6 +27,15 @@ export type PersonClaimCTABandProps = {
  * that posts to the same claim-request endpoint as the claim modal. Rendered in
  * the person `person-cta` section slot (below the content well, above the
  * elections index) in place of the claimed "Join the movement" CTA.
+ *
+ * Carries NO marketing-consent checkbox, unlike the claim modal, which is what
+ * the frame specifies (band 1922:92593 has name + email + submit; the modal's
+ * dialog 1901:51851 adds the opt-in). The two forms hit one endpoint but are
+ * different acts: the modal asks a visitor to opt in while notifying someone
+ * else, whereas this band is the person themselves entering their own address to
+ * claim their page. The proxy therefore records `marketingConsent: false` for
+ * every submission from here — absent an opt-in that is the accurate value, not
+ * a dropped field.
  */
 export function PersonClaimCTABand({ personId, displayName, isRunning }: PersonClaimCTABandProps) {
 	const [isSuccess, setIsSuccess] = useState(false);
@@ -73,7 +82,7 @@ export function PersonClaimCTABand({ personId, displayName, isRunning }: PersonC
 							aria-live='polite'
 						>
 							<Text styleType='body-2'>
-								Thanks — we&apos;ll let {displayName} know their GoodParty.org profile is ready to claim.
+								Thanks — we&apos;ll be in touch at that address about claiming your profile.
 							</Text>
 						</div>
 					) : (


### PR DESCRIPTION
## The bug

The claim band on unclaimed profiles asks **"Are you [Name]? Complete your profile now."** and collects that person's own email. On submit it answered:

> Thanks — we'll let [Name] know their GoodParty.org profile is ready to claim.

So a candidate who filled in their own address was told we'd notify them about their own profile. The string was shared with the claim modal, where it reads correctly because it sits under **"Not [Name]?"** — so only the band's copy changes.

New copy: *"Thanks — we'll be in touch at that address about claiming your profile."*

## Also: a comment recording why the band has no consent checkbox

While tracing this I checked the frames, because the band's missing opt-in looks like a dropped field. It isn't — the design is deliberate:

| | frame | fields |
|---|---|---|
| band (owner-facing) | `1922:92593` | name, email, submit |
| modal dialog (visitor-facing) | `1901:51851` | name, email, **consent opt-in**, submit |

The two forms post to the same `claim-request` endpoint but are different acts: the modal asks a visitor to opt in while notifying *someone else*, whereas the band is the person themselves entering their own address to claim their page. So the proxy recording `marketingConsent: false` for band submissions is the accurate value, not a bug. Comment added so this doesn't get "fixed" into a divergence later.

No behavior change beyond the one string.

## Known gap, not addressed here

Nothing in `gp-api` reads `ProfileClaimRequest` — the only references are the controller, its schema, the rate-limit guard, and tests. Both forms therefore record a row and send nothing, so "we'll be in touch" is only true once something consumes that table. Flagging rather than fixing, since building the notification path is its own piece of work.

## Verification

`bun run typecheck` and `bun run lint` clean. Confirmed the two remaining uses of the old string are both in `ClaimProfileModal`, where the visitor-facing wording is correct.

Made with [Cursor](https://cursor.com)