### PR TITLE
chore: automate election-api M2M token rotation

### DIFF
--- a/.github/workflows/rotate-election-api-token.yml
+++ b/.github/workflows/rotate-election-api-token.yml
@@ -44,8 +44,9 @@ jobs:
       - name: Rotate token
         env:
           CLERK_MACHINE_SECRET_KEY: ${{ secrets.CLERK_GP_MARKETING_MACHINE_SECRET }}
-          # Optional — not needed for minting (createToken uses the machine secret).
-          CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
+          # CLERK_SECRET_KEY is intentionally not injected: minting authenticates
+          # with the machine secret, and passing an unset optional secret would hand
+          # the script an empty string instead of a clean fallback.
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           # Non-secret project/team identifiers for good-party/gp-marketing.
           VERCEL_PROJECT_ID: prj_xUbQGrErwISW8pqTZtKzk9wN5gFc

--- a/.github/workflows/rotate-election-api-token.yml
+++ b/.github/workflows/rotate-election-api-token.yml
@@ -1,0 +1,61 @@
+name: Rotate election-api M2M token
+
+# gp-marketing talks to election-api with a static, long-lived Clerk JWT
+# (ELECTION_API_M2M_TOKEN). JWTs can't be revoked, so we bound them to ~90 days
+# and rotate on a ~60-day cadence — the old token stays valid long enough for
+# routine deploys to pick up the new one (zero-downtime). See
+# scripts/rotate-election-api-token.ts for the full rationale.
+
+on:
+  schedule:
+    # 08:00 UTC on the 1st of every other month (Jan, Mar, May, Jul, Sep, Nov).
+    # Max gap ~62 days, comfortably under the 90-day token lifetime.
+    - cron: '0 8 1 */2 *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Mint + validate only; do not write to Vercel'
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: rotate-election-api-token
+  cancel-in-progress: false
+
+jobs:
+  rotate:
+    name: Rotate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.2.23
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Rotate token
+        env:
+          CLERK_MACHINE_SECRET_KEY: ${{ secrets.CLERK_GP_MARKETING_MACHINE_SECRET }}
+          # Optional — not needed for minting (createToken uses the machine secret).
+          CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          # Non-secret project/team identifiers for good-party/gp-marketing.
+          VERCEL_PROJECT_ID: prj_xUbQGrErwISW8pqTZtKzk9wN5gFc
+          VERCEL_TEAM_ID: team_e4HAh1NYJW4yYc38qx66yTtG
+          # Optional — if set, forces an immediate production redeploy.
+          VERCEL_DEPLOY_HOOK_URL: ${{ secrets.VERCEL_DEPLOY_HOOK_URL }}
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
+        run: |
+          if [ "${DRY_RUN}" = "true" ]; then
+            bun run scripts/rotate-election-api-token.ts --dry-run
+          else
+            bun run scripts/rotate-election-api-token.ts
+          fi

--- a/bun.lock
+++ b/bun.lock
@@ -103,6 +103,7 @@
         "vwo-smartcode-nextjs": "^1.4.2",
       },
       "devDependencies": {
+        "@clerk/backend": "^3.16.4",
         "@eslint/eslintrc": "^3.3.1",
         "@next/bundle-analyzer": "^15.5.4",
         "@playwright/test": "^1.49.0",
@@ -423,6 +424,10 @@
     "@babel/traverse": ["@babel/traverse@7.28.5", "", { "dependencies": { "@babel/code-frame": "^7.27.1", "@babel/generator": "^7.28.5", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.28.5", "@babel/template": "^7.27.2", "@babel/types": "^7.28.5", "debug": "^4.3.1" } }, "sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ=="],
 
     "@babel/types": ["@babel/types@7.28.5", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA=="],
+
+    "@clerk/backend": ["@clerk/backend@3.16.4", "", { "dependencies": { "@clerk/shared": "^4.28.1", "standardwebhooks": "^1.0.0", "tslib": "2.8.1" } }, "sha512-7A9YlBLesYgKFn4DcaCq64Ggezmbzx+xYdWsiQLrMQV+U4Bm9LtDdyaNirQ0SStSsZy6PzL8RHw5zMmmEt0zMA=="],
+
+    "@clerk/shared": ["@clerk/shared@4.28.1", "", { "dependencies": { "@tanstack/query-core": "^5.100.6", "dequal": "2.0.3", "glob-to-regexp": "0.4.1", "js-cookie": "3.0.7" }, "peerDependencies": { "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0", "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0" }, "optionalPeers": ["react", "react-dom"] }, "sha512-OhpUczN6t8CYJ+g8HdzN1O4SFC2EANOZRDwlE3rXxKu13eNtyFbLspt+d6Nhb/PmcThS/fIAKYnQQrwv0vIEwg=="],
 
     "@codemirror/autocomplete": ["@codemirror/autocomplete@6.20.0", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.17.0", "@lezer/common": "^1.0.0" } }, "sha512-bOwvTOIJcG5FVo5gUUupiwYh8MioPLQ4UcqbcRf7UQ98X90tCa9E1kZ3Z7tqwpZxYyOvh1YTYbmZE9RTfTp5hg=="],
 
@@ -1382,6 +1387,8 @@
 
     "@sentry/react": ["@sentry/react@8.55.0", "", { "dependencies": { "@sentry/browser": "8.55.0", "@sentry/core": "8.55.0", "hoist-non-react-statics": "^3.3.2" }, "peerDependencies": { "react": "^16.14.0 || 17.x || 18.x || 19.x" } }, "sha512-/qNBvFLpvSa/Rmia0jpKfJdy16d4YZaAnH/TuKLAtm0BWlsPQzbXCU4h8C5Hsst0Do0zG613MEtEmWpWrVOqWA=="],
 
+    "@stablelib/base64": ["@stablelib/base64@1.0.1", "", {}, "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ=="],
+
     "@standard-schema/spec": ["@standard-schema/spec@1.0.0", "", {}, "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA=="],
 
     "@standard-schema/utils": ["@standard-schema/utils@0.3.0", "", {}, "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g=="],
@@ -1495,6 +1502,8 @@
     "@tailwindcss/typography": ["@tailwindcss/typography@0.5.19", "", { "dependencies": { "postcss-selector-parser": "6.0.10" }, "peerDependencies": { "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1" } }, "sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg=="],
 
     "@tanem/react-nprogress": ["@tanem/react-nprogress@5.0.56", "", { "dependencies": { "@babel/runtime": "^7.28.4", "hoist-non-react-statics": "^3.3.2" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-OI5rXB6jxC/RLJqnIuaKNXu3qQ6Lf3+g1HqkqGz01E25iV3pZFYBihMdGsEeg/4pAm0O7xo/umcAA3jsdeibHA=="],
+
+    "@tanstack/query-core": ["@tanstack/query-core@5.101.4", "", {}, "sha512-gNwcvOJcRbLWPOLG/2OBm+zM+Yv+MKsXKEOWC57USuZDEsI71hEErQsiEGx5wX9rzWWkfwM0fVSPoiIFSsxfiw=="],
 
     "@tanstack/react-table": ["@tanstack/react-table@8.21.3", "", { "dependencies": { "@tanstack/table-core": "8.21.3" }, "peerDependencies": { "react": ">=16.8", "react-dom": ">=16.8" } }, "sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww=="],
 
@@ -2380,6 +2389,8 @@
 
     "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="],
 
+    "fast-sha256": ["fast-sha256@1.3.0", "", {}, "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ=="],
+
     "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
 
     "fastq": ["fastq@1.19.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ=="],
@@ -2759,6 +2770,8 @@
     "jotai": ["jotai@2.16.0", "", { "peerDependencies": { "@babel/core": ">=7.0.0", "@babel/template": ">=7.0.0", "@types/react": ">=17.0.0", "react": ">=17.0.0" }, "optionalPeers": ["@babel/core", "@babel/template", "@types/react", "react"] }, "sha512-NmkwPBet0SHQ28GBfEb10sqnbVOYyn6DL4iazZgGRDUKxSWL0iqcm+IK4TqTSFC2ixGk+XX2e46Wbv364a3cKg=="],
 
     "js-base64": ["js-base64@3.7.8", "", {}, "sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow=="],
+
+    "js-cookie": ["js-cookie@3.0.7", "", {}, "sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw=="],
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
@@ -3545,6 +3558,8 @@
     "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
 
     "stackframe": ["stackframe@1.3.4", "", {}, "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw=="],
+
+    "standardwebhooks": ["standardwebhooks@1.0.0", "", { "dependencies": { "@stablelib/base64": "^1.0.0", "fast-sha256": "^1.3.0" } }, "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg=="],
 
     "std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
 

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "test:integration:sitemap:batches": "bash scripts/test-sitemap-batches.sh",
     "test:unit": "bun test src --path-ignore-patterns='**/*.test.tsx'",
     "validate:elections": "bun run scripts/validate-election-pages.ts",
+    "rotate:election-token": "bun run scripts/rotate-election-api-token.ts",
     "lint:sitemap": "next lint --file src/app/api/sitemap-index/route.ts --file src/app/sitemap.ts --file src/lib/sitemap-entries.ts"
   },
   "dependencies": {
@@ -140,6 +141,7 @@
     "vwo-smartcode-nextjs": "^1.4.2"
   },
   "devDependencies": {
+    "@clerk/backend": "^3.16.4",
     "@eslint/eslintrc": "^3.3.1",
     "@next/bundle-analyzer": "^15.5.4",
     "@playwright/test": "^1.49.0",

--- a/scripts/rotate-election-api-token.ts
+++ b/scripts/rotate-election-api-token.ts
@@ -1,0 +1,241 @@
+#!/usr/bin/env bun
+/**
+ * Rotates the gp-marketing → election-api M2M bearer (ELECTION_API_M2M_TOKEN).
+ *
+ * Why this exists: gp-marketing authenticates to election-api with a single
+ * long-lived Clerk JWT injected as ELECTION_API_M2M_TOKEN, instead of minting a
+ * token per request. The Vercel serverless fleet churns faster than any
+ * per-isolate token cache, so runtime minting fanned out enough Clerk
+ * `createToken` calls to trip the rate limit; a static token removes minting
+ * from the hot path entirely (see src/lib/electionApiAuth.ts).
+ *
+ * The catch: JWT M2M tokens are stateless and therefore cannot be revoked, so we
+ * cap the blast radius of a leak with a bounded ~90-day lifetime. That means the
+ * token must be replaced before it expires or — once ELECTION_API_AUTH_ENFORCED
+ * is on — election-api starts returning 401 to gp-marketing. This script mints a
+ * fresh JWT and writes it into every Vercel environment's ELECTION_API_M2M_TOKEN.
+ *
+ * Zero-downtime: we rotate on a ~60-day cadence while minting ~90-day tokens, so
+ * the previous token stays valid for ~30 more days — long enough for routine
+ * deployments to bake in the new value (Vercel env changes only apply to new
+ * deployments). No forced redeploy is required; one is triggered only if
+ * VERCEL_DEPLOY_HOOK_URL is provided.
+ *
+ * Run by .github/workflows/rotate-election-api-token.yml (scheduled + manual).
+ *
+ * Required env:
+ *   CLERK_MACHINE_SECRET_KEY  ak_… secret for the gp-marketing (production) machine
+ *   VERCEL_TOKEN              Vercel API token with write access to the project
+ *   VERCEL_PROJECT_ID         prj_… (not secret)
+ *   VERCEL_TEAM_ID            team_… (not secret)
+ * Optional env:
+ *   CLERK_SECRET_KEY          sk_… (not used for minting; only set if convenient)
+ *   TOKEN_TTL_DAYS            token lifetime in days (default 90)
+ *   ELECTION_API_BASE_URL     base for the post-mint liveness check (default prod)
+ *   VERCEL_DEPLOY_HOOK_URL    if set, POSTed after the update to force a redeploy
+ *
+ * Flags:
+ *   --dry-run  Mint + validate the token, but do not write anything to Vercel.
+ */
+
+import { createClerkClient } from '@clerk/backend';
+
+const TOKEN_ENV_KEY = 'ELECTION_API_M2M_TOKEN';
+const VERCEL_API = 'https://api.vercel.com';
+
+/** Vercel environments that hold the token, and the type each entry must use. */
+const TARGET_TYPES: Record<string, 'sensitive' | 'encrypted'> = {
+	// Production + Preview are sensitive (write-only); Vercel forbids sensitive on
+	// the Development environment, so it is stored encrypted (see set-secrets notes).
+	production: 'sensitive',
+	preview: 'sensitive',
+	development: 'encrypted',
+};
+
+interface VercelEnvVar {
+	id: string;
+	key: string;
+	target: string[];
+	type: string;
+}
+
+function requireEnv(name: string): string {
+	const value = process.env[name];
+	if (!value) {
+		throw new Error(`Missing required env var ${name}`);
+	}
+	return value;
+}
+
+/** Mask a bearer for logs: keep the first/last few chars, hide the middle. */
+function mask(token: string): string {
+	if (token.length <= 12) return '***';
+	return `${token.slice(0, 8)}…${token.slice(-4)} (len ${token.length})`;
+}
+
+/** Parse a JWT's `exp` (seconds) without verifying its signature. */
+function jwtExpMs(jwt: string): number {
+	const segments = jwt.split('.');
+	const payloadSegment = segments[1];
+	if (segments.length !== 3 || !payloadSegment) {
+		throw new Error(`Minted value is not a JWT (${segments.length} segments, expected 3)`);
+	}
+	const payload = JSON.parse(Buffer.from(payloadSegment, 'base64url').toString('utf8')) as {
+		exp?: number;
+	};
+	if (typeof payload.exp !== 'number') {
+		throw new Error('Minted JWT has no numeric `exp` claim');
+	}
+	return payload.exp * 1000;
+}
+
+async function mintJwt(machineSecretKey: string, ttlDays: number): Promise<string> {
+	// createToken authenticates with the machine secret, not the instance secret,
+	// so CLERK_SECRET_KEY is optional here; pass a placeholder when it is absent so
+	// the client constructs cleanly.
+	const clerk = createClerkClient({
+		secretKey: process.env['CLERK_SECRET_KEY'] ?? 'sk_unused_for_m2m_mint',
+	});
+
+	const minted = await clerk.m2m.createToken({
+		machineSecretKey,
+		tokenFormat: 'jwt',
+		secondsUntilExpiration: ttlDays * 24 * 60 * 60,
+	});
+
+	if (!minted.token) {
+		throw new Error('Clerk returned an M2M token with no `token` string');
+	}
+	return minted.token;
+}
+
+async function vercelFetch<T>(
+	path: string,
+	token: string,
+	teamId: string,
+	init?: RequestInit,
+): Promise<T> {
+	const separator = path.includes('?') ? '&' : '?';
+	const res = await fetch(`${VERCEL_API}${path}${separator}teamId=${teamId}`, {
+		...init,
+		headers: {
+			Authorization: `Bearer ${token}`,
+			'Content-Type': 'application/json',
+			...init?.headers,
+		},
+	});
+	if (!res.ok) {
+		const body = await res.text();
+		throw new Error(`Vercel ${init?.method ?? 'GET'} ${path} → ${res.status}: ${body}`);
+	}
+	return (await res.json()) as T;
+}
+
+async function listTokenEnvVars(
+	projectId: string,
+	token: string,
+	teamId: string,
+): Promise<VercelEnvVar[]> {
+	const data = await vercelFetch<{ envs: Array<Omit<VercelEnvVar, 'target'> & { target: string[] | string }> }>(
+		`/v9/projects/${projectId}/env`,
+		token,
+		teamId,
+	);
+	return data.envs
+		.filter(env => env.key === TOKEN_ENV_KEY)
+		.map(env => ({
+			id: env.id,
+			key: env.key,
+			type: env.type,
+			target: Array.isArray(env.target) ? env.target : [env.target],
+		}));
+}
+
+async function main(): Promise<void> {
+	const dryRun = process.argv.includes('--dry-run');
+	const ttlDays = Number(process.env['TOKEN_TTL_DAYS'] ?? '90');
+	if (!Number.isFinite(ttlDays) || ttlDays <= 0) {
+		throw new Error(`Invalid TOKEN_TTL_DAYS: ${process.env['TOKEN_TTL_DAYS']}`);
+	}
+
+	const machineSecretKey = requireEnv('CLERK_MACHINE_SECRET_KEY');
+
+	console.log(`Minting a ${ttlDays}-day election-api JWT for the gp-marketing machine…`);
+	const newToken = await mintJwt(machineSecretKey, ttlDays);
+
+	// Trust Clerk's `exp`, not our own arithmetic: reject an unexpectedly
+	// short-lived token before it is pushed, so a bad mint can't silently install
+	// a credential that expires next week.
+	const expMs = jwtExpMs(newToken);
+	const remainingDays = (expMs - Date.now()) / (24 * 60 * 60 * 1000);
+	console.log(`  minted ${mask(newToken)}, expires ${new Date(expMs).toISOString()} (~${remainingDays.toFixed(1)} days)`);
+	if (remainingDays < ttlDays - 2) {
+		throw new Error(
+			`Minted token expires in ~${remainingDays.toFixed(1)} days, well under the expected ${ttlDays}; refusing to roll out`,
+		);
+	}
+
+	// Best-effort liveness probe: confirm election-api accepts the token at the
+	// network layer. Non-fatal — in observe-only mode election-api answers 2xx/4xx
+	// regardless of auth, so this only guards against a malformed base URL or an
+	// election-api outage, not against a semantically wrong token.
+	const electionApiBase = process.env['ELECTION_API_BASE_URL'] ?? 'https://election-api.goodparty.org';
+	try {
+		const res = await fetch(`${electionApiBase}/v1/health`, {
+			headers: { Authorization: `Bearer ${newToken}` },
+		});
+		console.log(`  election-api /v1/health with new token → ${res.status}`);
+	} catch (err) {
+		console.warn(`  liveness probe failed (non-fatal): ${(err as Error).message}`);
+	}
+
+	if (dryRun) {
+		console.log('--dry-run: token minted and validated; not writing to Vercel.');
+		return;
+	}
+
+	const vercelToken = requireEnv('VERCEL_TOKEN');
+	const projectId = requireEnv('VERCEL_PROJECT_ID');
+	const teamId = requireEnv('VERCEL_TEAM_ID');
+
+	const existing = await listTokenEnvVars(projectId, vercelToken, teamId);
+	console.log(`Found ${existing.length} existing ${TOKEN_ENV_KEY} entrie(s) in Vercel.`);
+
+	// Update every existing entry that holds this key (one entry may cover several
+	// environments), then create entries for any target that isn't covered yet.
+	for (const env of existing) {
+		await vercelFetch(`/v9/projects/${projectId}/env/${env.id}`, vercelToken, teamId, {
+			method: 'PATCH',
+			body: JSON.stringify({ value: newToken }),
+		});
+		console.log(`  updated entry ${env.id} (targets: ${env.target.join(', ')})`);
+	}
+
+	const covered = new Set(existing.flatMap(env => env.target));
+	for (const [target, type] of Object.entries(TARGET_TYPES)) {
+		if (covered.has(target)) continue;
+		await vercelFetch(`/v10/projects/${projectId}/env`, vercelToken, teamId, {
+			method: 'POST',
+			body: JSON.stringify({ key: TOKEN_ENV_KEY, value: newToken, type, target: [target] }),
+		});
+		console.log(`  created ${type} entry for missing target: ${target}`);
+	}
+
+	const deployHook = process.env['VERCEL_DEPLOY_HOOK_URL'];
+	if (deployHook) {
+		const res = await fetch(deployHook, { method: 'POST' });
+		console.log(`Triggered deploy hook → ${res.status}`);
+	} else {
+		console.log(
+			'No VERCEL_DEPLOY_HOOK_URL set — the new token takes effect on the next deployment ' +
+				'(the previous token stays valid until then, so there is no gap).',
+		);
+	}
+
+	console.log('Rotation complete.');
+}
+
+main().catch(err => {
+	console.error(`Rotation failed: ${(err as Error).message}`);
+	process.exit(1);
+});

--- a/scripts/rotate-election-api-token.ts
+++ b/scripts/rotate-election-api-token.ts
@@ -181,13 +181,15 @@ async function main(): Promise<void> {
 	}
 
 	const machineSecretKey = requireEnv('CLERK_MACHINE_SECRET_KEY');
+	// Register before minting: mintJwt() can throw with the key echoed in the
+	// error, and the catch handler redacts against this set. (In CI the key is a
+	// declared GitHub secret and already masked; manual `bun run` has no masking.)
+	secretsToRedact.add(machineSecretKey);
 
 	console.log(`Minting a ${ttlDays}-day election-api JWT for the gp-marketing machine…`);
 	const newToken = await mintJwt(machineSecretKey, ttlDays);
-	// The machine secret is a declared GitHub secret (already masked), but the
-	// freshly minted token is not — keep it out of any error we might print.
+	// The freshly minted token is not a declared secret — keep it out of logs too.
 	secretsToRedact.add(newToken);
-	secretsToRedact.add(machineSecretKey);
 
 	// Trust Clerk's `exp`, not our own arithmetic: reject an unexpectedly
 	// short-lived token before it is pushed, so a bad mint can't silently install
@@ -237,9 +239,17 @@ async function main(): Promise<void> {
 	// Update every existing entry that holds this key (one entry may cover several
 	// environments), then create entries for any target that isn't covered yet.
 	for (const env of existing) {
+		// Also correct the variable type if it drifted (e.g. a production entry
+		// created manually as `encrypted` instead of `sensitive`, which would expose
+		// the bearer to anyone with project read access). Only set it when every
+		// target on the entry maps to one expected type, to avoid guessing on a
+		// mixed-target entry.
+		const expectedTypes = [...new Set(env.target.map(t => TARGET_TYPES[t]).filter(Boolean))];
+		const patchBody: Record<string, unknown> = { value: newToken };
+		if (expectedTypes.length === 1) patchBody['type'] = expectedTypes[0];
 		await vercelFetch(`/v9/projects/${projectId}/env/${env.id}`, vercelToken, teamId, {
 			method: 'PATCH',
-			body: JSON.stringify({ value: newToken }),
+			body: JSON.stringify(patchBody),
 		});
 		console.log(`  updated entry ${env.id} (targets: ${env.target.join(', ')})`);
 	}

--- a/scripts/rotate-election-api-token.ts
+++ b/scripts/rotate-election-api-token.ts
@@ -212,7 +212,8 @@ async function main(): Promise<void> {
 			headers: { Authorization: `Bearer ${newToken}` },
 		});
 	} catch (err) {
-		console.warn(`  auth probe inconclusive — transport error (non-fatal): ${redact((err as Error).message)}`);
+		const probeErrMsg = err instanceof Error ? err.message : String(err);
+		console.warn(`  auth probe inconclusive — transport error (non-fatal): ${redact(probeErrMsg)}`);
 	}
 	if (probeRes && (probeRes.status === 401 || probeRes.status === 403)) {
 		throw new Error(`election-api rejected the freshly minted token (HTTP ${probeRes.status}); aborting before rollout`);

--- a/scripts/rotate-election-api-token.ts
+++ b/scripts/rotate-election-api-token.ts
@@ -57,6 +57,10 @@ interface VercelEnvVar {
 	key: string;
 	target: string[];
 	type: string;
+	// Set on branch-scoped preview entries. Such an entry has target ['preview']
+	// but does NOT cover the canonical preview slot, so it must be excluded when
+	// computing which targets already have an entry.
+	gitBranch?: string;
 }
 
 function requireEnv(name: string): string {
@@ -164,6 +168,7 @@ async function listTokenEnvVars(projectId: string, token: string, teamId: string
 				key: env.key,
 				type: env.type,
 				target: Array.isArray(env.target) ? env.target : [env.target],
+				gitBranch: env.gitBranch,
 			});
 		}
 		const next = data.pagination?.next;
@@ -276,7 +281,10 @@ async function main(): Promise<void> {
 		console.log(`  updated entry ${env.id} (targets: ${env.target.join(', ')})`);
 	}
 
-	const covered = new Set(existing.flatMap(env => env.target));
+	// Exclude branch-scoped preview entries: they carry target ['preview'] but do
+	// not cover the canonical preview slot, so counting them would wrongly skip
+	// creating the canonical preview entry and leave preview on the stale token.
+	const covered = new Set(existing.filter(env => !env.gitBranch).flatMap(env => env.target));
 	for (const [target, type] of Object.entries(TARGET_TYPES)) {
 		if (covered.has(target)) continue;
 		await vercelFetch(`/v10/projects/${projectId}/env`, vercelToken, teamId, {

--- a/scripts/rotate-election-api-token.ts
+++ b/scripts/rotate-election-api-token.ts
@@ -92,9 +92,10 @@ function jwtExpMs(jwt: string): number {
 async function mintJwt(machineSecretKey: string, ttlDays: number): Promise<string> {
 	// createToken authenticates with the machine secret, not the instance secret,
 	// so CLERK_SECRET_KEY is optional here; pass a placeholder when it is absent so
-	// the client constructs cleanly.
+	// the client constructs cleanly. Use `||`, not `??`: GitHub Actions injects an
+	// unset optional secret as an empty string, which `??` would pass through.
 	const clerk = createClerkClient({
-		secretKey: process.env['CLERK_SECRET_KEY'] ?? 'sk_unused_for_m2m_mint',
+		secretKey: process.env['CLERK_SECRET_KEY'] || 'sk_unused_for_m2m_mint',
 	});
 
 	const minted = await clerk.m2m.createToken({
@@ -109,12 +110,7 @@ async function mintJwt(machineSecretKey: string, ttlDays: number): Promise<strin
 	return minted.token;
 }
 
-async function vercelFetch<T>(
-	path: string,
-	token: string,
-	teamId: string,
-	init?: RequestInit,
-): Promise<T> {
+async function vercelFetch<T>(path: string, token: string, teamId: string, init?: RequestInit): Promise<T> {
 	const separator = path.includes('?') ? '&' : '?';
 	const res = await fetch(`${VERCEL_API}${path}${separator}teamId=${teamId}`, {
 		...init,
@@ -131,24 +127,35 @@ async function vercelFetch<T>(
 	return (await res.json()) as T;
 }
 
-async function listTokenEnvVars(
-	projectId: string,
-	token: string,
-	teamId: string,
-): Promise<VercelEnvVar[]> {
-	const data = await vercelFetch<{ envs: Array<Omit<VercelEnvVar, 'target'> & { target: string[] | string }> }>(
-		`/v9/projects/${projectId}/env`,
-		token,
-		teamId,
-	);
-	return data.envs
-		.filter(env => env.key === TOKEN_ENV_KEY)
-		.map(env => ({
-			id: env.id,
-			key: env.key,
-			type: env.type,
-			target: Array.isArray(env.target) ? env.target : [env.target],
-		}));
+async function listTokenEnvVars(projectId: string, token: string, teamId: string): Promise<VercelEnvVar[]> {
+	// The project env list is returned in a single page today, but page through
+	// defensively: a project with more variables than the endpoint's page size
+	// would otherwise silently drop an ELECTION_API_M2M_TOKEN entry, leaving it on
+	// the stale token while the rest rotate. `pagination.next` is a timestamp
+	// cursor consumed via `until`.
+	const matches: VercelEnvVar[] = [];
+	let until: string | undefined;
+	for (;;) {
+		const query = new URLSearchParams({ limit: '100' });
+		if (until) query.set('until', until);
+		const data = await vercelFetch<{
+			envs: Array<Omit<VercelEnvVar, 'target'> & { target: string[] | string }>;
+			pagination?: { next: number | null };
+		}>(`/v9/projects/${projectId}/env?${query.toString()}`, token, teamId);
+		for (const env of data.envs) {
+			if (env.key !== TOKEN_ENV_KEY) continue;
+			matches.push({
+				id: env.id,
+				key: env.key,
+				type: env.type,
+				target: Array.isArray(env.target) ? env.target : [env.target],
+			});
+		}
+		const next = data.pagination?.next;
+		if (!next) break;
+		until = String(next);
+	}
+	return matches;
 }
 
 async function main(): Promise<void> {
@@ -170,9 +177,7 @@ async function main(): Promise<void> {
 	const remainingDays = (expMs - Date.now()) / (24 * 60 * 60 * 1000);
 	console.log(`  minted ${mask(newToken)}, expires ${new Date(expMs).toISOString()} (~${remainingDays.toFixed(1)} days)`);
 	if (remainingDays < ttlDays - 2) {
-		throw new Error(
-			`Minted token expires in ~${remainingDays.toFixed(1)} days, well under the expected ${ttlDays}; refusing to roll out`,
-		);
+		throw new Error(`Minted token expires in ~${remainingDays.toFixed(1)} days, well under the expected ${ttlDays}; refusing to roll out`);
 	}
 
 	// Best-effort liveness probe: confirm election-api accepts the token at the
@@ -223,7 +228,12 @@ async function main(): Promise<void> {
 
 	const deployHook = process.env['VERCEL_DEPLOY_HOOK_URL'];
 	if (deployHook) {
+		// fetch does not throw on non-2xx, so check explicitly: a swallowed hook
+		// failure would exit 0 and tell the operator the redeploy fired when it did not.
 		const res = await fetch(deployHook, { method: 'POST' });
+		if (!res.ok) {
+			throw new Error(`Deploy hook POST → ${res.status}: ${await res.text()}`);
+		}
 		console.log(`Triggered deploy hook → ${res.status}`);
 	} else {
 		console.log(

--- a/scripts/rotate-election-api-token.ts
+++ b/scripts/rotate-election-api-token.ts
@@ -73,6 +73,21 @@ function mask(token: string): string {
 	return `${token.slice(0, 8)}…${token.slice(-4)} (len ${token.length})`;
 }
 
+/**
+ * Credentials to scrub from anything we print. GitHub Actions only masks values
+ * declared as `secrets:`; a token minted at runtime is unknown to the masking
+ * engine, and a Vercel validation error can echo the submitted value back inside
+ * a thrown message. Register such values here and redact() before logging.
+ */
+const secretsToRedact = new Set<string>();
+function redact(text: string): string {
+	let out = text;
+	for (const secret of secretsToRedact) {
+		if (secret) out = out.split(secret).join('***');
+	}
+	return out;
+}
+
 /** Parse a JWT's `exp` (seconds) without verifying its signature. */
 function jwtExpMs(jwt: string): number {
 	const segments = jwt.split('.');
@@ -169,6 +184,10 @@ async function main(): Promise<void> {
 
 	console.log(`Minting a ${ttlDays}-day election-api JWT for the gp-marketing machine…`);
 	const newToken = await mintJwt(machineSecretKey, ttlDays);
+	// The machine secret is a declared GitHub secret (already masked), but the
+	// freshly minted token is not — keep it out of any error we might print.
+	secretsToRedact.add(newToken);
+	secretsToRedact.add(machineSecretKey);
 
 	// Trust Clerk's `exp`, not our own arithmetic: reject an unexpectedly
 	// short-lived token before it is pushed, so a bad mint can't silently install
@@ -180,18 +199,26 @@ async function main(): Promise<void> {
 		throw new Error(`Minted token expires in ~${remainingDays.toFixed(1)} days, well under the expected ${ttlDays}; refusing to roll out`);
 	}
 
-	// Best-effort liveness probe: confirm election-api accepts the token at the
-	// network layer. Non-fatal — in observe-only mode election-api answers 2xx/4xx
-	// regardless of auth, so this only guards against a malformed base URL or an
-	// election-api outage, not against a semantically wrong token.
+	// Auth probe against a *guarded* endpoint (not the public /v1/health) so the
+	// token is actually authenticated. A 401/403 is an unambiguous bad-token
+	// signal in any mode and MUST abort before we roll the token out — that is
+	// exactly how a broken token surfaces once ELECTION_API_AUTH_ENFORCED is on.
+	// In observe-only mode election-api still answers 2xx, so this can't fully
+	// validate today; genuine transport/5xx blips stay non-fatal.
 	const electionApiBase = process.env['ELECTION_API_BASE_URL'] ?? 'https://election-api.goodparty.org';
+	let probeRes: Response | undefined;
 	try {
-		const res = await fetch(`${electionApiBase}/v1/health`, {
+		probeRes = await fetch(`${electionApiBase}/v1/candidacies?slug=__token-rotation-probe__`, {
 			headers: { Authorization: `Bearer ${newToken}` },
 		});
-		console.log(`  election-api /v1/health with new token → ${res.status}`);
 	} catch (err) {
-		console.warn(`  liveness probe failed (non-fatal): ${(err as Error).message}`);
+		console.warn(`  auth probe inconclusive — transport error (non-fatal): ${redact((err as Error).message)}`);
+	}
+	if (probeRes && (probeRes.status === 401 || probeRes.status === 403)) {
+		throw new Error(`election-api rejected the freshly minted token (HTTP ${probeRes.status}); aborting before rollout`);
+	}
+	if (probeRes) {
+		console.log(`  election-api auth probe → ${probeRes.status}`);
 	}
 
 	if (dryRun) {
@@ -246,6 +273,7 @@ async function main(): Promise<void> {
 }
 
 main().catch(err => {
-	console.error(`Rotation failed: ${(err as Error).message}`);
+	// redact: a Vercel validation error can embed the submitted token value.
+	console.error(`Rotation failed: ${redact((err as Error).message)}`);
 	process.exit(1);
 });

--- a/scripts/rotate-election-api-token.ts
+++ b/scripts/rotate-election-api-token.ts
@@ -167,7 +167,9 @@ async function listTokenEnvVars(projectId: string, token: string, teamId: string
 			});
 		}
 		const next = data.pagination?.next;
-		if (!next) break;
+		// Strict nullish check: the cursor is `number | null`, so `!next` would stop
+		// early on a legitimate `0` cursor and drop remaining pages.
+		if (next == null) break;
 		until = String(next);
 	}
 	return matches;
@@ -230,6 +232,9 @@ async function main(): Promise<void> {
 	}
 
 	const vercelToken = requireEnv('VERCEL_TOKEN');
+	// Register for redaction like the other runtime credentials — manual runs have
+	// no GitHub Actions masking to fall back on.
+	secretsToRedact.add(vercelToken);
 	const projectId = requireEnv('VERCEL_PROJECT_ID');
 	const teamId = requireEnv('VERCEL_TEAM_ID');
 

--- a/scripts/rotate-election-api-token.ts
+++ b/scripts/rotate-election-api-token.ts
@@ -273,7 +273,10 @@ async function main(): Promise<void> {
 }
 
 main().catch(err => {
+	// Normalise before redacting: a non-Error throw would make `.message`
+	// undefined and redact() throw, swallowing the failure diagnosis.
 	// redact: a Vercel validation error can embed the submitted token value.
-	console.error(`Rotation failed: ${redact((err as Error).message)}`);
+	const message = err instanceof Error ? err.message : String(err);
+	console.error(`Rotation failed: ${redact(message)}`);
 	process.exit(1);
 });

--- a/scripts/rotate-election-api-token.ts
+++ b/scripts/rotate-election-api-token.ts
@@ -236,6 +236,23 @@ async function main(): Promise<void> {
 	const existing = await listTokenEnvVars(projectId, vercelToken, teamId);
 	console.log(`Found ${existing.length} existing ${TOKEN_ENV_KEY} entrie(s) in Vercel.`);
 
+	// Refuse to proceed on a manually-created entry that spans targets needing
+	// different types (e.g. one record covering both production and development).
+	// We deliberately do NOT auto-split it: that would require DELETE-then-POST on a
+	// live production credential, and a failure between the two calls would leave
+	// production with no token. Fail loudly before any write so an operator can
+	// split it by hand. Our provisioning creates one single-typed entry per
+	// environment, so this never triggers in practice.
+	for (const env of existing) {
+		const requiredTypes = new Set(env.target.map(t => TARGET_TYPES[t]).filter(Boolean));
+		if (requiredTypes.size > 1) {
+			throw new Error(
+				`Env entry ${env.id} spans targets needing different types (${[...requiredTypes].join(', ')}); ` +
+					`split it into one entry per target in Vercel and re-run — refusing to delete a live credential to fix this automatically`,
+			);
+		}
+	}
+
 	// Update every existing entry that holds this key (one entry may cover several
 	// environments), then create entries for any target that isn't covered yet.
 	for (const env of existing) {


### PR DESCRIPTION
## Summary
- gp-marketing authenticates to election-api with a **static, long-lived Clerk JWT** (`ELECTION_API_M2M_TOKEN`) instead of minting per request — the Vercel serverless fleet churns faster than any token cache and tripped Clerk's `createToken` rate limit. JWT M2M tokens **can't be revoked**, so we bound them to ~90 days to cap a leak's blast radius. That expiry is a manual landmine: once `ELECTION_API_AUTH_ENFORCED` is on, a missed rotation 401s gp-marketing.
- Adds `scripts/rotate-election-api-token.ts` + `.github/workflows/rotate-election-api-token.yml` that mint a fresh 90-day JWT and write it into every Vercel environment on a ~60-day cadence. The previous token stays valid for ~30 more days, so routine deploys bake in the new value with **no gap** (zero-downtime rotation).
- The script trusts Clerk's `exp` (rejects an unexpectedly short-lived mint before rollout), runs a best-effort election-api liveness probe, updates all existing `ELECTION_API_M2M_TOKEN` entries by id (creating any missing target with the correct type: sensitive for prod/preview, encrypted for dev), and optionally fires a deploy hook.
- Adds `@clerk/backend` as a **devDependency** (mint SDK) and a `rotate:election-token` script alias for manual/runbook use.

## Rollout — required GitHub Actions secrets
This workflow does nothing until these repo secrets exist:
- `CLERK_GP_MARKETING_MACHINE_SECRET` — the `ak_…` machine secret for the **production** gp-marketing Clerk machine (used to mint).
- `VERCEL_TOKEN` — a Vercel API token with write access to `good-party/gp-marketing`.
- `CLERK_SECRET_KEY` — *optional* (not needed for minting; the SDK authenticates with the machine secret).
- `VERCEL_DEPLOY_HOOK_URL` — *optional*; if set, forces an immediate prod redeploy instead of waiting for the next deploy.

Project/team IDs are non-secret and hardcoded in the workflow.

## Test plan
- [x] `bun run typecheck` green
- [x] `eslint` + `prettier` clean
- [x] Smoke: fails fast on missing `CLERK_MACHINE_SECRET_KEY`; with a (fake) secret the mint path reaches Clerk and only the credential is rejected (client construct + `createToken` dispatch verified)
- [ ] After merge: run the workflow via **workflow_dispatch with `dry_run: true`** (mint + validate only, no Vercel writes) using the real machine secret, then a real run

Made with [Cursor](https://cursor.com)