### PR TITLE
Release: fix the claim confirmation message and give the claim forms stable ids

### DIFF
--- a/src/components/people/ClaimProfileModal.tsx
+++ b/src/components/people/ClaimProfileModal.tsx
@@ -13,9 +13,30 @@ import { Text } from '~/ui/Text';
 
 const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
+/**
+ * Stable identity for HubSpot's non-HubSpot ("collected") forms tool. DO NOT
+ * rename, and do not remove it in favour of styling: the site-wide HubSpot
+ * tracking script keys a collected form on the `<form>` tag's id, falling back to
+ * its class list when there is no id. Without this the form was filed under
+ * `.flex, .w-full, .flex-col, .gap-4, .text-left`, so any change to its spacing
+ * or width silently created a NEW form in HubSpot and orphaned the marketing
+ * workflows attached to the old one — with no error anywhere.
+ *
+ * Distinct from {@link PersonClaimCTABand}'s id on purpose. HubSpot groups
+ * submissions by this value, and the two forms are different intents that want
+ * different follow-up: this one is a visitor asking us to nudge someone else,
+ * that one is the person claiming their own page.
+ */
+const NOTIFY_FORM_ID = 'person-claim-notify';
+
 type NotifyValues = { firstname: string; email: string; marketingConsent: boolean };
 
-function NotifyForm({ personId, displayName }: { personId: string; displayName: string }) {
+/**
+ * The "Not [Name]?" form in the dialog body. Exported so the HubSpot id contract
+ * can be asserted directly (see claimFormIds.test.tsx) without standing up
+ * Radix's dialog, whose event delegation does not survive JSDOM.
+ */
+export function NotifyForm({ personId, displayName }: { personId: string; displayName: string }) {
 	const [isSuccess, setIsSuccess] = useState(false);
 	const {
 		register,
@@ -60,6 +81,7 @@ function NotifyForm({ personId, displayName }: { personId: string; displayName: 
 
 	return (
 		<form
+			id={NOTIFY_FORM_ID}
 			className='flex w-full flex-col gap-4 text-left'
 			onSubmit={(e) => void handleSubmit(onSubmit)(e)}
 			noValidate

--- a/src/components/people/PersonClaimCTABand.tsx
+++ b/src/components/people/PersonClaimCTABand.tsx
@@ -27,6 +27,15 @@ export type PersonClaimCTABandProps = {
  * that posts to the same claim-request endpoint as the claim modal. Rendered in
  * the person `person-cta` section slot (below the content well, above the
  * elections index) in place of the claimed "Join the movement" CTA.
+ *
+ * Carries NO marketing-consent checkbox, unlike the claim modal, which is what
+ * the frame specifies (band 1922:92593 has name + email + submit; the modal's
+ * dialog 1901:51851 adds the opt-in). The two forms hit one endpoint but are
+ * different acts: the modal asks a visitor to opt in while notifying someone
+ * else, whereas this band is the person themselves entering their own address to
+ * claim their page. The proxy therefore records `marketingConsent: false` for
+ * every submission from here — absent an opt-in that is the accurate value, not
+ * a dropped field.
  */
 export function PersonClaimCTABand({ personId, displayName, isRunning }: PersonClaimCTABandProps) {
 	const [isSuccess, setIsSuccess] = useState(false);
@@ -73,7 +82,7 @@ export function PersonClaimCTABand({ personId, displayName, isRunning }: PersonC
 							aria-live='polite'
 						>
 							<Text styleType='body-2'>
-								Thanks — we&apos;ll let {displayName} know their GoodParty.org profile is ready to claim.
+								Thanks — we&apos;ll be in touch at that address about claiming your profile.
 							</Text>
 						</div>
 					) : (

--- a/src/components/people/PersonClaimCTABand.tsx
+++ b/src/components/people/PersonClaimCTABand.tsx
@@ -11,6 +11,14 @@ import { Text } from '~/ui/Text';
 
 const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
+/**
+ * Stable identity for HubSpot's non-HubSpot ("collected") forms tool — see the
+ * matching constant in ClaimProfileModal for why this must not be renamed or
+ * dropped. Deliberately different from that one so HubSpot files owner claims
+ * separately from visitor nudges; they warrant different follow-up.
+ */
+const CLAIM_FORM_ID = 'person-claim-owner';
+
 type NotifyValues = { firstname: string; email: string };
 
 export type PersonClaimCTABandProps = {
@@ -87,6 +95,7 @@ export function PersonClaimCTABand({ personId, displayName, isRunning }: PersonC
 						</div>
 					) : (
 						<form
+							id={CLAIM_FORM_ID}
 							className='flex w-full max-w-md flex-col gap-4 text-left'
 							onSubmit={(e) => void handleSubmit(onSubmit)(e)}
 							noValidate

--- a/src/components/people/claimFormIds.test.tsx
+++ b/src/components/people/claimFormIds.test.tsx
@@ -1,0 +1,134 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { JSDOM } from 'jsdom';
+import * as React from 'react';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+/**
+ * Guards the `<form id>` on both person-profile claim forms.
+ *
+ * These ids are an external contract with HubSpot, not decoration. The site-wide
+ * tracking script collects submissions via the non-HubSpot forms tool, which keys
+ * a form on its id and silently falls back to the class list when the id is
+ * absent — filing submissions under a brand-new form and orphaning whatever
+ * marketing workflow was attached to the old one. Nothing throws when that
+ * happens, on the site or in HubSpot, so CI is the only place it can be caught.
+ *
+ * These mount the form components directly rather than driving the dialog open.
+ * Radix's click delegation does not fire under JSDOM once this file shares a
+ * process with the rest of the suite (which is how CI runs it, since bun 1.2.23
+ * ignores the `--path-ignore-patterns` split between the logic and DOM suites).
+ * The id lives on the form element either way, so the dialog buys nothing here.
+ */
+
+const DOM_GLOBALS = [
+	'Node',
+	'NodeFilter',
+	'Element',
+	'HTMLElement',
+	'HTMLInputElement',
+	'HTMLButtonElement',
+	'HTMLFormElement',
+	'DocumentFragment',
+	'DOMRect',
+	'Event',
+	'CustomEvent',
+	'MouseEvent',
+	'KeyboardEvent',
+	'FocusEvent',
+	'MutationObserver',
+] as const;
+
+let dom: JSDOM;
+let root: Root;
+
+beforeEach(() => {
+	dom = new JSDOM('<!DOCTYPE html><html><body><div id="root"></div></body></html>', {
+		url: 'http://localhost/people/example-person',
+		pretendToBeVisual: true,
+	});
+	const { window } = dom;
+
+	globalThis.window = window as unknown as Window & typeof globalThis;
+	globalThis.document = window.document;
+	globalThis.navigator = window.navigator;
+	globalThis.getComputedStyle = window.getComputedStyle.bind(window);
+
+	// These have to come from the JSDOM realm rather than Bun's natives, which
+	// JSDOM rejects as foreign ("parameter 1 is not of type 'Event'").
+	for (const name of DOM_GLOBALS) {
+		(globalThis as Record<string, unknown>)[name] = (window as unknown as Record<string, unknown>)[name];
+	}
+
+	(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterEach(async () => {
+	if (root) {
+		await act(async () => {
+			root.unmount();
+		});
+	}
+	dom.window.close();
+});
+
+async function render(element: React.ReactElement) {
+	await act(async () => {
+		root = createRoot(document.getElementById('root')!);
+		root.render(element);
+		await new Promise<void>(resolve => {
+			window.setTimeout(resolve, 0);
+		});
+	});
+}
+
+const bandProps = { personId: 'person-1', displayName: 'Example Person', isRunning: true };
+const notifyProps = { personId: 'person-1', displayName: 'Example Person' };
+
+describe('claim form HubSpot ids', () => {
+	test('PersonClaimCTABand renders form#person-claim-owner', async () => {
+		const { PersonClaimCTABand } = await import('./PersonClaimCTABand');
+
+		await render(React.createElement(PersonClaimCTABand, bandProps));
+
+		const form = document.querySelector('form#person-claim-owner');
+		expect(form).not.toBeNull();
+		// Field names are what HubSpot maps onto contact properties.
+		expect(form?.querySelector('input[name="firstname"]')).not.toBeNull();
+		expect(form?.querySelector('input[name="email"]')).not.toBeNull();
+	});
+
+	test('the claim dialog notify form renders form#person-claim-notify', async () => {
+		const { NotifyForm } = await import('./ClaimProfileModal');
+
+		await render(React.createElement(NotifyForm, notifyProps));
+
+		const form = document.querySelector('form#person-claim-notify');
+		expect(form).not.toBeNull();
+		expect(form?.querySelector('input[name="firstname"]')).not.toBeNull();
+		expect(form?.querySelector('input[name="email"]')).not.toBeNull();
+	});
+
+	test('the two ids differ, so HubSpot files owner claims apart from visitor nudges', async () => {
+		const [{ PersonClaimCTABand }, { NotifyForm }] = await Promise.all([
+			import('./PersonClaimCTABand'),
+			import('./ClaimProfileModal'),
+		]);
+
+		// Both are reachable on an unclaimed empowered profile. Sharing an id would
+		// collapse the two intents into one HubSpot form, besides being invalid markup.
+		await render(
+			React.createElement(
+				React.Fragment,
+				null,
+				React.createElement(PersonClaimCTABand, bandProps),
+				React.createElement(NotifyForm, notifyProps),
+			),
+		);
+
+		const ids = [...document.querySelectorAll('form')].map(f => f.id);
+		expect(ids).toContain('person-claim-owner');
+		expect(ids).toContain('person-claim-notify');
+		expect(new Set(ids).size).toBe(ids.length);
+	});
+});


### PR DESCRIPTION
Two small fixes to the person profile pages, both on the "claim your profile" flow.

## What changes for people using the site

**The confirmation message after claiming a profile was wrong.** When someone entered their email in the claim band on their own profile, we replied "Thanks — we'll let [their own name] know their GoodParty.org profile is ready to claim." We were telling a candidate that we'd notify them about themselves. It now reads "Thanks — we'll be in touch at that address about claiming your profile," which is what actually happens.

That band only appears on unclaimed profiles, so this is the first message a candidate sees from us on their own page — worth getting right.

## What changes for the marketing team

**The two claim forms now have permanent names in HubSpot.** HubSpot's "collected forms" tool tracks forms that weren't built in HubSpot, and it identifies each one by the form's id. Neither of these forms had one, so HubSpot fell back to identifying them by their styling — the list of CSS classes on the form. That meant any cosmetic tweak (changing the spacing or the width) would silently register as a brand-new form in HubSpot and quietly orphan whatever workflow was attached to the old one. Nothing would error, on the site or in HubSpot; submissions would just stop arriving where someone expected them.

The two forms are now `person-claim-owner` (the band on the profile, where the person claims their own page) and `person-claim-notify` (the form in the dialog, where a visitor asks us to nudge someone else). They're deliberately different ids, because the two are different intents that deserve different follow-up: one is a person claiming themselves, the other is a stranger flagging someone.

A test now asserts both ids, so a future restyle can't quietly drop them.

## Risk

Contained. The changes touch only the two claim form components on person profiles — one message string and one attribute on each form. No API, routing, data model, or build configuration is involved, and nothing here depends on a backend change landing first.

Made with [Cursor](https://cursor.com)