### PR TITLE
fix(people): give the claim forms stable ids for HubSpot form collection

### DIFF
--- a/src/components/people/ClaimProfileModal.tsx
+++ b/src/components/people/ClaimProfileModal.tsx
@@ -31,7 +31,12 @@ const NOTIFY_FORM_ID = 'person-claim-notify';
 
 type NotifyValues = { firstname: string; email: string; marketingConsent: boolean };
 
-function NotifyForm({ personId, displayName }: { personId: string; displayName: string }) {
+/**
+ * The "Not [Name]?" form in the dialog body. Exported so the HubSpot id contract
+ * can be asserted directly (see claimFormIds.test.tsx) without standing up
+ * Radix's dialog, whose event delegation does not survive JSDOM.
+ */
+export function NotifyForm({ personId, displayName }: { personId: string; displayName: string }) {
 	const [isSuccess, setIsSuccess] = useState(false);
 	const {
 		register,

--- a/src/components/people/ClaimProfileModal.tsx
+++ b/src/components/people/ClaimProfileModal.tsx
@@ -13,6 +13,22 @@ import { Text } from '~/ui/Text';
 
 const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
+/**
+ * Stable identity for HubSpot's non-HubSpot ("collected") forms tool. DO NOT
+ * rename, and do not remove it in favour of styling: the site-wide HubSpot
+ * tracking script keys a collected form on the `<form>` tag's id, falling back to
+ * its class list when there is no id. Without this the form was filed under
+ * `.flex, .w-full, .flex-col, .gap-4, .text-left`, so any change to its spacing
+ * or width silently created a NEW form in HubSpot and orphaned the marketing
+ * workflows attached to the old one — with no error anywhere.
+ *
+ * Distinct from {@link PersonClaimCTABand}'s id on purpose. HubSpot groups
+ * submissions by this value, and the two forms are different intents that want
+ * different follow-up: this one is a visitor asking us to nudge someone else,
+ * that one is the person claiming their own page.
+ */
+const NOTIFY_FORM_ID = 'person-claim-notify';
+
 type NotifyValues = { firstname: string; email: string; marketingConsent: boolean };
 
 function NotifyForm({ personId, displayName }: { personId: string; displayName: string }) {
@@ -60,6 +76,7 @@ function NotifyForm({ personId, displayName }: { personId: string; displayName: 
 
 	return (
 		<form
+			id={NOTIFY_FORM_ID}
 			className='flex w-full flex-col gap-4 text-left'
 			onSubmit={(e) => void handleSubmit(onSubmit)(e)}
 			noValidate

--- a/src/components/people/PersonClaimCTABand.tsx
+++ b/src/components/people/PersonClaimCTABand.tsx
@@ -11,6 +11,14 @@ import { Text } from '~/ui/Text';
 
 const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
+/**
+ * Stable identity for HubSpot's non-HubSpot ("collected") forms tool — see the
+ * matching constant in ClaimProfileModal for why this must not be renamed or
+ * dropped. Deliberately different from that one so HubSpot files owner claims
+ * separately from visitor nudges; they warrant different follow-up.
+ */
+const CLAIM_FORM_ID = 'person-claim-owner';
+
 type NotifyValues = { firstname: string; email: string };
 
 export type PersonClaimCTABandProps = {
@@ -87,6 +95,7 @@ export function PersonClaimCTABand({ personId, displayName, isRunning }: PersonC
 						</div>
 					) : (
 						<form
+							id={CLAIM_FORM_ID}
 							className='flex w-full max-w-md flex-col gap-4 text-left'
 							onSubmit={(e) => void handleSubmit(onSubmit)(e)}
 							noValidate

--- a/src/components/people/claimFormIds.test.tsx
+++ b/src/components/people/claimFormIds.test.tsx
@@ -14,8 +14,11 @@ import { createRoot, type Root } from 'react-dom/client';
  * marketing workflow was attached to the old one. Nothing throws when that
  * happens, on the site or in HubSpot, so CI is the only place it can be caught.
  *
- * Analytics is deliberately left unmocked: these cases only mount and open, never
- * submit or click through, so no tracking call is reached.
+ * These mount the form components directly rather than driving the dialog open.
+ * Radix's click delegation does not fire under JSDOM once this file shares a
+ * process with the rest of the suite (which is how CI runs it, since bun 1.2.23
+ * ignores the `--path-ignore-patterns` split between the logic and DOM suites).
+ * The id lives on the form element either way, so the dialog buys nothing here.
  */
 
 const DOM_GLOBALS = [
@@ -51,9 +54,8 @@ beforeEach(() => {
 	globalThis.navigator = window.navigator;
 	globalThis.getComputedStyle = window.getComputedStyle.bind(window);
 
-	// These have to come from the JSDOM realm rather than Bun's natives. Radix's
-	// dialog constructs events and walks the tree using the *global* constructors,
-	// and JSDOM rejects foreign instances ("parameter 1 is not of type 'Event'").
+	// These have to come from the JSDOM realm rather than Bun's natives, which
+	// JSDOM rejects as foreign ("parameter 1 is not of type 'Event'").
 	for (const name of DOM_GLOBALS) {
 		(globalThis as Record<string, unknown>)[name] = (window as unknown as Record<string, unknown>)[name];
 	}
@@ -62,8 +64,6 @@ beforeEach(() => {
 });
 
 afterEach(async () => {
-	// Unmount inside act so the dialog's dismissable-layer teardown settles here
-	// rather than warning after the test has finished.
 	if (root) {
 		await act(async () => {
 			root.unmount();
@@ -82,17 +82,14 @@ async function render(element: React.ReactElement) {
 	});
 }
 
+const bandProps = { personId: 'person-1', displayName: 'Example Person', isRunning: true };
+const notifyProps = { personId: 'person-1', displayName: 'Example Person' };
+
 describe('claim form HubSpot ids', () => {
 	test('PersonClaimCTABand renders form#person-claim-owner', async () => {
 		const { PersonClaimCTABand } = await import('./PersonClaimCTABand');
 
-		await render(
-			React.createElement(PersonClaimCTABand, {
-				personId: 'person-1',
-				displayName: 'Example Person',
-				isRunning: true,
-			}),
-		);
+		await render(React.createElement(PersonClaimCTABand, bandProps));
 
 		const form = document.querySelector('form#person-claim-owner');
 		expect(form).not.toBeNull();
@@ -101,30 +98,10 @@ describe('claim form HubSpot ids', () => {
 		expect(form?.querySelector('input[name="email"]')).not.toBeNull();
 	});
 
-	test('ClaimProfileModal renders form#person-claim-notify once opened', async () => {
-		const { ClaimProfileModal } = await import('./ClaimProfileModal');
+	test('the claim dialog notify form renders form#person-claim-notify', async () => {
+		const { NotifyForm } = await import('./ClaimProfileModal');
 
-		await render(
-			React.createElement(ClaimProfileModal, {
-				personId: 'person-1',
-				displayName: 'Example Person',
-				persona: 'candidate',
-				variant: 'voter-card',
-			}),
-		);
-
-		// The notify form only exists once the dialog is open.
-		expect(document.querySelector('form#person-claim-notify')).toBeNull();
-
-		const trigger = [...document.querySelectorAll('button')].find(b => b.textContent?.includes('Notify'));
-		expect(trigger).toBeDefined();
-
-		await act(async () => {
-			trigger!.click();
-			await new Promise<void>(resolve => {
-				window.setTimeout(resolve, 0);
-			});
-		});
+		await render(React.createElement(NotifyForm, notifyProps));
 
 		const form = document.querySelector('form#person-claim-notify');
 		expect(form).not.toBeNull();
@@ -133,39 +110,22 @@ describe('claim form HubSpot ids', () => {
 	});
 
 	test('the two ids differ, so HubSpot files owner claims apart from visitor nudges', async () => {
-		const [{ PersonClaimCTABand }, { ClaimProfileModal }] = await Promise.all([
+		const [{ PersonClaimCTABand }, { NotifyForm }] = await Promise.all([
 			import('./PersonClaimCTABand'),
 			import('./ClaimProfileModal'),
 		]);
 
+		// Both are reachable on an unclaimed empowered profile. Sharing an id would
+		// collapse the two intents into one HubSpot form, besides being invalid markup.
 		await render(
 			React.createElement(
 				React.Fragment,
 				null,
-				React.createElement(PersonClaimCTABand, {
-					personId: 'person-1',
-					displayName: 'Example Person',
-					isRunning: true,
-				}),
-				React.createElement(ClaimProfileModal, {
-					personId: 'person-1',
-					displayName: 'Example Person',
-					persona: 'candidate',
-					variant: 'voter-card',
-				}),
+				React.createElement(PersonClaimCTABand, bandProps),
+				React.createElement(NotifyForm, notifyProps),
 			),
 		);
 
-		const trigger = [...document.querySelectorAll('button')].find(b => b.textContent?.includes('Notify'));
-		await act(async () => {
-			trigger!.click();
-			await new Promise<void>(resolve => {
-				window.setTimeout(resolve, 0);
-			});
-		});
-
-		// Both forms coexist on an unclaimed empowered profile; duplicate ids would
-		// collapse the two intents into one HubSpot form (and be invalid markup).
 		const ids = [...document.querySelectorAll('form')].map(f => f.id);
 		expect(ids).toContain('person-claim-owner');
 		expect(ids).toContain('person-claim-notify');

--- a/src/components/people/claimFormIds.test.tsx
+++ b/src/components/people/claimFormIds.test.tsx
@@ -58,13 +58,6 @@ beforeEach(() => {
 		(globalThis as Record<string, unknown>)[name] = (window as unknown as Record<string, unknown>)[name];
 	}
 
-	// Not implemented by JSDOM, and Radix's scroll lock expects it.
-	globalThis.ResizeObserver = class {
-		observe() {}
-		unobserve() {}
-		disconnect() {}
-	} as unknown as typeof ResizeObserver;
-
 	(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 });
 

--- a/src/components/people/claimFormIds.test.tsx
+++ b/src/components/people/claimFormIds.test.tsx
@@ -1,0 +1,181 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { JSDOM } from 'jsdom';
+import * as React from 'react';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+/**
+ * Guards the `<form id>` on both person-profile claim forms.
+ *
+ * These ids are an external contract with HubSpot, not decoration. The site-wide
+ * tracking script collects submissions via the non-HubSpot forms tool, which keys
+ * a form on its id and silently falls back to the class list when the id is
+ * absent — filing submissions under a brand-new form and orphaning whatever
+ * marketing workflow was attached to the old one. Nothing throws when that
+ * happens, on the site or in HubSpot, so CI is the only place it can be caught.
+ *
+ * Analytics is deliberately left unmocked: these cases only mount and open, never
+ * submit or click through, so no tracking call is reached.
+ */
+
+const DOM_GLOBALS = [
+	'Node',
+	'NodeFilter',
+	'Element',
+	'HTMLElement',
+	'HTMLInputElement',
+	'HTMLButtonElement',
+	'HTMLFormElement',
+	'DocumentFragment',
+	'DOMRect',
+	'Event',
+	'CustomEvent',
+	'MouseEvent',
+	'KeyboardEvent',
+	'FocusEvent',
+	'MutationObserver',
+] as const;
+
+let dom: JSDOM;
+let root: Root;
+
+beforeEach(() => {
+	dom = new JSDOM('<!DOCTYPE html><html><body><div id="root"></div></body></html>', {
+		url: 'http://localhost/people/example-person',
+		pretendToBeVisual: true,
+	});
+	const { window } = dom;
+
+	globalThis.window = window as unknown as Window & typeof globalThis;
+	globalThis.document = window.document;
+	globalThis.navigator = window.navigator;
+	globalThis.getComputedStyle = window.getComputedStyle.bind(window);
+
+	// These have to come from the JSDOM realm rather than Bun's natives. Radix's
+	// dialog constructs events and walks the tree using the *global* constructors,
+	// and JSDOM rejects foreign instances ("parameter 1 is not of type 'Event'").
+	for (const name of DOM_GLOBALS) {
+		(globalThis as Record<string, unknown>)[name] = (window as unknown as Record<string, unknown>)[name];
+	}
+
+	// Not implemented by JSDOM, and Radix's scroll lock expects it.
+	globalThis.ResizeObserver = class {
+		observe() {}
+		unobserve() {}
+		disconnect() {}
+	} as unknown as typeof ResizeObserver;
+
+	(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterEach(async () => {
+	// Unmount inside act so the dialog's dismissable-layer teardown settles here
+	// rather than warning after the test has finished.
+	if (root) {
+		await act(async () => {
+			root.unmount();
+		});
+	}
+	dom.window.close();
+});
+
+async function render(element: React.ReactElement) {
+	await act(async () => {
+		root = createRoot(document.getElementById('root')!);
+		root.render(element);
+		await new Promise<void>(resolve => {
+			window.setTimeout(resolve, 0);
+		});
+	});
+}
+
+describe('claim form HubSpot ids', () => {
+	test('PersonClaimCTABand renders form#person-claim-owner', async () => {
+		const { PersonClaimCTABand } = await import('./PersonClaimCTABand');
+
+		await render(
+			React.createElement(PersonClaimCTABand, {
+				personId: 'person-1',
+				displayName: 'Example Person',
+				isRunning: true,
+			}),
+		);
+
+		const form = document.querySelector('form#person-claim-owner');
+		expect(form).not.toBeNull();
+		// Field names are what HubSpot maps onto contact properties.
+		expect(form?.querySelector('input[name="firstname"]')).not.toBeNull();
+		expect(form?.querySelector('input[name="email"]')).not.toBeNull();
+	});
+
+	test('ClaimProfileModal renders form#person-claim-notify once opened', async () => {
+		const { ClaimProfileModal } = await import('./ClaimProfileModal');
+
+		await render(
+			React.createElement(ClaimProfileModal, {
+				personId: 'person-1',
+				displayName: 'Example Person',
+				persona: 'candidate',
+				variant: 'voter-card',
+			}),
+		);
+
+		// The notify form only exists once the dialog is open.
+		expect(document.querySelector('form#person-claim-notify')).toBeNull();
+
+		const trigger = [...document.querySelectorAll('button')].find(b => b.textContent?.includes('Notify'));
+		expect(trigger).toBeDefined();
+
+		await act(async () => {
+			trigger!.click();
+			await new Promise<void>(resolve => {
+				window.setTimeout(resolve, 0);
+			});
+		});
+
+		const form = document.querySelector('form#person-claim-notify');
+		expect(form).not.toBeNull();
+		expect(form?.querySelector('input[name="firstname"]')).not.toBeNull();
+		expect(form?.querySelector('input[name="email"]')).not.toBeNull();
+	});
+
+	test('the two ids differ, so HubSpot files owner claims apart from visitor nudges', async () => {
+		const [{ PersonClaimCTABand }, { ClaimProfileModal }] = await Promise.all([
+			import('./PersonClaimCTABand'),
+			import('./ClaimProfileModal'),
+		]);
+
+		await render(
+			React.createElement(
+				React.Fragment,
+				null,
+				React.createElement(PersonClaimCTABand, {
+					personId: 'person-1',
+					displayName: 'Example Person',
+					isRunning: true,
+				}),
+				React.createElement(ClaimProfileModal, {
+					personId: 'person-1',
+					displayName: 'Example Person',
+					persona: 'candidate',
+					variant: 'voter-card',
+				}),
+			),
+		);
+
+		const trigger = [...document.querySelectorAll('button')].find(b => b.textContent?.includes('Notify'));
+		await act(async () => {
+			trigger!.click();
+			await new Promise<void>(resolve => {
+				window.setTimeout(resolve, 0);
+			});
+		});
+
+		// Both forms coexist on an unclaimed empowered profile; duplicate ids would
+		// collapse the two intents into one HubSpot form (and be invalid markup).
+		const ids = [...document.querySelectorAll('form')].map(f => f.id);
+		expect(ids).toContain('person-claim-owner');
+		expect(ids).toContain('person-claim-notify');
+		expect(new Set(ids).size).toBe(ids.length);
+	});
+});


### PR DESCRIPTION
## Why

HubSpot has been collecting submissions from our claim forms all along — via the non-HubSpot ("collected") forms tool, not through any code we wrote. The site-wide tracking script (portal `21589597`, `layout.tsx`) picks them up automatically.

That tool keys a form on the `<form>` tag's **id**, falling back to its **class list** when there is no id. Neither form had an id, so the notify form is filed in HubSpot as:

```
.flex, .w-full, .flex-col, .gap-4, .text-left
```

Which means marketing automation is currently a hostage of styling. Any change to that form's spacing or width mints a **new** form in HubSpot and silently orphans every workflow attached to the old one — no error, submissions just stop arriving where anyone is watching. Renaming in the HubSpot UI isn't a safe workaround either; it's [known](https://community.hubspot.com/t/non-hubspot-forms-rename-issue/125355) to file subsequent submissions under a numbered variant.

## What

| form | new id | intent |
|---|---|---|
| `PersonClaimCTABand` | `person-claim-owner` | the person claiming their own page |
| `ClaimProfileModal` notify form | `person-claim-notify` | a visitor asking us to nudge someone else |

Deliberately different values: HubSpot groups submissions by this id, and these two want different follow-up. They were already landing as separate entries anyway (the band's class list carries an extra `max-w-md`), just under names nobody could recognise.

## For whoever builds the workflows

This **changes the collected-form identity**, so both show up in HubSpot as new entries once it deploys. Build automation against `#person-claim-owner` and `#person-claim-notify`; the class-named entry stays as history.

## Two things this does NOT fix

**Consent isn't honored.** The scraper captures the email on submit regardless of our checkbox, and collected-form fields only map to single-line text properties — so a checkbox can't map to a consent property at all. Someone who unchecks the opt-in still becomes a contact, and the band has no consent field by design (per Figma `1922:92593`). Flagged for a policy call, not fixed here.

**Our backend still notifies nobody.** `gp-api` writes a `ProfileClaimRequest` row and nothing reads it. The HubSpot path is currently the only thing that does anything with these submissions.

## Verification

Measured the live DOM on an unclaimed profile, where both forms render together:

```
person-claim-owner   fields: firstname:text, email:email
person-claim-notify  fields: firstname:text, email:email, marketingConsent:checkbox
duplicate ids: none
```

Field names are unchanged, so existing contact-property mapping (`firstname`, `email`) is unaffected. `bun run typecheck` and `bun run lint` clean.

Made with [Cursor](https://cursor.com)