### PR TITLE
Send the claim CTA to the claim form, and split Win from Serve

### DIFF
--- a/src/components/people/ClaimProfileModal.tsx
+++ b/src/components/people/ClaimProfileModal.tsx
@@ -11,6 +11,7 @@ import { Button, ButtonLink } from '~/ui/Inputs/Button';
 import { TextInput } from '~/ui/Inputs/TextInput';
 import { IconResolver } from '~/ui/IconResolver';
 import { Text } from '~/ui/Text';
+import { scrollToPersonClaimForm } from './claimFormAnchor';
 
 const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
@@ -173,12 +174,12 @@ function ClaimPromptCard({
 	displayName,
 	isRunning,
 	variant,
-	onOpen,
+	onClaim,
 }: {
 	displayName: string;
 	isRunning: boolean;
 	variant: 'voter-card' | 'owner-card';
-	onOpen: VoidFunction;
+	onClaim: VoidFunction;
 }) {
 	const owner = variant === 'owner-card';
 	const heading = owner ? `Are you ${displayName}?` : `Want to hear from ${displayName}?`;
@@ -204,7 +205,7 @@ function ClaimPromptCard({
 				styleType='primary'
 				styleSize='md'
 				className='w-fit'
-				onClick={onOpen}
+				onClick={onClaim}
 			>
 				{cta}
 			</Button>
@@ -215,6 +216,17 @@ function ClaimPromptCard({
 export function ClaimProfileModal({ personId, displayName, persona, variant = 'banner' }: ClaimProfileModalProps) {
 	const [open, setOpen] = useState(false);
 	const isRunning = persona === 'candidate' || persona === 'both';
+
+	// The owner-facing prompts ("is this you?") pull the person down to the claim
+	// form at the bottom of their own profile rather than opening this dialog, so
+	// there is one place to claim from and the Win/Serve branch happens once, on
+	// submit. If the band is not on the page the dialog is still the fallback.
+	const claimHere = () => {
+		if (!scrollToPersonClaimForm()) setOpen(true);
+	};
+	// The voter-facing prompt is unchanged: it asks a visitor to nudge someone
+	// else, which is the dialog's "Not [Name]?" notify form, not the claim form.
+	const openDialog = () => setOpen(true);
 
 	const headline = `Is this you, ${displayName}?`;
 	const bannerBody = isRunning
@@ -232,7 +244,7 @@ export function ClaimProfileModal({ personId, displayName, persona, variant = 'b
 					claimButton={{
 						buttonType: 'button',
 						label: 'Claim your profile',
-						onClick: () => setOpen(true),
+						onClick: claimHere,
 						buttonProps: { styleType: 'primary', styleSize: 'md' },
 					}}
 				/>
@@ -241,7 +253,7 @@ export function ClaimProfileModal({ personId, displayName, persona, variant = 'b
 					displayName={displayName}
 					isRunning={isRunning}
 					variant={variant}
-					onOpen={() => setOpen(true)}
+					onClaim={variant === 'owner-card' ? claimHere : openDialog}
 				/>
 			)}
 

--- a/src/components/people/PersonClaimCTABand.tsx
+++ b/src/components/people/PersonClaimCTABand.tsx
@@ -5,6 +5,7 @@ import { useForm } from 'react-hook-form';
 
 import { APP_SIGN_UP_HREF, trackEvent, trackSignUpClicked } from '~/lib/analytics';
 import { buildClaimRequestBody } from '~/lib/claimRequest';
+import { useDecoratedAppHref } from '~/ui/AttributionProvider';
 import { Container } from '~/ui/Container';
 import { Button } from '~/ui/Inputs/Button';
 import { TextInput } from '~/ui/Inputs/TextInput';
@@ -57,6 +58,12 @@ export type PersonClaimCTABandProps = {
  */
 export function PersonClaimCTABand({ personId, displayName, isRunning }: PersonClaimCTABandProps) {
 	const [isSuccess, setIsSuccess] = useState(false);
+	// Every other sign-up link on the site reaches the app through `Anchor`,
+	// which decorates app.goodparty.org URLs with the captured fbclid/utm params.
+	// This branch navigates programmatically and so has to do it by hand, or a
+	// claim that arrived from an ad would land on sign-up stripped of the
+	// attribution that stitches the two halves of the funnel together.
+	const signUpHref = useDecoratedAppHref(APP_SIGN_UP_HREF) ?? APP_SIGN_UP_HREF;
 	const {
 		register,
 		handleSubmit,
@@ -87,8 +94,11 @@ export function PersonClaimCTABand({ personId, displayName, isRunning }: PersonC
 			// still counted in the funnel. Serve stops here: sales follows up from
 			// HubSpot and sends the access link by hand.
 			if (isRunning) {
+				// The event carries the bare href, as every other sign-up link on the
+				// site does, so this point is comparable with the rest of the funnel;
+				// the navigation carries the decorated one.
 				trackSignUpClicked({ href: APP_SIGN_UP_HREF, label: 'Claim profile', formId: CLAIM_FORM_ID });
-				window.location.assign(APP_SIGN_UP_HREF);
+				window.location.assign(signUpHref);
 			}
 		} catch {
 			setError('root', { message: 'Something went wrong. Please try again.' });

--- a/src/components/people/PersonClaimCTABand.tsx
+++ b/src/components/people/PersonClaimCTABand.tsx
@@ -3,12 +3,13 @@
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 
-import { trackEvent } from '~/lib/analytics';
+import { APP_SIGN_UP_HREF, trackEvent, trackSignUpClicked } from '~/lib/analytics';
 import { buildClaimRequestBody } from '~/lib/claimRequest';
 import { Container } from '~/ui/Container';
 import { Button } from '~/ui/Inputs/Button';
 import { TextInput } from '~/ui/Inputs/TextInput';
 import { Text } from '~/ui/Text';
+import { PERSON_CLAIM_ANCHOR_ID } from './claimFormAnchor';
 
 const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
@@ -26,7 +27,14 @@ type NotifyValues = { firstname: string; email: string };
 export type PersonClaimCTABandProps = {
 	personId: string;
 	displayName: string;
-	/** Running personas get "share why you're running"; office personas get "your record". */
+	/**
+	 * Which product this person belongs to, derived from their persona upstream:
+	 * running (candidate/both) is **Win**, in office only is **Serve**.
+	 *
+	 * It picks the body copy ("share why you're running" vs "your record") and,
+	 * on submit, which branch they take — Win self-serves into sign-up, Serve is
+	 * handed to sales, who send an access link by hand.
+	 */
 	isRunning: boolean;
 };
 
@@ -71,8 +79,17 @@ export function PersonClaimCTABand({ personId, displayName, isRunning }: PersonC
 				}),
 			});
 			if (!res.ok) throw new Error('Submission failed');
-			trackEvent('Person Profile Claim CTA Submitted', { personId });
+			trackEvent('Person Profile Claim CTA Submitted', { personId, product: isRunning ? 'win' : 'serve' });
 			setIsSuccess(true);
+
+			// Win only. The lead is stored either way — the redirect happens after a
+			// successful POST so a candidate who abandons sign-up is still a lead and
+			// still counted in the funnel. Serve stops here: sales follows up from
+			// HubSpot and sends the access link by hand.
+			if (isRunning) {
+				trackSignUpClicked({ href: APP_SIGN_UP_HREF, label: 'Claim profile', formId: CLAIM_FORM_ID });
+				window.location.assign(APP_SIGN_UP_HREF);
+			}
 		} catch {
 			setError('root', { message: 'Something went wrong. Please try again.' });
 		}
@@ -82,8 +99,19 @@ export function PersonClaimCTABand({ personId, displayName, isRunning }: PersonC
 		? 'Your community deserves accountable leadership. Claim your profile and share why you\u2019re running and your top priorities with residents. Enter your email to get started.'
 		: 'Your community deserves accountable leadership. Claim your profile and share your record and priorities in office with residents. Enter your email to get started.';
 
+	// Both branches speak to the person themselves, not to a visitor — this band is
+	// only ever the subject entering their own address.
+	const successCopy = isRunning
+		? 'Thanks — taking you to GoodParty.org now to create your free account and finish claiming your profile.'
+		: 'Thanks — someone from our team will email you at that address with a link to access your profile.';
+
 	return (
-		<article className='py-(--container-padding) bg-goodparty-cream' data-component='CTABannerBlock'>
+		<article
+			id={PERSON_CLAIM_ANCHOR_ID}
+			tabIndex={-1}
+			className='py-(--container-padding) scroll-mt-24 bg-goodparty-cream focus:outline-none'
+			data-component='CTABannerBlock'
+		>
 			<Container size='xl'>
 				<div className='flex flex-col items-center gap-6 rounded-2xl bg-blue-100 p-6 text-center text-midnight-900 md:p-12'>
 					<div className='flex max-w-2xl flex-col items-center gap-3 md:gap-4'>
@@ -98,9 +126,7 @@ export function PersonClaimCTABand({ personId, displayName, isRunning }: PersonC
 							role='status'
 							aria-live='polite'
 						>
-							<Text styleType='body-2'>
-								Thanks — we&apos;ll be in touch at that address about claiming your profile.
-							</Text>
+							<Text styleType='body-2'>{successCopy}</Text>
 						</div>
 					) : (
 						// The sizing sits on the wrapper, not the <form>, because the band is a

--- a/src/components/people/claimFlow.test.tsx
+++ b/src/components/people/claimFlow.test.tsx
@@ -1,0 +1,319 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { JSDOM } from 'jsdom';
+import * as React from 'react';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+/**
+ * Covers the claim flow on an unclaimed person profile: the owner-facing prompt
+ * at the top of the content well scrolls down to the claim form rather than
+ * opening the dialog, and submitting that form branches on the person's product
+ * — Win (currently running) into sign-up, Serve (in office only) into a "a human
+ * will be in touch" confirmation.
+ *
+ * Like claimFormIds.test.tsx these mount components directly instead of driving
+ * the Radix dialog, whose click delegation has proven unreliable under JSDOM,
+ * and nothing here mocks `~/lib/analytics`: a partial module mock of it drops
+ * the exports other importers rely on. The analytics assertions read the
+ * `window.amplitude` / `window.dataLayer` sinks the real functions write to.
+ */
+
+const DOM_GLOBALS = [
+	'Node',
+	'NodeFilter',
+	'Element',
+	'HTMLElement',
+	'HTMLInputElement',
+	'HTMLButtonElement',
+	'HTMLFormElement',
+	'DocumentFragment',
+	'DOMRect',
+	'Event',
+	'CustomEvent',
+	'MouseEvent',
+	'KeyboardEvent',
+	'FocusEvent',
+	'MutationObserver',
+] as const;
+
+type ScrollCall = { behavior?: string; id: string };
+
+let dom: JSDOM;
+let root: Root;
+let scrollCalls: ScrollCall[];
+let navigations: string[];
+let trackedEvents: { name: string; props?: Record<string, unknown> }[];
+let dataLayer: Record<string, unknown>[];
+let fetchCalls: { url: string; body: Record<string, unknown> }[];
+let fetchOk: boolean;
+
+beforeEach(() => {
+	dom = new JSDOM('<!DOCTYPE html><html><body><div id="root"></div></body></html>', {
+		url: 'http://localhost/people/example-person',
+		pretendToBeVisual: true,
+	});
+	const { window } = dom;
+
+	globalThis.document = window.document;
+	globalThis.navigator = window.navigator;
+	globalThis.getComputedStyle = window.getComputedStyle.bind(window);
+
+	for (const name of DOM_GLOBALS) {
+		(globalThis as Record<string, unknown>)[name] = (window as unknown as Record<string, unknown>)[name];
+	}
+
+	scrollCalls = [];
+	navigations = [];
+	trackedEvents = [];
+	dataLayer = [];
+	fetchCalls = [];
+	fetchOk = true;
+
+	// JSDOM ships no scrollIntoView at all, so the component would silently skip
+	// the optional call. Standing one up is what makes the scroll observable.
+	(window.Element.prototype as unknown as { scrollIntoView(o?: ScrollIntoViewOptions): void }).scrollIntoView = function (
+		this: Element,
+		options?: ScrollIntoViewOptions,
+	) {
+		scrollCalls.push({ behavior: options?.behavior, id: this.id });
+	};
+
+	// React DOM decides once per process, when it is first imported, whether the
+	// browser fires `input` events — and it answers by looking for a `window`
+	// global. Whichever `.test.tsx` file bun loads first sets that answer for the
+	// whole DOM suite, and every one of them (this file included) imports
+	// react-dom before its JSDOM exists, so react-dom concludes "no" and falls
+	// back to its Internet Explorer path: change tracking via `attachEvent` /
+	// `detachEvent` and `keyup` rather than `input`. JSDOM has neither method, so
+	// focusing an input throws inside React. These no-ops let that path run;
+	// `setInputValue` below then fires the events both paths listen for, which is
+	// what keeps this file independent of which test file bun happens to load
+	// first.
+	const shim = window.HTMLElement.prototype as unknown as Record<string, unknown>;
+	shim['attachEvent'] = () => {};
+	shim['detachEvent'] = () => {};
+
+	(window as unknown as { amplitude: unknown }).amplitude = {
+		track: (name: string, props?: Record<string, unknown>) => trackedEvents.push({ name, props }),
+	};
+	(window as unknown as { dataLayer: unknown }).dataLayer = dataLayer;
+
+	globalThis.fetch = (async (url: string, init?: { body?: string }) => {
+		fetchCalls.push({ url: String(url), body: JSON.parse(init?.body ?? '{}') as Record<string, unknown> });
+		return { ok: fetchOk } as Response;
+	}) as unknown as typeof fetch;
+
+	// `window.location` is unforgeable in JSDOM — it cannot be reassigned or
+	// redefined — so the Win redirect is only observable by handing the code under
+	// test a window whose `location` is ours. Everything else passes straight
+	// through, and `document.defaultView` still points at the real window, which
+	// is what React reads.
+	const fakeLocation = { assign: (url: string) => navigations.push(url), href: window.location.href, pathname: window.location.pathname };
+	globalThis.window = new Proxy(window, {
+		get: (target, prop) => (prop === 'location' ? fakeLocation : Reflect.get(target, prop, target)),
+	}) as unknown as Window & typeof globalThis;
+
+	(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterEach(async () => {
+	if (root) {
+		await act(async () => {
+			root.unmount();
+		});
+	}
+	dom.window.close();
+});
+
+async function render(element: React.ReactElement) {
+	await act(async () => {
+		root = createRoot(document.getElementById('root')!);
+		root.render(element);
+		await flush();
+	});
+}
+
+async function flush() {
+	await new Promise<void>(resolve => {
+		dom.window.setTimeout(resolve, 0);
+	});
+}
+
+async function click(element: Element) {
+	await act(async () => {
+		element.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true, cancelable: true }));
+		await flush();
+	});
+}
+
+async function submitClaimForm({ name, email }: { name: string; email: string }) {
+	const firstname = document.querySelector<HTMLInputElement>('#person-claim-owner input[name="firstname"]')!;
+	const address = document.querySelector<HTMLInputElement>('#person-claim-owner input[name="email"]')!;
+
+	await act(async () => {
+		setInputValue(firstname, name);
+		setInputValue(address, email);
+		await flush();
+	});
+	await act(async () => {
+		document.querySelector('form#person-claim-owner')!.dispatchEvent(new dom.window.Event('submit', { bubbles: true, cancelable: true }));
+		await flush();
+		await flush();
+	});
+}
+
+/**
+ * Types into a react-hook-form field.
+ *
+ * The value goes through the prototype setter so it bypasses the setter React
+ * installs on the element, which is what makes React's value tracker notice a
+ * change. `input` is what React listens to normally; the focus and `keyup` are
+ * what its Internet Explorer fallback listens to (see the shims in
+ * `beforeEach`). Firing all of them makes this work whichever path React took,
+ * and the tracker means only one change is delivered either way.
+ */
+function setInputValue(input: HTMLInputElement, value: string) {
+	const setter = Object.getOwnPropertyDescriptor(dom.window.HTMLInputElement.prototype, 'value')!.set!;
+	input.focus();
+	setter.call(input, value);
+	input.dispatchEvent(new dom.window.Event('input', { bubbles: true }));
+	input.dispatchEvent(new dom.window.KeyboardEvent('keyup', { bubbles: true }));
+	input.dispatchEvent(new dom.window.Event('change', { bubbles: true }));
+}
+
+const personId = '11111111-1111-4111-8111-111111111111';
+const displayName = 'Example Person';
+
+/** Win: currently running (persona `candidate` or `both`). */
+const winProps = { personId, displayName, isRunning: true };
+/** Serve: in office only (persona `officeholder`). */
+const serveProps = { personId, displayName, isRunning: false };
+
+async function renderProfileClaimSurfaces(variant: 'owner-card' | 'voter-card', isRunning: boolean) {
+	const [{ ClaimProfileModal }, { PersonClaimCTABand }] = await Promise.all([import('./ClaimProfileModal'), import('./PersonClaimCTABand')]);
+
+	await render(
+		React.createElement(
+			React.Fragment,
+			null,
+			React.createElement(ClaimProfileModal, {
+				personId,
+				displayName,
+				persona: isRunning ? 'candidate' : 'officeholder',
+				variant,
+			}),
+			React.createElement(PersonClaimCTABand, { personId, displayName, isRunning }),
+		),
+	);
+}
+
+function claimPromptButton(variant: 'owner-card' | 'voter-card') {
+	return document.querySelector(`[data-component='ClaimPromptCard'][data-variant='${variant}'] button`)!;
+}
+
+describe('the top claim prompt pulls the person down to the claim form', () => {
+	test('the owner prompt scrolls to the claim form instead of opening the dialog', async () => {
+		await renderProfileClaimSurfaces('owner-card', true);
+
+		await click(claimPromptButton('owner-card'));
+
+		expect(scrollCalls).toEqual([{ behavior: 'smooth', id: 'person-claim-form' }]);
+		expect(document.querySelector('[role="dialog"]')).toBeNull();
+	});
+
+	test('the owner prompt moves keyboard focus into the claim form', async () => {
+		await renderProfileClaimSurfaces('owner-card', true);
+
+		await click(claimPromptButton('owner-card'));
+
+		const active = document.activeElement;
+		expect(active?.getAttribute('name')).toBe('firstname');
+		expect(active?.closest('form')?.id).toBe('person-claim-owner');
+	});
+
+	test('the scroll is instant when the visitor asks for reduced motion', async () => {
+		(dom.window as unknown as { matchMedia: unknown }).matchMedia = (query: string) => ({ matches: query.includes('reduce'), media: query });
+
+		await renderProfileClaimSurfaces('owner-card', true);
+		await click(claimPromptButton('owner-card'));
+
+		expect(scrollCalls.map(c => c.behavior)).toEqual(['auto']);
+	});
+
+	/**
+	 * Reachable rather than theoretical: the code-default template fallback strips
+	 * the CTA banner block the claim band renders into, which would leave the
+	 * prompt on a page with no form to scroll to. The prompt falls back to the
+	 * dialog there, so it is never a button that does nothing.
+	 */
+	test('the scroll reports failure when the claim band is not on the page', async () => {
+		const { scrollToPersonClaimForm } = await import('./claimFormAnchor');
+
+		expect(scrollToPersonClaimForm()).toBe(false);
+		expect(scrollCalls).toEqual([]);
+	});
+
+	test('the voter prompt is untouched — it does not scroll to the claim form', async () => {
+		await renderProfileClaimSurfaces('voter-card', true);
+
+		await click(claimPromptButton('voter-card'));
+
+		expect(scrollCalls).toEqual([]);
+		expect(document.querySelector('form#person-claim-owner')).not.toBeNull();
+	});
+});
+
+describe('submitting the claim form branches on the person’s product', () => {
+	test('Win stores the claim request and then routes to sign-up', async () => {
+		const { PersonClaimCTABand } = await import('./PersonClaimCTABand');
+		await render(React.createElement(PersonClaimCTABand, winProps));
+
+		await submitClaimForm({ name: 'Example', email: 'example@example.org' });
+
+		expect(fetchCalls).toHaveLength(1);
+		expect(fetchCalls[0]?.url).toBe('/api/people/claim-request');
+		expect(fetchCalls[0]?.body).toEqual({ personId, firstname: 'Example', email: 'example@example.org', source: 'owner' });
+		// The lead is stored first, so an abandoned sign-up still leaves a lead.
+		expect(navigations).toEqual(['https://app.goodparty.org/sign-up']);
+	});
+
+	test('Win fires the sign-up event at the point it navigates', async () => {
+		const { PersonClaimCTABand } = await import('./PersonClaimCTABand');
+		await render(React.createElement(PersonClaimCTABand, winProps));
+
+		await submitClaimForm({ name: 'Example', email: 'example@example.org' });
+
+		const signUp = trackedEvents.filter(e => e.name === 'Sign Up Clicked');
+		expect(signUp).toHaveLength(1);
+		expect(signUp[0]?.props).toMatchObject({ href: 'https://app.goodparty.org/sign-up' });
+		expect(dataLayer).toEqual([{ event: 'sign_up_click', formId: 'person-claim-owner' }]);
+	});
+
+	test('Serve stores the claim request and promises a human, not self-serve access', async () => {
+		const { PersonClaimCTABand } = await import('./PersonClaimCTABand');
+		await render(React.createElement(PersonClaimCTABand, serveProps));
+
+		await submitClaimForm({ name: 'Example', email: 'example@example.org' });
+
+		expect(fetchCalls).toHaveLength(1);
+		expect(fetchCalls[0]?.body).toEqual({ personId, firstname: 'Example', email: 'example@example.org', source: 'owner' });
+		expect(navigations).toEqual([]);
+		expect(trackedEvents.filter(e => e.name === 'Sign Up Clicked')).toHaveLength(0);
+
+		const status = document.querySelector('[role="status"]')?.textContent ?? '';
+		expect(status).toContain('someone from our team will email you');
+		expect(status).toContain('link to access your profile');
+	});
+
+	test('a failed submission neither navigates nor claims success', async () => {
+		fetchOk = false;
+		const { PersonClaimCTABand } = await import('./PersonClaimCTABand');
+		await render(React.createElement(PersonClaimCTABand, winProps));
+
+		await submitClaimForm({ name: 'Example', email: 'example@example.org' });
+
+		expect(navigations).toEqual([]);
+		expect(document.querySelector('form#person-claim-owner')).not.toBeNull();
+		expect(document.querySelector('[role="alert"]')?.textContent).toContain('Something went wrong');
+	});
+});

--- a/src/components/people/claimFlow.test.tsx
+++ b/src/components/people/claimFlow.test.tsx
@@ -253,13 +253,21 @@ describe('the top claim prompt pulls the person down to the claim form', () => {
 		expect(scrollCalls).toEqual([]);
 	});
 
-	test('the voter prompt is untouched — it does not scroll to the claim form', async () => {
+	/**
+	 * The counterpart to the owner-prompt test above: this is the entry point the
+	 * notify form is left with, so it has to be shown opening the dialog, not
+	 * merely not scrolling.
+	 */
+	test('the voter prompt still opens the dialog and its notify form', async () => {
 		await renderProfileClaimSurfaces('voter-card', true);
+
+		expect(document.querySelector('[role="dialog"]')).toBeNull();
 
 		await click(claimPromptButton('voter-card'));
 
+		expect(document.querySelector('[role="dialog"]')).not.toBeNull();
+		expect(document.querySelector('[role="dialog"] form#person-claim-notify')).not.toBeNull();
 		expect(scrollCalls).toEqual([]);
-		expect(document.querySelector('form#person-claim-owner')).not.toBeNull();
 	});
 });
 

--- a/src/components/people/claimFormAnchor.ts
+++ b/src/components/people/claimFormAnchor.ts
@@ -1,0 +1,46 @@
+/**
+ * The scroll target for the owner-facing "claim your profile" CTAs, which pull
+ * the person down to the claim form at the bottom of their profile instead of
+ * opening a dialog.
+ *
+ * Deliberately NOT the `<form id>`. `person-claim-owner` is HubSpot's key for
+ * the collected form and is an external contract; keeping the scroll target on
+ * a wrapper means a future layout change can move the anchor without re-keying
+ * the form in HubSpot, and vice versa.
+ */
+export const PERSON_CLAIM_ANCHOR_ID = 'person-claim-form';
+
+const CLAIM_FIELD_SELECTORS = ['#person-claim-owner input[name="firstname"]', '#person-claim-owner input[name="email"]'];
+
+function prefersReducedMotion(): boolean {
+	if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return false;
+	return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+}
+
+/**
+ * Scrolls to the claim form and moves keyboard focus into it, so keyboard and
+ * screen-reader users land where sighted users are looking.
+ *
+ * Returns `false` when the band is not on the page. That is reachable: the
+ * code-default template fallback strips the CTA banner block the band renders
+ * into, which would leave the claim card on a page with no form. Callers fall
+ * back to the dialog rather than leaving the button doing nothing.
+ */
+export function scrollToPersonClaimForm(): boolean {
+	if (typeof document === 'undefined') return false;
+
+	const anchor = document.getElementById(PERSON_CLAIM_ANCHOR_ID);
+	if (!anchor) return false;
+
+	const field = CLAIM_FIELD_SELECTORS.reduce<HTMLElement | null>(
+		(found, selector) => found ?? document.querySelector<HTMLElement>(selector),
+		null,
+	);
+
+	// Focus first, with preventScroll, so the browser does not jump instantly and
+	// then animate — and so the smooth scroll below is what the user actually sees.
+	(field ?? anchor).focus({ preventScroll: true });
+
+	anchor.scrollIntoView?.({ behavior: prefersReducedMotion() ? 'auto' : 'smooth', block: 'start' });
+	return true;
+}

--- a/src/components/people/personSectionOverrides.test.ts
+++ b/src/components/people/personSectionOverrides.test.ts
@@ -125,6 +125,63 @@ describe('unclaimed pages prompt for every section the claimed page would show',
 	});
 });
 
+describe('the claim prompt and the claim form ship together', () => {
+	/** Every Figma state A–L, so no state can render one half of the pair. */
+	const ALL_STATES = [
+		'allen-slagle-74eee01a',
+		'tracy-good-ecff49d3',
+		'susan-overman-ad914b82',
+		'kim-byrd-b77f912d',
+		'rob-zotti-d8c578fb',
+		'tim-ficken-0a951485',
+		'bill-fortner-61a42912',
+		'gregory-schreurs-136cadf0',
+		'jeb-hanson-3753676b',
+		'deb-craft-f88e7434',
+		'x-27255f40',
+		'x-3412f69c',
+	];
+
+	function claimPromptVariants(slug: string): string[] {
+		return contentCards(slug).flatMap(card => {
+			const variant = (card.content as { props?: { variant?: string } } | undefined)?.props?.variant;
+			return variant ? [variant] : [];
+		});
+	}
+
+	function rendersClaimBand(slug: string): boolean {
+		const view = getDevPersonProfileView(slug);
+		if (!view) throw new Error(`no dev fixture for ${slug}`);
+		const cta = buildPersonSectionOverrides(view).component_ctaBannerBlock as { render?: unknown } | undefined;
+		return cta?.render !== undefined;
+	}
+
+	/**
+	 * The owner prompt's button scrolls to `#person-claim-form`, and that anchor
+	 * only exists inside PersonClaimCTABand. Both hang off the same `showClaim`
+	 * gate today; this pins the pairing so a future change to either gate cannot
+	 * quietly leave the button scrolling to nothing.
+	 */
+	test('no state renders the owner claim prompt without the claim form below it', () => {
+		for (const slug of ALL_STATES) {
+			expect([slug, claimPromptVariants(slug).includes('owner-card')]).toEqual([slug, rendersClaimBand(slug)]);
+		}
+	});
+
+	test('the unclaimed states lead with the owner prompt, then the voter prompt', () => {
+		for (const slug of ['kim-byrd-b77f912d', 'rob-zotti-d8c578fb', 'tim-ficken-0a951485']) {
+			expect([slug, claimPromptVariants(slug)]).toEqual([slug, ['owner-card', 'voter-card']]);
+		}
+	});
+
+	// A claimed profile has nothing to claim, and a removed one asked us to stop.
+	test('claimed and removed states show neither prompt', () => {
+		for (const slug of ['allen-slagle-74eee01a', 'x-27255f40', 'x-3412f69c']) {
+			expect([slug, claimPromptVariants(slug)]).toEqual([slug, []]);
+		}
+	});
+});
+
 describe('card grouping sets the Figma heading levels', () => {
 	/** Headings per white card: the first is the 32/44 one, the rest are 24/32. */
 	function headingsByCard(slug: string): string[][] {

--- a/src/components/people/personSectionOverrides.tsx
+++ b/src/components/people/personSectionOverrides.tsx
@@ -678,11 +678,11 @@ export function buildPersonSectionOverrides(view: PersonProfileView): SectionOve
 				}
 			: { hidden: true };
 
-	// The Figma content well is one column of cards. For unclaimed empowered
-	// pages a voter-facing "hear from …" claim card leads the column; the
-	// person-facing "Are you …?" prompt is NOT in-column — it renders as the
-	// full-width claim CTA band below the well (see `ctaOverride`). Between the
-	// voter card and the civics cards: authored cards (empowerment-gated) then
+	// The Figma content well is one column of cards. For unclaimed empowered pages
+	// two claim cards lead the column: the person-facing "Are you …?" prompt,
+	// whose button scrolls down to the claim form in the band below the well, then
+	// the voter-facing "hear from …" prompt, whose button opens the notify dialog.
+	// Between them and the civics cards: authored cards (empowerment-gated) then
 	// the civics-spine cards (Recent Experience → Other candidates → Nearby
 	// officials → About position → District map) that render on every state.
 	const claimCard = (variant: 'voter-card' | 'owner-card'): ProfileContentCardProps => ({
@@ -706,7 +706,7 @@ export function buildPersonSectionOverrides(view: PersonProfileView): SectionOve
 			: {};
 	const contentCards: ProfileContentCardProps[] = [
 		...(view.persona === 'past' ? [pastElectionDisclaimer(view)] : []),
-		...(showClaim ? [claimCard('voter-card')] : []),
+		...(showClaim ? [claimCard('owner-card'), claimCard('voter-card')] : []),
 		...orderedSectionCards(view, { ...authoredSections, ...buildCivicSections(view) }),
 	];
 	const sidebar = buildSidebar(view);
@@ -741,6 +741,12 @@ export function buildPersonSectionOverrides(view: PersonProfileView): SectionOve
 			// The standalone full-width claim banner is always suppressed now: the
 			// claim prompt renders in-column as light-blue cards inside the content
 			// well (see `claimCard` above), matching the Figma layout.
+			//
+			// It also cannot go here: the hero portrait deliberately overflows 104px
+			// (md) / 216px (lg) below the hero box, and the next section is expected
+			// to offset for it the way ProfileContentBlock's sidebar does. A
+			// full-width banner in this slot renders its headline underneath the
+			// photo.
 			claimed: true,
 		},
 		component_profileContentBlock: {


### PR DESCRIPTION
## Why

On an unclaimed person profile the two claim CTAs both dead-ended.

The prompt at the top of the content well opened a dialog whose only real
action was a generic sign-up link — no lead captured, no context carried. The
form that actually captures the claim (`#person-claim-owner`, the one HubSpot
collects) sits in the band *below the entire content well*, roughly 3,800px
down on desktop and 5,400px on mobile. Nobody scrolls that far, so the page
had a claim form almost nobody reached.

This wires the top prompt to that form, and makes the form do something
different depending on who is filling it in.

## Persona → product

The profile already derives `isRunning` from `view.persona`, and that is the
whole signal — no new data plumbing:

| persona | running? | product |
| --- | --- | --- |
| `candidate` | yes | **Win** |
| `both` | yes | **Win** |
| `officeholder` | no | **Serve** |
| `past` | n/a | no claim CTA at all (unchanged) |

## What each branch does on submit

**Win (currently running).** The claim request is POSTed and stored first,
exactly as today, and only then is the person sent to `app.goodparty.org/sign-up`.
Storing first is deliberate: a candidate who abandons sign-up is still a lead
and still counted in the funnel. If the POST fails they stay put and see the
error, as before.

The redirect target is decorated with the visitor's captured attribution
(`useDecoratedAppHref`), because navigating programmatically bypasses `Anchor`,
which is what normally appends fbclid/utm to app links. Without it, a candidate
who arrived from an ad would land on sign-up with the attribution stripped —
precisely the path where stitching the two halves of the funnel matters most.
The analytics event keeps the bare href, matching every other sign-up link, so
this point stays comparable with the rest of the funnel.

**Serve (in office only).** The claim request is stored and nothing else
happens — no redirect. **This path is deliberately manual: there is no
automated magic link, no HubSpot deal creation, no new backend integration.**
Sales picks the request up from HubSpot and sends the access link by hand. The
only change is the confirmation copy, which now sets that expectation instead
of implying self-serve access.

Confirmation copy, both addressed to the person themselves (this band is only
ever the subject entering their own address — the "notify" form is the one
addressed to a visitor):

- Win: *"Thanks — taking you to GoodParty.org now to create your free account and finish claiming your profile."*
- Serve: *"Thanks — someone from our team will email you at that address with a link to access your profile."*

The email is **not** prefilled into the sign-up URL. `app.goodparty.org/sign-up`
is a custom Clerk flow whose email field is a controlled input initialised to
`''` and never reads the query string, so `?email=` would be a silent no-op —
it would only put an address in a URL for no benefit.

## The top button

It scrolls, for everyone; the Win/Serve split happens on submit, not here.

Accessibility: focus moves to the claim form's first field with
`preventScroll`, so keyboard and screen-reader users land where sighted users
are looking rather than being left at the top of the page, and the scroll
itself is instant when `prefers-reduced-motion: reduce` is set.

If the band is not on the page the button falls back to opening the dialog
rather than doing nothing. That case is reachable rather than theoretical: the
code-default template fallback strips `component_ctaBannerBlock`, which is what
the band renders into.

## Two things worth a second look

**The top claim button did not exist.** The request described changing "the
'Claim profile' button at the top". The `ClaimProfileModal` banner variant that
carries that label has never been reachable from any route — `personSectionOverrides`
suppresses the section and nothing has ever set `interactive: true` (confirmed
against production HTML as well as locally). What was at the top was the
*voter*-facing "Want to hear from …? / Notify …" card. Rather than ship a
behaviour change to dead code, this enables the owner-facing prompt that was
already written for the slot — `claimCard('owner-card')`, "Are you …? / Complete
your profile" — as the first card in the well, ahead of the voter card.

I tried the yellow banner in its reserved `person-claim` slot first and backed
it out: the hero portrait deliberately overflows 104px/216px below the hero box
and expects the next section to offset for it, so a full-width banner there
renders its headline underneath the photo.

**The notify form's reachability is unchanged.** The voter card still opens the
dialog, which is still the only home of `#person-claim-notify`. It was the
form's only live entry point before this change and it still is, so the
`candidate_profile_requests` counter is unaffected. Its `marketingConsent`
default stays unchecked.

Neither form id changed, neither `<form>` element gained a class, and the
scroll target is a separate id (`#person-claim-form`) on a wrapper so the
HubSpot contract and the scroll concern stay independent. The claim-request
payload is unchanged, so no gp-api change is required.

## Renders differently on the live site

Every unclaimed, empowered, non-past person profile gains the "Are you …?" card
above the "Want to hear from …?" card, and the claim band's confirmation copy
changes. Worth eyeballing the Vercel preview.

Made with [Cursor](https://cursor.com)
