### PR TITLE
fix(people): strip Tailwind classes off the claim forms so HubSpot's selector holds

### DIFF
--- a/src/components/people/ClaimProfileModal.tsx
+++ b/src/components/people/ClaimProfileModal.tsx
@@ -15,12 +15,18 @@ const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 /**
  * Stable identity for HubSpot's non-HubSpot ("collected") forms tool. DO NOT
- * rename, and do not remove it in favour of styling: the site-wide HubSpot
- * tracking script keys a collected form on the `<form>` tag's id, falling back to
- * its class list when there is no id. Without this the form was filed under
- * `.flex, .w-full, .flex-col, .gap-4, .text-left`, so any change to its spacing
- * or width silently created a NEW form in HubSpot and orphaned the marketing
- * workflows attached to the old one — with no error anywhere.
+ * rename or drop it.
+ *
+ * The site-wide HubSpot tracking script names a collected form after a CSS
+ * selector built from the `<form>` tag's `id` **and** its class list — the id is
+ * not a replacement for the classes, it is a prefix to them. An id alone yields
+ * `#person-claim-notify`; an id plus classes yields
+ * `#person-claim-notify .flex, .w-full, .flex-col, .gap-4, .text-left`, which
+ * re-keys the form in HubSpot the moment anyone touches its spacing or width.
+ * HubSpot then files submissions under a brand-new form and orphans the
+ * workflows attached to the old one, with no error anywhere. That is why the
+ * `<form>` below carries the id and nothing else: every styling class lives on
+ * the wrapper `<div>` inside it, where designers can churn it freely.
  *
  * Distinct from {@link PersonClaimCTABand}'s id on purpose. HubSpot groups
  * submissions by this value, and the two forms are different intents that want
@@ -80,67 +86,64 @@ export function NotifyForm({ personId, displayName }: { personId: string; displa
 	}
 
 	return (
-		<form
-			id={NOTIFY_FORM_ID}
-			className='flex w-full flex-col gap-4 text-left'
-			onSubmit={(e) => void handleSubmit(onSubmit)(e)}
-			noValidate
-		>
-			<TextInput
-				label='Your name (optional)'
-				autoComplete='name'
-				error={errors.firstname?.message}
-				{...register('firstname')}
-			/>
-			<TextInput
-				label='Your email'
-				type='email'
-				required
-				autoComplete='email'
-				inputMode='email'
-				error={errors.email?.message}
-				{...register('email', {
-					required: 'Email is required',
-					pattern: { value: EMAIL_PATTERN, message: 'Enter a valid email address' },
-				})}
-			/>
-			<label htmlFor='notify-marketing-consent' className='flex items-start gap-2.5'>
-				<input
-					id='notify-marketing-consent'
-					type='checkbox'
-					className='mt-0.5 h-5 w-5 shrink-0 rounded border-neutral-300 text-btn-primary-bg accent-btn-primary-bg focus:outline-none focus-visible:ring-2 focus-visible:ring-btn-primary-bg/30'
-					{...register('marketingConsent')}
+		<form id={NOTIFY_FORM_ID} onSubmit={(e) => void handleSubmit(onSubmit)(e)} noValidate>
+			<div className='flex w-full flex-col gap-4 text-left'>
+				<TextInput
+					label='Your name (optional)'
+					autoComplete='name'
+					error={errors.firstname?.message}
+					{...register('firstname')}
 				/>
-				<Text as='span' styleType='body-2'>
-					Sign up for marketing communications from{' '}
-					<a
-						href='https://goodparty.org'
-						target='_blank'
-						rel='noopener noreferrer'
-						className='underline'
-						onClick={(e) => e.stopPropagation()}
-					>
-						GoodParty.org
-					</a>
-					. Unsubscribe at any time.
-				</Text>
-			</label>
-			{errors.root?.message && (
-				<Text styleType='caption' className='text-error-600' role='alert'>
-					{errors.root.message}
-				</Text>
-			)}
-			<Button
-				parent='ClaimProfileModal'
-				type='submit'
-				styleType='secondary'
-				styleSize='md'
-				isLoading={isSubmitting}
-				disabled={isSubmitting}
-				className='w-fit'
-			>
-				Notify {displayName}
-			</Button>
+				<TextInput
+					label='Your email'
+					type='email'
+					required
+					autoComplete='email'
+					inputMode='email'
+					error={errors.email?.message}
+					{...register('email', {
+						required: 'Email is required',
+						pattern: { value: EMAIL_PATTERN, message: 'Enter a valid email address' },
+					})}
+				/>
+				<label htmlFor='notify-marketing-consent' className='flex items-start gap-2.5'>
+					<input
+						id='notify-marketing-consent'
+						type='checkbox'
+						className='mt-0.5 h-5 w-5 shrink-0 rounded border-neutral-300 text-btn-primary-bg accent-btn-primary-bg focus:outline-none focus-visible:ring-2 focus-visible:ring-btn-primary-bg/30'
+						{...register('marketingConsent')}
+					/>
+					<Text as='span' styleType='body-2'>
+						Sign up for marketing communications from{' '}
+						<a
+							href='https://goodparty.org'
+							target='_blank'
+							rel='noopener noreferrer'
+							className='underline'
+							onClick={(e) => e.stopPropagation()}
+						>
+							GoodParty.org
+						</a>
+						. Unsubscribe at any time.
+					</Text>
+				</label>
+				{errors.root?.message && (
+					<Text styleType='caption' className='text-error-600' role='alert'>
+						{errors.root.message}
+					</Text>
+				)}
+				<Button
+					parent='ClaimProfileModal'
+					type='submit'
+					styleType='secondary'
+					styleSize='md'
+					isLoading={isSubmitting}
+					disabled={isSubmitting}
+					className='w-fit'
+				>
+					Notify {displayName}
+				</Button>
+			</div>
 		</form>
 	);
 }

--- a/src/components/people/PersonClaimCTABand.tsx
+++ b/src/components/people/PersonClaimCTABand.tsx
@@ -14,8 +14,9 @@ const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 /**
  * Stable identity for HubSpot's non-HubSpot ("collected") forms tool — see the
  * matching constant in ClaimProfileModal for why this must not be renamed or
- * dropped. Deliberately different from that one so HubSpot files owner claims
- * separately from visitor nudges; they warrant different follow-up.
+ * dropped, and why the `<form>` tag below carries no className. Deliberately
+ * different from that one so HubSpot files owner claims separately from visitor
+ * nudges; they warrant different follow-up.
  */
 const CLAIM_FORM_ID = 'person-claim-owner';
 
@@ -94,47 +95,53 @@ export function PersonClaimCTABand({ personId, displayName, isRunning }: PersonC
 							</Text>
 						</div>
 					) : (
-						<form
-							id={CLAIM_FORM_ID}
-							className='flex w-full max-w-md flex-col gap-4 text-left'
-							onSubmit={(e) => void handleSubmit(onSubmit)(e)}
-							noValidate
-						>
-							<TextInput
-								label='Name (optional)'
-								autoComplete='name'
-								error={errors.firstname?.message}
-								{...register('firstname')}
-							/>
-							<TextInput
-								label='Email address'
-								type='email'
-								required
-								autoComplete='email'
-								inputMode='email'
-								error={errors.email?.message}
-								{...register('email', {
-									required: 'Email is required',
-									pattern: { value: EMAIL_PATTERN, message: 'Enter a valid email address' },
-								})}
-							/>
-							{errors.root?.message && (
-								<Text styleType='caption' className='text-error-600' role='alert'>
-									{errors.root.message}
-								</Text>
-							)}
-							<Button
-								parent='PersonClaimCTABand'
-								type='submit'
-								styleType='primary'
-								styleSize='md'
-								isLoading={isSubmitting}
-								disabled={isSubmitting}
-								className='mx-auto w-fit'
-							>
-								Submit
-							</Button>
-						</form>
+						// The sizing sits on the wrapper, not the <form>, because the band is a
+						// `flex flex-col items-center` column: its children do not stretch, so
+						// whichever element is the flex item has to carry `w-full max-w-md` or
+						// the field column collapses to its content width.
+						<div className='w-full max-w-md'>
+							<form id={CLAIM_FORM_ID} onSubmit={(e) => void handleSubmit(onSubmit)(e)} noValidate>
+								<div className='flex flex-col gap-4 text-left'>
+									<TextInput
+										label='Name (optional)'
+										autoComplete='name'
+										error={errors.firstname?.message}
+										{...register('firstname')}
+									/>
+									<TextInput
+										label='Email address'
+										type='email'
+										required
+										autoComplete='email'
+										inputMode='email'
+										error={errors.email?.message}
+										{...register('email', {
+											required: 'Email is required',
+											pattern: {
+												value: EMAIL_PATTERN,
+												message: 'Enter a valid email address',
+											},
+										})}
+									/>
+									{errors.root?.message && (
+										<Text styleType='caption' className='text-error-600' role='alert'>
+											{errors.root.message}
+										</Text>
+									)}
+									<Button
+										parent='PersonClaimCTABand'
+										type='submit'
+										styleType='primary'
+										styleSize='md'
+										isLoading={isSubmitting}
+										disabled={isSubmitting}
+										className='mx-auto w-fit'
+									>
+										Submit
+									</Button>
+								</div>
+							</form>
+						</div>
 					)}
 				</div>
 			</Container>

--- a/src/components/people/claimFormIds.test.tsx
+++ b/src/components/people/claimFormIds.test.tsx
@@ -5,14 +5,18 @@ import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 
 /**
- * Guards the `<form id>` on both person-profile claim forms.
+ * Guards the `<form id>` — and the absence of a `<form class>` — on both
+ * person-profile claim forms.
  *
  * These ids are an external contract with HubSpot, not decoration. The site-wide
- * tracking script collects submissions via the non-HubSpot forms tool, which keys
- * a form on its id and silently falls back to the class list when the id is
- * absent — filing submissions under a brand-new form and orphaning whatever
- * marketing workflow was attached to the old one. Nothing throws when that
- * happens, on the site or in HubSpot, so CI is the only place it can be caught.
+ * tracking script collects submissions via the non-HubSpot forms tool, which
+ * names each form after a CSS selector built from the form element's id AND its
+ * class list, concatenated. An id does not replace the classes, it prefixes
+ * them: `id` + `class='flex gap-4'` is filed as `#the-id .flex, .gap-4`, so
+ * bumping `gap-4` to `gap-6` re-keys the form and HubSpot starts a fresh one,
+ * orphaning whatever marketing workflow was attached to the old one. Nothing
+ * throws when that happens, on the site or in HubSpot, so CI is the only place
+ * it can be caught.
  *
  * These mount the form components directly rather than driving the dialog open,
  * because Radix's click delegation has proven unreliable under JSDOM here. The id
@@ -84,6 +88,29 @@ async function render(element: React.ReactElement) {
 const bandProps = { personId: 'person-1', displayName: 'Example Person', isRunning: true };
 const notifyProps = { personId: 'person-1', displayName: 'Example Person' };
 
+/**
+ * The empty class list is load-bearing, not tidiness — do not relax this to make
+ * a styling change easier.
+ *
+ * HubSpot appends the form element's classes to the id when it names a collected
+ * form, so a bare id yields the selector `#person-claim-owner` while a single
+ * Tailwind utility yields `#person-claim-owner .flex`. Every subsequent utility
+ * churn (a designer widening a gap, dropping `max-w-md`, a Figma-parity pass)
+ * then hands HubSpot a name it has never seen and it opens a new form, breaking
+ * submission history and the workflows keyed on the old one. Silently: no error
+ * surfaces anywhere, the numbers just go flat.
+ *
+ * Styling belongs on the wrapper `<div>` inside each form, which HubSpot never
+ * looks at. If a class genuinely must live on the form element, it has to be a
+ * stable semantic name that styling passes will not touch — update this helper
+ * deliberately rather than deleting the assertion.
+ */
+function expectNoStylingClasses(form: Element | null) {
+	if (!form) throw new Error('expected the claim form to be in the document');
+	expect(form.getAttribute('class')).toBeNull();
+	expect(form.classList.length).toBe(0);
+}
+
 describe('claim form HubSpot ids', () => {
 	test('PersonClaimCTABand renders form#person-claim-owner', async () => {
 		const { PersonClaimCTABand } = await import('./PersonClaimCTABand');
@@ -97,6 +124,14 @@ describe('claim form HubSpot ids', () => {
 		expect(form?.querySelector('input[name="email"]')).not.toBeNull();
 	});
 
+	test('the band form carries no classes, so HubSpot sees #person-claim-owner alone', async () => {
+		const { PersonClaimCTABand } = await import('./PersonClaimCTABand');
+
+		await render(React.createElement(PersonClaimCTABand, bandProps));
+
+		expectNoStylingClasses(document.querySelector('form#person-claim-owner'));
+	});
+
 	test('the claim dialog notify form renders form#person-claim-notify', async () => {
 		const { NotifyForm } = await import('./ClaimProfileModal');
 
@@ -106,6 +141,14 @@ describe('claim form HubSpot ids', () => {
 		expect(form).not.toBeNull();
 		expect(form?.querySelector('input[name="firstname"]')).not.toBeNull();
 		expect(form?.querySelector('input[name="email"]')).not.toBeNull();
+	});
+
+	test('the notify form carries no classes, so HubSpot sees #person-claim-notify alone', async () => {
+		const { NotifyForm } = await import('./ClaimProfileModal');
+
+		await render(React.createElement(NotifyForm, notifyProps));
+
+		expectNoStylingClasses(document.querySelector('form#person-claim-notify'));
 	});
 
 	test('the two ids differ, so HubSpot files owner claims apart from visitor nudges', async () => {


### PR DESCRIPTION
## Why

We gave the two person-profile claim forms stable ids in #222 so HubSpot's
collected-forms tracker would have something durable to key on. It turns out an
id is not enough on its own.

HubSpot names a non-HubSpot form after a CSS selector built from the form
element's **id and its class list, concatenated**. The id prefixes the classes;
it does not replace them. So the forms have been showing up in HubSpot as:

| | before | after |
|---|---|---|
| Owner claim band | `#person-claim-owner .flex, .w-full, .max-w-md, .flex-col, .gap-4, .text-left` | `#person-claim-owner` |
| "Not <name>?" notify form | `#person-claim-notify .flex, .w-full, .flex-col, .gap-4, .text-left` | `#person-claim-notify` |

Those trailing classes are Tailwind utilities sitting on the `<form>` tag, which
makes the name churn with the styling. A designer widening `gap-4` to `gap-6`,
dropping `max-w-md`, or a Figma-parity pass touching the spacing would each hand
HubSpot a selector it has never seen. HubSpot has no way to recognise that as the
same form, so it opens a new one: submission history stops accumulating on the
old record, and any workflow, list, or report keyed on it quietly stops firing.
Nothing errors — on the site or in HubSpot — so the only symptom is the numbers
going flat, and nobody would notice for weeks.

This is a real external-contract problem rather than a tidiness nit: the form
element's markup is effectively a public API that a styling change can break by
accident.

## What changes

Every utility class moves off the two `<form>` tags onto a wrapper `<div>` inside
them, so each form carries its id and nothing else and future styling can only
touch the wrapper.

The CTA band needed one extra step. Its parent is a `flex flex-col items-center`
column, so children do not stretch and whichever element is the flex item has to
carry `w-full max-w-md` — otherwise the field column collapses to its content
width. That sizing now lives on an outer wrapper around the form. The notify
form's parent is a plain `flex flex-col` (default `align-items: stretch`), so the
form fills the width on its own and needed no outer wrapper.

## Rendering

Unchanged, and verified rather than eyeballed: the band and the opened claim
modal were screenshotted at 1280px and 375px before and after, and all four pairs
are pixel-identical, with every measured bounding box (form, first field, submit
button) matching exactly. Worth a quick look at the Vercel preview anyway since
this touches what renders.

The existing `claimFormIds` test now also asserts each form element has no class
attribute, with a comment explaining that the empty class list is load-bearing —
otherwise a future reader would reasonably assume the assertion is pointless and
delete it.

## Not fixed here

`src/ui/ClickToCallBlock.tsx` has the same pattern and is arguably worse: its
`<form>` has **no id at all**, so HubSpot is keying it purely on
`.flex, .w-full, .max-w-md, .flex-col, .items-stretch, .gap-4`. Leaving it alone
deliberately — giving it an id would itself change its selector and cut its
existing submission history, which is a call for marketing to make (they may want
to rename the old record in HubSpot first). Flagging it rather than folding it
into this PR.

Made with [Cursor](https://cursor.com)