### PR TITLE
feat(people): tell gp-api which claim form a submission came from

### DIFF
--- a/src/app/api/people/claim-request/route.test.ts
+++ b/src/app/api/people/claim-request/route.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+
+/**
+ * The proxy half of the claim-request seam. Both public claim forms POST here
+ * and this route forwards to gp-api's `POST /v1/public-person-profiles/claim-request`.
+ *
+ * The field that matters most is `source`: gp-api counts only `notify`
+ * submissions into the subject's HubSpot `candidate_profile_requests`, so if
+ * this route drops or mangles it, either the counter stops moving or owners'
+ * own claims start counting as other people's interest. Neither surfaces an
+ * error anywhere.
+ *
+ * See packages/gp-api/src/personProfiles/controllers/public-person-profiles.controller.ts
+ * in the omni repo for the receiving end.
+ */
+
+const PERSON_ID = '74eee01a-1111-4222-8333-444444444444';
+const EMAIL = 'visitor@example.com';
+
+const { POST } = await import('./route');
+
+let calls: Array<{ url: string; body: Record<string, unknown> }>;
+let originalFetch: typeof globalThis.fetch;
+
+beforeEach(() => {
+	calls = [];
+	originalFetch = globalThis.fetch;
+	globalThis.fetch = (async (url: string, init?: { body?: string }) => {
+		calls.push({ url: String(url), body: JSON.parse(init?.body ?? '{}') as Record<string, unknown> });
+		return { ok: true, status: 200 } as Response;
+	}) as unknown as typeof globalThis.fetch;
+});
+
+afterEach(() => {
+	globalThis.fetch = originalFetch;
+});
+
+async function post(body: unknown): Promise<Response> {
+	const req = new Request('https://marketing.test/api/people/claim-request', {
+		method: 'POST',
+		headers: { 'content-type': 'application/json' },
+		body: JSON.stringify(body),
+	});
+	// The handler only uses the standard Request surface (json()).
+	return POST(req as never);
+}
+
+describe('POST /api/people/claim-request', () => {
+	test('forwards the notify discriminator, which is what drives the counter', async () => {
+		const res = await post({ personId: PERSON_ID, email: EMAIL, firstname: 'Voter', source: 'notify' });
+
+		expect(res.status).toBe(200);
+		expect(calls).toHaveLength(1);
+		expect(calls[0]?.url).toContain('/v1/public-person-profiles/claim-request');
+		expect(calls[0]?.body).toMatchObject({
+			personId: PERSON_ID,
+			requesterEmail: EMAIL,
+			requesterName: 'Voter',
+			source: 'notify',
+		});
+	});
+
+	test('forwards the owner discriminator', async () => {
+		await post({ personId: PERSON_ID, email: EMAIL, source: 'owner' });
+
+		expect(calls[0]?.body['source']).toBe('owner');
+	});
+
+	test('omits source when the caller sends none, rather than guessing one', async () => {
+		// Nothing else on the site posts here, but an unattributed submission must
+		// not be attributed by default: gp-api leaves it out of the count instead.
+		await post({ personId: PERSON_ID, email: EMAIL });
+
+		expect(calls[0]?.body).not.toHaveProperty('source');
+	});
+
+	test('drops an unrecognised source instead of losing the lead to a 400', async () => {
+		// gp-api validates the enum strictly, so forwarding junk would reject the
+		// whole submission. The lead is worth more than the attribution.
+		const res = await post({ personId: PERSON_ID, email: EMAIL, source: 'somewhere-else' });
+
+		expect(res.status).toBe(200);
+		expect(calls[0]?.body).not.toHaveProperty('source');
+		expect(calls[0]?.body['requesterEmail']).toBe(EMAIL);
+	});
+
+	test('still records an absent opt-in as no consent', async () => {
+		await post({ personId: PERSON_ID, email: EMAIL, source: 'owner' });
+
+		expect(calls[0]?.body['marketingConsent']).toBe(false);
+	});
+
+	test('rejects a bad personId before calling gp-api', async () => {
+		const res = await post({ personId: 'nope', email: EMAIL, source: 'notify' });
+
+		expect(res.status).toBe(400);
+		expect(calls).toHaveLength(0);
+	});
+
+	test('rejects a bad email before calling gp-api', async () => {
+		const res = await post({ personId: PERSON_ID, email: 'not-an-email', source: 'notify' });
+
+		expect(res.status).toBe(400);
+		expect(calls).toHaveLength(0);
+	});
+});

--- a/src/app/api/people/claim-request/route.ts
+++ b/src/app/api/people/claim-request/route.ts
@@ -1,5 +1,7 @@
 import { type NextRequest, NextResponse } from 'next/server';
 
+import { isClaimRequestSource } from '~/lib/claimRequest';
+
 const ELECTION_API_BASE = process.env['ELECTIONS_API_BASE_URL'] ?? 'https://election-api.goodparty.org';
 
 const GP_API_BASE =
@@ -10,7 +12,13 @@ const GP_API_BASE =
 const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const PERSON_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
-type ClaimBody = { personId?: string; email?: string; firstname?: string; marketingConsent?: boolean };
+type ClaimBody = {
+	personId?: string;
+	email?: string;
+	firstname?: string;
+	marketingConsent?: boolean;
+	source?: string;
+};
 
 /**
  * POST /api/people/claim-request
@@ -26,7 +34,7 @@ export async function POST(request: NextRequest) {
 		return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
 	}
 
-	const { personId, email, firstname, marketingConsent } = body;
+	const { personId, email, firstname, marketingConsent, source } = body;
 
 	if (!personId || !PERSON_ID_PATTERN.test(personId)) {
 		return NextResponse.json({ error: 'Invalid personId' }, { status: 400 });
@@ -46,6 +54,12 @@ export async function POST(request: NextRequest) {
 				requesterEmail: email,
 				...(firstname ? { requesterName: firstname } : {}),
 				marketingConsent: marketingConsent ?? false,
+				// Only the notify form's submissions count towards a person's HubSpot
+				// candidate_profile_requests, so gp-api needs to know which of the two
+				// forms sent this. An unrecognised value is dropped rather than
+				// forwarded: gp-api validates the enum strictly and would 400 the whole
+				// submission, losing a real lead over a bad discriminator.
+				...(isClaimRequestSource(source) ? { source } : {}),
 			}),
 		});
 		if (!res.ok) {

--- a/src/components/people/ClaimProfileModal.tsx
+++ b/src/components/people/ClaimProfileModal.tsx
@@ -5,6 +5,7 @@ import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 
 import { APP_SIGN_UP_HREF, trackEvent, trackSignUpClicked } from '~/lib/analytics';
+import { buildClaimRequestBody } from '~/lib/claimRequest';
 import { ClaimProfileBlock } from '~/ui/ClaimProfileBlock';
 import { Button, ButtonLink } from '~/ui/Inputs/Button';
 import { TextInput } from '~/ui/Inputs/TextInput';
@@ -59,11 +60,14 @@ export function NotifyForm({ personId, displayName }: { personId: string; displa
 			const res = await fetch('/api/people/claim-request', {
 				method: 'POST',
 				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify({
+				// `notify` marks this as a visitor nudging someone else, which is what
+				// gp-api counts into that person's candidate_profile_requests.
+				body: buildClaimRequestBody({
 					personId,
 					firstname: values.firstname,
 					email: values.email,
 					marketingConsent: values.marketingConsent,
+					source: 'notify',
 				}),
 			});
 			if (!res.ok) throw new Error('Submission failed');

--- a/src/components/people/PersonClaimCTABand.tsx
+++ b/src/components/people/PersonClaimCTABand.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 
 import { trackEvent } from '~/lib/analytics';
+import { buildClaimRequestBody } from '~/lib/claimRequest';
 import { Container } from '~/ui/Container';
 import { Button } from '~/ui/Inputs/Button';
 import { TextInput } from '~/ui/Inputs/TextInput';
@@ -60,7 +61,14 @@ export function PersonClaimCTABand({ personId, displayName, isRunning }: PersonC
 			const res = await fetch('/api/people/claim-request', {
 				method: 'POST',
 				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify({ personId, firstname: values.firstname, email: values.email }),
+				// `owner` is the person claiming their own page, which is not demand
+				// from other people and must never reach candidate_profile_requests.
+				body: buildClaimRequestBody({
+					personId,
+					firstname: values.firstname,
+					email: values.email,
+					source: 'owner',
+				}),
 			});
 			if (!res.ok) throw new Error('Submission failed');
 			trackEvent('Person Profile Claim CTA Submitted', { personId });

--- a/src/lib/claimRequest.test.ts
+++ b/src/lib/claimRequest.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from 'bun:test';
+import { buildClaimRequestBody, isClaimRequestSource } from './claimRequest';
+
+/**
+ * `source` is the only thing that tells gp-api which of the two claim forms a
+ * submission came from, and it decides whether the submission counts towards
+ * that person's HubSpot `candidate_profile_requests`. Getting it wrong is
+ * silent: no error surfaces on the site or in HubSpot, the number just stops
+ * reflecting reality.
+ */
+
+const PERSON_ID = '74eee01a-1111-4222-8333-444444444444';
+const EMAIL = 'visitor@example.com';
+
+const parse = (body: string) => JSON.parse(body) as Record<string, unknown>;
+
+describe('buildClaimRequestBody', () => {
+	test('marks a visitor nudge as notify, the submissions the counter is built on', () => {
+		const body = parse(
+			buildClaimRequestBody({
+				personId: PERSON_ID,
+				email: EMAIL,
+				firstname: 'Curious Voter',
+				marketingConsent: true,
+				source: 'notify',
+			}),
+		);
+
+		expect(body).toEqual({
+			personId: PERSON_ID,
+			firstname: 'Curious Voter',
+			email: EMAIL,
+			marketingConsent: true,
+			source: 'notify',
+		});
+	});
+
+	test('marks a self-claim as owner, so it never inflates the counter', () => {
+		const body = parse(
+			buildClaimRequestBody({
+				personId: PERSON_ID,
+				email: EMAIL,
+				firstname: 'Jane Rivera',
+				source: 'owner',
+			}),
+		);
+
+		expect(body['source']).toBe('owner');
+	});
+
+	test('omits marketingConsent entirely when the form has no opt-in checkbox', () => {
+		// The owner band carries no checkbox. Omitting lets the proxy record the
+		// absence as false; sending false here would be indistinguishable from a
+		// visitor who deliberately unticked it.
+		const body = parse(buildClaimRequestBody({ personId: PERSON_ID, email: EMAIL, source: 'owner' }));
+
+		expect(body).not.toHaveProperty('marketingConsent');
+	});
+
+	test('keeps a false opt-in, which is a real answer rather than an absent one', () => {
+		const body = parse(
+			buildClaimRequestBody({ personId: PERSON_ID, email: EMAIL, marketingConsent: false, source: 'notify' }),
+		);
+
+		expect(body['marketingConsent']).toBe(false);
+	});
+});
+
+describe('isClaimRequestSource', () => {
+	test('accepts the two values gp-api recognises', () => {
+		expect(isClaimRequestSource('notify')).toBe(true);
+		expect(isClaimRequestSource('owner')).toBe(true);
+	});
+
+	test('rejects anything else, so a bad value is never forwarded', () => {
+		// gp-api validates the enum strictly and 400s an unrecognised value, which
+		// would lose the whole lead.
+		expect(isClaimRequestSource('NOTIFY')).toBe(false);
+		expect(isClaimRequestSource('person-claim-notify')).toBe(false);
+		expect(isClaimRequestSource(undefined)).toBe(false);
+		expect(isClaimRequestSource(null)).toBe(false);
+		expect(isClaimRequestSource(1)).toBe(false);
+	});
+});

--- a/src/lib/claimRequest.ts
+++ b/src/lib/claimRequest.ts
@@ -1,0 +1,50 @@
+/**
+ * The wire contract for `/api/people/claim-request`, shared by the two public
+ * claim forms and the proxy route that forwards them to gp-api.
+ *
+ * Both forms POST the same endpoint but mean opposite things:
+ *
+ * - `notify` — a VISITOR asking us to nudge someone else to complete their
+ *   profile (the "Not [Name]?" form in ClaimProfileModal).
+ * - `owner` — the person THEMSELVES claiming their page (PersonClaimCTABand).
+ *
+ * gp-api counts only `notify` submissions into that person's HubSpot
+ * `candidate_profile_requests`, so conflating the two would credit someone's own
+ * claim as demand from other people. Nothing errors if the field is wrong — the
+ * number just goes quietly wrong — which is why the payload is built here, in
+ * one tested place, rather than inline at each call site.
+ *
+ * These strings are the values gp-api's `ProfileClaimRequestSource` enum
+ * accepts. Do not reword them.
+ */
+export const CLAIM_REQUEST_SOURCES = ['notify', 'owner'] as const;
+
+export type ClaimRequestSource = (typeof CLAIM_REQUEST_SOURCES)[number];
+
+export function isClaimRequestSource(value: unknown): value is ClaimRequestSource {
+	return CLAIM_REQUEST_SOURCES.includes(value as ClaimRequestSource);
+}
+
+export type ClaimRequestInput = {
+	personId: string;
+	email: string;
+	firstname?: string;
+	/**
+	 * Omitted entirely by the owner band, which carries no opt-in checkbox — the
+	 * proxy records the absence as `false`. Sending `false` from here instead
+	 * would be indistinguishable from a visitor who unticked the box.
+	 */
+	marketingConsent?: boolean;
+	source: ClaimRequestSource;
+};
+
+export function buildClaimRequestBody(input: ClaimRequestInput): string {
+	const { personId, email, firstname, marketingConsent, source } = input;
+	return JSON.stringify({
+		personId,
+		firstname,
+		email,
+		...(marketingConsent === undefined ? {} : { marketingConsent }),
+		source,
+	});
+}


### PR DESCRIPTION
Pairs with [omni#1235](https://github.com/thegoodparty/omni/pull/1235), which
should land first.

## Why

The two claim forms on a public person profile POST the same endpoint but mean
opposite things:

- **`person-claim-notify`** — a visitor asking us to nudge someone else to
  complete their profile.
- **`person-claim-owner`** — that person claiming their own page.

gp-api now counts the first kind into the subject's HubSpot
`candidate_profile_requests`, so marketing can see which unclaimed people
visitors actually want to hear from. Nothing in the payload distinguished the
two, so without this the counter would either not move or would count a person's
own claim as demand from other people.

Each form now sends `source` (`notify` | `owner`) and the proxy forwards it.

## Notes

The request body moved into a small shared module rather than staying inline at
each call site. Getting `source` wrong is completely silent — no error on the
site, none in HubSpot, the number just stops matching reality — so it is worth
having the payload built once and covered by tests.

An unrecognised `source` is dropped rather than forwarded. gp-api validates the
enum strictly and would reject the whole submission, and a real lead is worth
more than its attribution.

The field is additive and safe to deploy in either order: gp-api treats a
submission without a `source` as unattributed and leaves it out of the count, so
if this ships before the backend nothing breaks — the counter simply does not
move yet.

Nothing changes visually or behaviourally for visitors; the form ids that
HubSpot keys its collected forms on are untouched.

Made with [Cursor](https://cursor.com)