### PR TITLE
fix(people): don't pre-check the claim modal's marketing opt-in

### DIFF
--- a/src/components/people/ClaimProfileModal.tsx
+++ b/src/components/people/ClaimProfileModal.tsx
@@ -38,12 +38,15 @@ type NotifyValues = { firstname: string; email: string; marketingConsent: boolea
  */
 export function NotifyForm({ personId, displayName }: { personId: string; displayName: string }) {
 	const [isSuccess, setIsSuccess] = useState(false);
+	// marketingConsent starts false against the Figma dialog (1901:51851), which
+	// draws the box ticked: a pre-ticked box opts the sender in unless they notice
+	// and clear it, which is not consent under GDPR. Do not restore Figma parity.
 	const {
 		register,
 		handleSubmit,
 		setError,
 		formState: { errors, isSubmitting },
-	} = useForm<NotifyValues>({ defaultValues: { firstname: '', email: '', marketingConsent: true } });
+	} = useForm<NotifyValues>({ defaultValues: { firstname: '', email: '', marketingConsent: false } });
 
 	async function onSubmit(values: NotifyValues) {
 		try {

--- a/src/components/people/claimFormIds.test.tsx
+++ b/src/components/people/claimFormIds.test.tsx
@@ -131,3 +131,22 @@ describe('claim form HubSpot ids', () => {
 		expect(new Set(ids).size).toBe(ids.length);
 	});
 });
+
+describe('claim form marketing consent', () => {
+	/**
+	 * The Figma dialog (1901:51851) draws this box ticked, so the unchecked default
+	 * looks like a parity bug to anyone re-reading the frame and is a one-word revert
+	 * away. It is deliberate: a pre-ticked box opts the sender in unless they notice
+	 * and clear it, which is not consent under GDPR. Nothing else fails if it flips.
+	 */
+	test('the notify form does not pre-check the marketing opt-in', async () => {
+		const { NotifyForm } = await import('./ClaimProfileModal');
+
+		await render(React.createElement(NotifyForm, notifyProps));
+
+		const consent = document.querySelector<HTMLInputElement>('input[name="marketingConsent"]');
+		expect(consent).not.toBeNull();
+		expect(consent?.type).toBe('checkbox');
+		expect(consent?.checked).toBe(false);
+	});
+});


### PR DESCRIPTION
Flagged by Emily from a screenshot of the claim modal on a public person profile.

## What's wrong

The "Not [Name]?" notify form inside the unclaimed-profile claim modal ships its marketing-consent checkbox already ticked. That form is filled in by a **visitor** who is doing us a favour by nudging someone else to claim their page — the email captured is the visitor's own — so as it stands we sign that person up for GoodParty.org marketing unless they spot the box and untick it.

Opting someone in by default isn't valid consent. Under GDPR consent has to be a freely given, unambiguous affirmative action, and a box the user never touched isn't one; pre-ticking is also contrary to normal practice under CAN-SPAM and CASL.

It's also the only pre-ticked consent box we have. App sign-up starts unchecked (`SignUpForm.tsx`), and every layer behind this form already assumes no: the `/api/people/claim-request` proxy, the public Zod contract, `createClaimRequest`, and the `person_profile_claim_request.marketing_consent` column all default to `false`. The UI default contradicted its own stack.

## Deliberate divergence from Figma

The Figma dialog (`1901:51851`) draws the box **ticked**, in both the desktop and mobile frames, which is why it was built this way. This PR intentionally diverges from that, and the divergence was approved: a consent default is a legal question, not a design one. Emily has been asked to update the frames so they stop being cited as justification.

Because it looks like a parity bug to anyone re-reading the frame, and is a one-word revert away with nothing else failing if it flips, the unchecked default is pinned by a test and by a comment at the `useForm` call.

## No backfill needed

Nothing was retroactively broken. The stored flag is inert — there is no reader of `marketing_consent` or `ProfileClaimRequest` anywhere in gp-marketing or gp-api outside the write path and its tests, no HubSpot sync, no workflow, no export. Nobody was subscribed to anything on the strength of the ticked box, so there is no bad consent data to clean up.

(Separately, and unaffected by this PR: HubSpot's collected-forms script picks the submitted email up regardless of the checkbox, since the form carries the `person-claim-notify` id for exactly that purpose. Whether the consent field maps to a HubSpot property lives in the portal config, not in this repo — worth a look by whoever administers it.)

## Known follow-ups, deliberately not in this PR

- **The consent sentence is ambiguous about who is signing up.** In a form headed "Not [Name]?", "Sign up for marketing communications from GoodParty.org" can be read as signing the candidate up rather than the sender. Needs a copy change; Emily to confirm wording.
- **The band has no consent checkbox at all.** `PersonClaimCTABand` is the form the candidate themself fills in, and it never asks — so today we ask the bystander and not the person we actually want a relationship with. Adding an unchecked box there is the coherent fix, pending Emily's sign-off on the copy.
- **"Your name (optional)" registers as `firstname`.** That's the field HubSpot maps onto its first-name property, so anyone typing a full name puts it all in first name. Affects the band the same way.

## Conflict note

Touches `ClaimProfileModal.tsx` and `claimFormIds.test.tsx`, which are also being edited by the in-flight HubSpot form-selector PR. This change sits on the `useForm` defaults rather than the `<form>` element, and the test addition is a separate `describe` block appended to the file, so both should merge cleanly.

Made with [Cursor](https://cursor.com)