### PR TITLE
fix(people): stop treating a concluded race as a current candidacy

### DIFF
--- a/src/lib/peopleProfile.test.ts
+++ b/src/lib/peopleProfile.test.ts
@@ -247,6 +247,90 @@ describe('composeView persona resolution', () => {
 		expect(view.persona).toBe('both');
 	});
 
+	// Regression: election-api keeps a candidacy row forever, so counting rows
+	// rather than dating them kept every officeholder who had ever run reading
+	// as a current candidate. Shape below is Monique Bryant's live spine — a
+	// 2024 school-board race she won, and the 2025–2028 term she is serving.
+	test('an officeholder whose only race already happened is not still running', () => {
+		const view = composeView(
+			PID,
+			makePerson({
+				fullName: 'Monique Bryant',
+				Candidacies: [
+					{
+						id: 'c1',
+						positionName: 'Detroit Community School District Board',
+						Race: { electionDate: '2024-11-05' },
+					},
+				],
+				OfficeHolders: [
+					makeOffice({
+						isCurrent: true,
+						positionName: 'Detroit Community School District Board',
+						partyNames: ['Nonpartisan'],
+						startAt: '2025-01-01',
+						endAt: '2028-12-31',
+					}),
+				],
+			}),
+			null,
+		);
+		expect(view.persona).toBe('officeholder');
+		expect(view.roleTitle).toBe('Detroit Community School District Board');
+		// The "Candidate for …" line is what the bug report saw; it must be gone.
+		expect(view.secondaryRoleTitle).toBeNull();
+		// Persona drives the template: unclaimed non-partisan officeholder is E,
+		// not the candidate-and-officeholder frame F.
+		expect(view.state).toBe('E');
+	});
+
+	test('serving and running at once still resolves to both when the race is ahead', () => {
+		const view = composeView(
+			PID,
+			makePerson({
+				fullName: 'Santosh Salvi',
+				Candidacies: [
+					{ id: 'c1', positionName: 'Nashua School Board', Race: { electionDate: '2025-11-04' } },
+					{ id: 'c2', positionName: 'State House', Race: { electionDate: '2099-09-08' } },
+				],
+				OfficeHolders: [makeOffice({ isCurrent: true, officeTitle: 'State Representative' })],
+			}),
+			null,
+		);
+		expect(view.persona).toBe('both');
+		expect(view.secondaryRoleTitle).toBe('Candidate for State House');
+	});
+
+	test('a former officeholder whose only race is over reads as past, not running', () => {
+		const view = composeView(
+			PID,
+			makePerson({
+				fullName: 'Jane Doe',
+				Candidacies: [{ id: 'c1', positionName: 'Mayor', Race: { electionDate: '2018-11-06' } }],
+				OfficeHolders: [
+					makeOffice({ isCurrent: false, officeTitle: 'Mayor', startAt: '2014-01-01', endAt: '2018-01-01' }),
+				],
+			}),
+			null,
+		);
+		expect(view.persona).toBe('past');
+		expect(view.roleTitle).toBe('Former Mayor');
+	});
+
+	test('an undated race counts as running — absent data is not a concluded race', () => {
+		const view = composeView(
+			PID,
+			makePerson({
+				fullName: 'Jane Doe',
+				// No Race at all: the spine could not date this run.
+				Candidacies: [{ id: 'c1', positionName: 'Mayor' }],
+				OfficeHolders: [makeOffice({ isCurrent: true, officeTitle: 'City Council' })],
+			}),
+			null,
+		);
+		expect(view.persona).toBe('both');
+	});
+
 	test('the hero names the current race, not whichever candidacy the API returns first', () => {
 		const view = composeView(
 			PID,

--- a/src/lib/peopleProfile.ts
+++ b/src/lib/peopleProfile.ts
@@ -241,19 +241,38 @@ function pickCurrentOffice(person: PersonItem | null): PersonOfficeHolder | null
 	return [...offices].sort((a, b) => (b.startAt ?? '').localeCompare(a.startAt ?? ''))[0] ?? null;
 }
 
+/**
+ * Whether the person is running in a race that has not been decided yet.
+ *
+ * Candidacy rows are permanent — election-api keeps every race a person ever
+ * ran in — so the mere existence of one says nothing about whether they are
+ * running *now*. Only a race whose election is still ahead of us counts.
+ *
+ * Undated rows count as current: a missing `Race.electionDate` means "we don't
+ * know when", not "already happened", and treating absent data as concluded
+ * would silently demote a real candidate out of the running personas.
+ */
+function isRunningNow(person: PersonItem | null): boolean {
+	const { upcoming, undated } = candidaciesByRecency(person?.Candidacies ?? []);
+	return upcoming.length > 0 || undated.length > 0;
+}
+
 export function resolvePersona(
 	person: PersonItem | null,
 	office: PersonOfficeHolder | null,
 ): PersonPersona {
-	const hasCandidacy = (person?.Candidacies?.length ?? 0) > 0;
+	const runningNow = isRunningNow(person);
 	const isCurrentlyInOffice = office?.isCurrent === true;
 	const heldOfficeBefore = (person?.OfficeHolders?.length ?? 0) > 0;
 
-	if (hasCandidacy && isCurrentlyInOffice) return 'both';
+	if (runningNow && isCurrentlyInOffice) return 'both';
 	if (isCurrentlyInOffice) return 'officeholder';
-	if (hasCandidacy) return 'candidate';
+	if (runningNow) return 'candidate';
 	if (heldOfficeBefore) return 'past';
-	// A claimed person with no civics rows yet reads best as a candidate.
+	// Nothing current to go on. Someone whose only row is a concluded race has
+	// no officeholder term to say they won and no result field to say they
+	// lost, so the candidate framing stays the least-wrong reading — as it does
+	// for a claimed person with no civics rows at all.
 	return 'candidate';
 }
 

--- a/src/testing/peopleProfileFixtures.ts
+++ b/src/testing/peopleProfileFixtures.ts
@@ -57,6 +57,17 @@ export interface ExpectedFacts {
 
 // ----- builders --------------------------------------------------------------
 
+/**
+ * Election day for the fixtures' candidacy, always ~1 year out.
+ *
+ * Derived from the clock rather than hardcoded because `resolvePersona` only
+ * treats an UPCOMING race as making someone a current candidate. Every fixture
+ * below that expects a `candidate` or `both` persona depends on this date being
+ * in the future, so a fixed literal would quietly reclassify half the matrix
+ * the moment it went stale — the same class of bug this date guards against.
+ */
+const UPCOMING_ELECTION_DATE = `${new Date().getUTCFullYear() + 1}-11-03`;
+
 function candidacy(over: Partial<PersonCandidacySummary> = {}): PersonCandidacySummary {
 	// No `slug` on purpose: loadPrimaryCandidacy short-circuits without one, so
 	// the matrix stays focused on state/gating rather than the race fetch.
@@ -66,7 +77,7 @@ function candidacy(over: Partial<PersonCandidacySummary> = {}): PersonCandidacyS
 		positionName: 'Mayor of Springfield',
 		party: 'Independent',
 		state: 'CA',
-		Race: { electionDate: '2024-11-05' },
+		Race: { electionDate: UPCOMING_ELECTION_DATE },
 		...over,
 	};
 }


### PR DESCRIPTION
Marketing reported that some elected officials show up as active candidates, with Monique Bryant as the example: she is serving a 2025–2028 school board term, and her profile was also billing her as a candidate for the very seat she already holds.

## Why it happened

`resolvePersona` decided someone was running by counting candidacy rows:

```ts
const hasCandidacy = (person?.Candidacies?.length ?? 0) > 0;
```

election-api keeps every race a person ever filed in — that is the point of the spine — so a row proves they ran once, not that they are running now. Monique's only candidacy is the November 2024 race she won, which is exactly what produced the 2025–2028 term. Counting it made her `both` (serving *and* running), so the page rendered the candidate-and-officeholder frame plus a "Candidate for Detroit Community School District Board" line under a hero that already named that office.

The odd part is that this file already knew how to do this correctly. `candidaciesByRecency` exists precisely to bucket races into upcoming / past / undated, and both `primaryCandidacy` and `selectPrimaryCandidacy` go through it. Persona derivation was the one place that read the array raw, so the hero line and the persona could disagree about whether a race had happened.

## What changed

Only an upcoming race now makes someone a current candidate. Undated races still count — a missing `Race.electionDate` means "we don't know when", not "already happened", and treating absent data as concluded would silently blank a real candidate's hero.

This is deliberately not pushed into election-api: serving every candidacy row is correct, and deciding whether someone is *currently* running is presentation logic that already lives here.

## Scope of the behaviour change

This moves people between rendered templates, so it is worth eyeballing on the preview. Against live production data:

| Person | Before | After |
| --- | --- | --- |
| Monique Bryant | `both`, state F, "Candidate for Detroit Community School District Board" | `officeholder`, state E, no candidate line |
| Monica Radyko | `both`, state F | `officeholder`, state E |
| Omari Ferguson | `both`, state F | `officeholder`, state E |
| Santosh Salvi | `both`, state I | `both`, state I — unchanged, he has a real 2026 primary ahead |
| Matthew Crowley | `candidate`, state D | `candidate`, state D — unchanged |

It is not a handful of pages. Sampling seven states (MI, FL, CA, NH, OH, NC, WA) — 35,971 people — 9,461 of them hold current office with only concluded races on file, so roughly a quarter of profiles were wearing the wrong frame. 1,437 in that sample are legitimately serving-and-running and keep the `both` treatment.

One knock-on beyond the report, which I think is the same bug: a former officeholder whose only race is long over now reads `past` ("Former Mayor") instead of `candidate` ("Candidate for Mayor").

## A fixture trap worth knowing about

The 12-state matrix fixtures dated their candidacy `2024-11-05`, which stopped meaning "currently running" a while ago — so states A/C/D/F/I/K were quietly describing concluded races while asserting candidate personas. They now derive a date a year out from the clock instead of a literal, so they cannot go stale and reclassify themselves again. That is the same failure mode as the bug itself, just in test data.

The stale-candidate half was the less urgent of the two reports; the pledged-showing-as-unclaimed half is diagnosed separately in #226 and is an upstream data problem, not a change to this repo.

Made with [Cursor](https://cursor.com)