### PR TITLE
Match the voter-facing claim card to the Figma copy

### DIFF
--- a/src/components/people/ClaimProfileModal.tsx
+++ b/src/components/people/ClaimProfileModal.tsx
@@ -156,39 +156,90 @@ export function NotifyForm({ personId, displayName }: { personId: string; displa
 	);
 }
 
+export type Persona = 'candidate' | 'officeholder' | 'both' | 'past';
+
 export type ClaimProfileModalProps = {
 	personId: string;
 	displayName: string;
-	persona: 'candidate' | 'officeholder' | 'both' | 'past';
+	persona: Persona;
+	/**
+	 * Most specific place the profile resolves to (city, else county, else
+	 * state). Fills the "[Location]" the Figma voter card opens with for someone
+	 * in office; omit it and that sentence falls back to a generic subject.
+	 */
+	locationLabel?: string | null;
 	/**
 	 * Which trigger to render (the dialog itself is identical):
 	 *  - `banner`      full-width yellow CMS banner (default; legacy section use)
-	 *  - `voter-card`  in-column light-blue prompt aimed at visitors ("hear from …")
+	 *  - `voter-card`  in-column light-blue prompt aimed at visitors (nudge them to complete their profile)
 	 *  - `owner-card`  in-column light-blue prompt aimed at the person ("Are you …?")
 	 */
 	variant?: 'banner' | 'voter-card' | 'owner-card';
 };
 
+/** Running now — the tense the owner-facing copy is written in. */
+function isRunning(persona: Persona): boolean {
+	return persona === 'candidate' || persona === 'both';
+}
+
+/** Currently serving — the axis the voter-facing copy splits on (see `voterCopy`). */
+function holdsOffice(persona: Persona): boolean {
+	return persona === 'officeholder' || persona === 'both';
+}
+
+/**
+ * Voter-facing card copy, verbatim from the unclaimed Figma frames.
+ *
+ * Note the split is NOT the owner card's "is running" one. The candidate-only
+ * frame (D, card 1958:108619) sells casting an informed vote, while both frames
+ * for someone already in office — officeholder (E, card 1928:99467) and
+ * simultaneous candidate/officeholder (F, card 1928:100987), which are
+ * word-for-word identical — sell transparency about their record. So persona
+ * `both` takes the office copy, the opposite of how `isRunning` groups it.
+ *
+ * `location` fills Figma's "[Location]"; there is no locality on the view, so
+ * the caller derives it and a profile that resolves to no place at all keeps the
+ * sentence readable with a generic subject rather than an empty one.
+ *
+ * Persona `past` never reaches here: past-election profiles lead with the voter
+ * guide disclaimer instead of a claim prompt (Figma H), so no claim card renders.
+ */
+function voterCopy(displayName: string, persona: Persona, location: string | null): { heading: string; body: string } {
+	if (holdsOffice(persona)) {
+		return {
+			heading: `${location ?? 'Your community'} deserves greater transparency. Ask ${displayName} to complete their profile.`,
+			body: `Advocate for transparency in local government. Send a message to ${displayName} to share their top priorities and accomplishments with constituents like you.`,
+		};
+	}
+	return {
+		heading: `Want to learn more about this candidate? Ask ${displayName} to complete their profile.`,
+		body: `Step into the voting booth fully informed. Send a message to ${displayName} to share their top issues.`,
+	};
+}
+
 /** In-column light-blue claim prompt (voter- or owner-facing) — a Figma content-well card. */
 function ClaimPromptCard({
 	displayName,
-	isRunning,
+	persona,
+	locationLabel = null,
 	variant,
 	onClaim,
 }: {
 	displayName: string;
-	isRunning: boolean;
+	persona: Persona;
+	locationLabel?: string | null;
 	variant: 'voter-card' | 'owner-card';
 	onClaim: VoidFunction;
 }) {
 	const owner = variant === 'owner-card';
-	const heading = owner ? `Are you ${displayName}?` : `Want to hear from ${displayName}?`;
+	const voter = voterCopy(displayName, persona, locationLabel);
+	const heading = owner ? `Are you ${displayName}?` : voter.heading;
 	const body = owner
-		? isRunning
+		? isRunning(persona)
 			? 'Complete your profile now to share why you\u2019re running, your top issues, and how voters can reach you.'
 			: 'Complete your profile now to share your record, your priorities in office, and how constituents can reach you.'
-		: `Ask ${displayName} to claim their GoodParty.org profile and share their platform.`;
-	const cta = owner ? 'Complete your profile' : `Notify ${displayName}`;
+		: voter.body;
+	const cta = owner ? 'Complete your profile' : 'Send request';
 
 	return (
 		<div
@@ -206,6 +257,7 @@ function ClaimPromptCard({
 				styleSize='md'
 				className='w-fit'
 				onClick={onClaim}
+				iconRight={owner ? undefined : <IconResolver icon='arrow-up-right' className='h-4 w-4' />}
 			>
 				{cta}
 			</Button>
@@ -213,9 +265,15 @@ function ClaimPromptCard({
 	);
 }
 
-export function ClaimProfileModal({ personId, displayName, persona, variant = 'banner' }: ClaimProfileModalProps) {
+export function ClaimProfileModal({
+	personId,
+	displayName,
+	persona,
+	locationLabel = null,
+	variant = 'banner',
+}: ClaimProfileModalProps) {
 	const [open, setOpen] = useState(false);
-	const isRunning = persona === 'candidate' || persona === 'both';
+	const running = isRunning(persona);
 
 	// The owner-facing prompts ("is this you?") pull the person down to the claim
 	// form at the bottom of their own profile rather than opening this dialog, so
@@ -229,7 +287,7 @@ export function ClaimProfileModal({ personId, displayName, persona, variant = 'b
 	const openDialog = () => setOpen(true);
 
 	const headline = `Is this you, ${displayName}?`;
-	const bannerBody = isRunning
+	const bannerBody = running
 		? 'Claim this profile to share why you\u2019re running, your top issues, and how voters can reach you.'
 		: 'Claim this profile to share your record, your priorities in office, and how constituents can reach you.';
 
@@ -251,7 +309,8 @@ export function ClaimProfileModal({ personId, displayName, persona, variant = 'b
 			) : (
 				<ClaimPromptCard
 					displayName={displayName}
-					isRunning={isRunning}
+					persona={persona}
+					locationLabel={locationLabel}
 					variant={variant}
 					onClaim={variant === 'owner-card' ? claimHere : openDialog}
 				/>

--- a/src/components/people/claimPromptCopy.test.tsx
+++ b/src/components/people/claimPromptCopy.test.tsx
@@ -1,0 +1,190 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { JSDOM } from 'jsdom';
+import * as React from 'react';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+/**
+ * Pins the voter-facing claim prompt card to the Figma unclaimed frames:
+ *   D 1958:108619 (candidate only)   E 1928:99467 (elected official only)
+ *   F 1928:100987 (serving and running — word-for-word identical to E)
+ * Past-election profiles (H 1970:113629) show the voter-guide disclaimer instead
+ * of a claim prompt, so no card copy exists for that persona.
+ *
+ * The copy drifted once already (the shipped card asked "Want to hear from
+ * [Name]?" while the frames ask visitors to send a request), which nothing
+ * caught because no test read the card's words. The persona split is the part
+ * most likely to regress: it is NOT the owner card's running/not-running one.
+ *
+ * Like claimFormIds.test.tsx these mount the component directly rather than
+ * driving the Radix dialog, whose click delegation has proven unreliable under
+ * JSDOM, and nothing here mocks `~/lib/analytics` (a partial mock of it drops
+ * exports other importers rely on).
+ */
+
+const DOM_GLOBALS = [
+	'Node',
+	'NodeFilter',
+	'Element',
+	'HTMLElement',
+	'HTMLInputElement',
+	'HTMLButtonElement',
+	'HTMLFormElement',
+	'DocumentFragment',
+	'DOMRect',
+	'Event',
+	'CustomEvent',
+	'MouseEvent',
+	'KeyboardEvent',
+	'FocusEvent',
+	'MutationObserver',
+] as const;
+
+let dom: JSDOM;
+let root: Root | null = null;
+
+beforeEach(() => {
+	dom = new JSDOM('<!DOCTYPE html><html><body><div id="root"></div></body></html>', {
+		url: 'http://localhost/people/example-person',
+		pretendToBeVisual: true,
+	});
+	const { window } = dom;
+
+	globalThis.window = window as unknown as Window & typeof globalThis;
+	globalThis.document = window.document;
+	globalThis.navigator = window.navigator;
+	globalThis.getComputedStyle = window.getComputedStyle.bind(window);
+
+	for (const name of DOM_GLOBALS) {
+		(globalThis as Record<string, unknown>)[name] = (window as unknown as Record<string, unknown>)[name];
+	}
+
+	(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterEach(async () => {
+	await unmount();
+	dom.window.close();
+});
+
+/** Several cases render more than once, and React only allows one root per container. */
+async function unmount() {
+	const current = root;
+	root = null;
+	if (!current) return;
+	await act(async () => {
+		current.unmount();
+	});
+}
+
+async function render(element: React.ReactElement) {
+	await unmount();
+	await act(async () => {
+		root = createRoot(document.getElementById('root')!);
+		root.render(element);
+		await new Promise<void>(resolve => {
+			window.setTimeout(resolve, 0);
+		});
+	});
+}
+
+const displayName = 'Example Person';
+
+async function renderPromptCard(options: {
+	persona: 'candidate' | 'officeholder' | 'both';
+	variant?: 'voter-card' | 'owner-card';
+	locationLabel?: string | null;
+}) {
+	const { ClaimProfileModal } = await import('./ClaimProfileModal');
+
+	await render(
+		React.createElement(ClaimProfileModal, {
+			personId: '11111111-1111-4111-8111-111111111111',
+			displayName,
+			persona: options.persona,
+			locationLabel: options.locationLabel ?? null,
+			variant: options.variant ?? 'voter-card',
+		}),
+	);
+}
+
+function card(variant: 'voter-card' | 'owner-card' = 'voter-card') {
+	const element = document.querySelector(`[data-component='ClaimPromptCard'][data-variant='${variant}']`);
+	if (!element) throw new Error(`expected the ${variant} claim prompt to render`);
+	return {
+		heading: element.querySelector('h2')?.textContent ?? '',
+		body: element.querySelector('h2 + div')?.textContent ?? '',
+		// The label sits in Button's own wrapper div; reading the whole button
+		// would pick up the arrow icon's <title> text too.
+		button: element.querySelector('button > div')?.textContent ?? '',
+	};
+}
+
+describe('the voter claim prompt card matches the Figma frames', () => {
+	test('a candidate asks the visitor to vote informed (D 1958:108619)', async () => {
+		await renderPromptCard({ persona: 'candidate', locationLabel: 'Springfield' });
+
+		expect(card().heading).toBe(
+			`Want to learn more about this candidate? Ask ${displayName} to complete their profile.`,
+		);
+		expect(card().body).toBe(
+			`Step into the voting booth fully informed. Send a message to ${displayName} to share their top issues.`,
+		);
+	});
+
+	test('an elected official asks for transparency in their place (E 1928:99467)', async () => {
+		await renderPromptCard({ persona: 'officeholder', locationLabel: 'Springfield' });
+
+		expect(card().heading).toBe(
+			`Springfield deserves greater transparency. Ask ${displayName} to complete their profile.`,
+		);
+		expect(card().body).toBe(
+			`Advocate for transparency in local government. Send a message to ${displayName} to share their top priorities and accomplishments with constituents like you.`,
+		);
+	});
+
+	/**
+	 * The trap this file exists for. `both` is running, so the owner card treats
+	 * it as a candidate — but frame F copies E word for word, because what a
+	 * visitor wants from someone already in office is their record.
+	 */
+	test('serving and running takes the officeholder copy, not the candidate copy (F 1928:100987)', async () => {
+		await renderPromptCard({ persona: 'both', locationLabel: 'Springfield' });
+		const both = card();
+
+		await renderPromptCard({ persona: 'officeholder', locationLabel: 'Springfield' });
+
+		expect(both).toEqual(card());
+	});
+
+	test('a profile with no resolvable place still reads as a sentence', async () => {
+		await renderPromptCard({ persona: 'officeholder', locationLabel: null });
+
+		expect(card().heading).toBe(
+			`Your community deserves greater transparency. Ask ${displayName} to complete their profile.`,
+		);
+		expect(card().heading).not.toContain('undefined');
+		expect(card().heading).not.toContain('null');
+	});
+
+	/** The frames label this "Send request"; it used to read "Notify [Name]". */
+	test('every persona sends the visitor to the same "Send request" button', async () => {
+		for (const persona of ['candidate', 'officeholder', 'both'] as const) {
+			await renderPromptCard({ persona, locationLabel: 'Springfield' });
+			expect([persona, card().button]).toEqual([persona, 'Send request']);
+		}
+	});
+});
+
+describe('the owner claim prompt card is untouched by the voter copy', () => {
+	/**
+	 * The two cards share a component and sit next to each other in the content
+	 * well, so voter copy leaking into the owner card would be easy to miss.
+	 */
+	test('the owner card keeps its own heading and button', async () => {
+		await renderPromptCard({ persona: 'candidate', variant: 'owner-card', locationLabel: 'Springfield' });
+
+		expect(card('owner-card').heading).toBe(`Are you ${displayName}?`);
+		expect(card('owner-card').button).toBe('Complete your profile');
+	});
+});

--- a/src/components/people/personSectionOverrides.test.ts
+++ b/src/components/people/personSectionOverrides.test.ts
@@ -180,6 +180,25 @@ describe('the claim prompt and the claim form ship together', () => {
 			expect([slug, claimPromptVariants(slug)]).toEqual([slug, []]);
 		}
 	});
+
+	function claimPromptLocation(slug: string): unknown {
+		return contentCards(slug)
+			.map(card => (card.content as { props?: { variant?: string; locationLabel?: unknown } } | undefined)?.props)
+			.find(props => props?.variant === 'voter-card')?.locationLabel;
+	}
+
+	/**
+	 * The voter prompt for someone in office opens "[Location] deserves greater
+	 * transparency" (Figma E 1928:99467, F 1928:100987). Nothing on the view is
+	 * that place — `districtLabel` is a ward, `stateLabel` a two-letter code — so
+	 * it is read back off the breadcrumb, and picking the wrong crumb would name
+	 * the state, or the office, where the frame names the town.
+	 */
+	test('the voter prompt is handed the most specific place in the breadcrumb', () => {
+		for (const slug of ['kim-byrd-b77f912d', 'rob-zotti-d8c578fb', 'tim-ficken-0a951485']) {
+			expect([slug, claimPromptLocation(slug)]).toEqual([slug, 'Springfield']);
+		}
+	});
 });
 
 describe('card grouping sets the Figma heading levels', () => {

--- a/src/components/people/personSectionOverrides.test.ts
+++ b/src/components/people/personSectionOverrides.test.ts
@@ -10,6 +10,7 @@
  */
 import { describe, expect, test } from 'bun:test';
 import { getDevPersonProfileView } from '~/lib/devPeopleProfileFixtures';
+import { buildBreadcrumbTrail } from '~/lib/peopleProfile';
 import { chunkCardGroups } from '~/ui/_lib/chunkCardGroups';
 import { buildPersonSectionOverrides } from './personSectionOverrides';
 
@@ -181,10 +182,14 @@ describe('the claim prompt and the claim form ship together', () => {
 		}
 	});
 
-	function claimPromptLocation(slug: string): unknown {
-		return contentCards(slug)
+	function voterPromptLocation(cards: ReturnType<typeof contentCards>): unknown {
+		return cards
 			.map(card => (card.content as { props?: { variant?: string; locationLabel?: unknown } } | undefined)?.props)
 			.find(props => props?.variant === 'voter-card')?.locationLabel;
+	}
+
+	function claimPromptLocation(slug: string): unknown {
+		return voterPromptLocation(contentCards(slug));
 	}
 
 	/**
@@ -198,6 +203,32 @@ describe('the claim prompt and the claim form ship together', () => {
 		for (const slug of ['kim-byrd-b77f912d', 'rob-zotti-d8c578fb', 'tim-ficken-0a951485']) {
 			expect([slug, claimPromptLocation(slug)]).toEqual([slug, 'Springfield']);
 		}
+	});
+
+	/**
+	 * The dev fixtures hand every persona a city race, but in production someone
+	 * who only holds office has no candidacy and so no race slug, and their trail
+	 * degrades to `Elections > State > Name`. The card then names the state. That
+	 * is the accepted degradation (see `profileLocationLabel`) — what must not
+	 * happen is the state crumb being skipped for the office, or dropped for the
+	 * generic subject, so this pins the degraded shape rather than assuming the
+	 * fixtures represent it.
+	 */
+	test('an officeholder with no race falls back to the state, not the office', () => {
+		const view = getDevPersonProfileView('rob-zotti-d8c578fb');
+		if (!view) throw new Error('no dev fixture for rob-zotti-d8c578fb');
+		const stateOnly = {
+			...view,
+			breadcrumb: buildBreadcrumbTrail({
+				displayName: view.displayName,
+				stateCode: 'WY',
+				raceSlug: null,
+				positionLevel: null,
+				positionName: null,
+			}),
+		};
+		const cards = buildPersonSectionOverrides(stateOnly).component_profileContentBlock?.contentCards ?? [];
+		expect(voterPromptLocation(cards)).toBe('Wyoming');
 	});
 });
 

--- a/src/components/people/personSectionOverrides.tsx
+++ b/src/components/people/personSectionOverrides.tsx
@@ -629,6 +629,25 @@ function buildDistrictMap(view: PersonProfileView): ReactNode | undefined {
 }
 
 /**
+ * The most specific place this profile sits in — city, else county, else state.
+ *
+ * Figma's voter-facing claim card for someone in office opens "[Location]
+ * deserves greater transparency" (E 1928:99467, F 1928:100987). The view carries
+ * no locality field (`districtLabel` is a ward/seat, `stateLabel` a two-letter
+ * code), so this reads the place crumbs off the breadcrumb, which is built from
+ * the canonical elections path `/elections/<state>/<county?>/<city?>/position/…`
+ * and is already humanised. The position crumb and the trailing name crumb are
+ * not places, hence the href filter. Null when the profile resolved to no place
+ * at all (no race and no state).
+ */
+function profileLocationLabel(view: PersonProfileView): string | null {
+	const places = view.breadcrumb.filter(
+		crumb => crumb.href?.startsWith('/elections/') && !crumb.href.includes('/position/'),
+	);
+	return places.at(-1)?.label ?? null;
+}
+
+/**
  * Maps a resolved PersonProfileView onto the `personProfile` template's section
  * overrides (keyed by section `_type`/`_key`). Per-state gating (empowerment,
  * removal, claim/pledge/CTA visibility) is expressed by suppressing sections —
@@ -681,7 +700,8 @@ export function buildPersonSectionOverrides(view: PersonProfileView): SectionOve
 	// The Figma content well is one column of cards. For unclaimed empowered pages
 	// two claim cards lead the column: the person-facing "Are you …?" prompt,
 	// whose button scrolls down to the claim form in the band below the well, then
-	// the voter-facing "hear from …" prompt, whose button opens the notify dialog.
+	// the voter-facing "ask them to complete their profile" prompt, whose button
+	// opens the notify dialog.
 	// Between them and the civics cards: authored cards (empowerment-gated) then
 	// the civics-spine cards (Recent Experience → Other candidates → Nearby
 	// officials → About position → District map) that render on every state.
@@ -692,6 +712,7 @@ export function buildPersonSectionOverrides(view: PersonProfileView): SectionOve
 				personId={view.personId}
 				displayName={view.displayName}
 				persona={view.persona}
+				locationLabel={profileLocationLabel(view)}
 				variant={variant}
 			/>
 		),

--- a/src/components/people/personSectionOverrides.tsx
+++ b/src/components/people/personSectionOverrides.tsx
@@ -639,6 +639,14 @@ function buildDistrictMap(view: PersonProfileView): ReactNode | undefined {
  * and is already humanised. The position crumb and the trailing name crumb are
  * not places, hence the href filter. Null when the profile resolved to no place
  * at all (no race and no state).
+ *
+ * Someone who only holds office has no candidacy, so today they have no race
+ * slug and their trail stops at the state — the same gap that leaves
+ * `positionHref` null for them (see `composePersonProfileView`). They therefore
+ * get "Wyoming deserves greater transparency" where the frame shows the town.
+ * That is deliberately preferred to a vaguer stand-in: it is still the place
+ * they serve, it is the same place the rest of their page links to, and it
+ * sharpens on its own once election-api threads the office's race slug through.
  */
 function profileLocationLabel(view: PersonProfileView): string | null {
 	const places = view.breadcrumb.filter(


### PR DESCRIPTION
The light-blue card in the content well of an unclaimed profile — the one asking a visitor to nudge the person — still carries pre-Figma copy: "Want to hear from [Name]?" with a **Notify [Name]** button. The approved unclaimed states ask the visitor to send a request so they can vote informed, and they say it differently depending on who the person is. Nothing in the test suite read the card's words, so the drift sat there unnoticed.

What the frames actually say, and what the card now says:

| Figma state | Persona | Card |
| --- | --- | --- |
| D — candidate only | `candidate` | "Want to learn more about this candidate? Ask [Name] to complete their profile." / "Step into the voting booth fully informed…" |
| E — elected official only | `officeholder` | "[Location] deserves greater transparency. Ask [Name] to complete their profile." / "Advocate for transparency in local government…" |
| F — serving and running | `both` | word-for-word identical to E |
| H — past election | `past` | no claim prompt at all; leads with the voter-guide disclaimer, which is already what we render |

The persona split is the part worth a second look, because it is **not** the owner card's running/not-running one. Someone serving *and* running is a candidate to the owner card ("share why you're running") but an incumbent to a voter, who wants their record — so `both` takes the officeholder copy. That inversion is the thing most likely to be "corrected" back into a bug later, so it is commented at the source and pinned by a test.

Figma writes the officeholder headline as "[Location] deserves greater transparency", and the view has no locality field (`districtLabel` is a ward, `stateLabel` a two-letter code). The place is read off the breadcrumb, which is built from the canonical `/elections/<state>/<county?>/<city?>/…` path, so it is the same town the rest of the page links to rather than an invented one. A profile that resolves to no place at all falls back to a generic subject instead of opening the sentence with nothing.

Deliberately untouched: the owner-facing "Are you [Name]?" card added in #231, its scroll-to-form behaviour and the order of the two cards; the `person-claim-notify` / `person-claim-owner` form ids and their bare class lists (the HubSpot collected-forms contract); and the notify form's unchecked marketing consent default. The dialog's own submit button still reads "Notify [Name]" — that is the dialog frame's copy, not this card's.

**This changes what renders on every unclaimed person profile**, so the Vercel preview is worth an eyeball: `/people/kim-byrd-b77f912d` (candidate), `/people/rob-zotti-d8c578fb` (elected official), `/people/tim-ficken-0a951485` (both).

Made with [Cursor](https://cursor.com)