### PR TITLE
Put the claim surfaces back on the Figma frames

### DIFF
--- a/src/PageSections/ClaimProfileBlockSection.tsx
+++ b/src/PageSections/ClaimProfileBlockSection.tsx
@@ -3,7 +3,6 @@ import { isButtonType, transformButton } from '~/lib/buttonTransformer';
 import type { TokenMap } from '~/lib/resolveTokens';
 import { resolveSectionText } from '~/lib/resolveSectionText';
 import { ClaimProfileBlock } from '~/ui/ClaimProfileBlock';
-import { ClaimProfileModal } from '~/components/people/ClaimProfileModal';
 import { stegaClean } from 'next-sanity';
 
 type Props = Extract<Sections, { _type: 'component_claimProfileBlock' }> & {
@@ -40,21 +39,6 @@ export function resolveClaimProfileBlockText(
 export function ClaimProfileBlockSection({ claimProfileOverride, tokens, ...section }: Props) {
 	const bgValue = stegaClean(section.claimProfileBlockDesignSettings?.field_blockColorCreamMidnight);
 	const backgroundColor = resolveClaimProfileBlockBackgroundColor(bgValue);
-
-	// Person profiles: render the interactive claim/notify modal so the "notify"
-	// form posts the real personId to the claim-request endpoint. Falls through
-	// to the static CMS banner for regular marketing pages.
-	if (claimProfileOverride?.interactive && claimProfileOverride.personId) {
-		return (
-			<section data-section='Claim Profile Block'>
-				<ClaimProfileModal
-					personId={claimProfileOverride.personId}
-					displayName={claimProfileOverride.displayName ?? 'this candidate'}
-					persona={claimProfileOverride.persona ?? 'candidate'}
-				/>
-			</section>
-		);
-	}
 
 	const ctaButton = section.ctaAction;
 	const claimButton = ctaButton && isButtonType(ctaButton) ? transformButton(ctaButton) : undefined;

--- a/src/PageSections/index.tsx
+++ b/src/PageSections/index.tsx
@@ -184,13 +184,6 @@ export type SectionOverrides = {
 		candidateName?: string;
 		partyAffiliation?: string;
 		layout?: 'card' | 'banner';
-		// When set, render the interactive claim/notify modal (which posts the
-		// personId to the claim-request endpoint → ProfileClaimRequest) instead of
-		// the static CMS banner. Populated for unclaimed person profiles.
-		interactive?: boolean;
-		personId?: string;
-		displayName?: string;
-		persona?: 'candidate' | 'officeholder' | 'both' | 'past';
 	};
 };
 

--- a/src/components/people/ClaimProfileModal.tsx
+++ b/src/components/people/ClaimProfileModal.tsx
@@ -4,14 +4,12 @@ import * as Dialog from '@radix-ui/react-dialog';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 
-import { APP_SIGN_UP_HREF, trackEvent, trackSignUpClicked } from '~/lib/analytics';
+import { trackEvent } from '~/lib/analytics';
 import { buildClaimRequestBody } from '~/lib/claimRequest';
-import { ClaimProfileBlock } from '~/ui/ClaimProfileBlock';
-import { Button, ButtonLink } from '~/ui/Inputs/Button';
+import { Button } from '~/ui/Inputs/Button';
 import { TextInput } from '~/ui/Inputs/TextInput';
 import { IconResolver } from '~/ui/IconResolver';
 import { Text } from '~/ui/Text';
-import { scrollToPersonClaimForm } from './claimFormAnchor';
 
 const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
@@ -40,15 +38,25 @@ const NOTIFY_FORM_ID = 'person-claim-notify';
 type NotifyValues = { firstname: string; email: string; marketingConsent: boolean };
 
 /**
- * The "Not [Name]?" form in the dialog body. Exported so the HubSpot id contract
- * can be asserted directly (see claimFormIds.test.tsx) without standing up
- * Radix's dialog, whose event delegation does not survive JSDOM.
+ * The dialog body from Figma 1901:51851 — name, email, marketing opt-in, and a
+ * Cancel/Submit footer. Exported so the HubSpot id contract can be asserted
+ * directly (see claimFormIds.test.tsx) without standing up Radix's dialog, whose
+ * event delegation does not survive JSDOM; `onCancel` is therefore optional so
+ * the form renders outside a `Dialog.Root` too.
  */
-export function NotifyForm({ personId, displayName }: { personId: string; displayName: string }) {
+export function NotifyForm({
+	personId,
+	displayName,
+	onCancel,
+}: {
+	personId: string;
+	displayName: string;
+	onCancel?: VoidFunction;
+}) {
 	const [isSuccess, setIsSuccess] = useState(false);
-	// marketingConsent starts false against the Figma dialog (1901:51851), which
-	// draws the box ticked: a pre-ticked box opts the sender in unless they notice
-	// and clear it, which is not consent under GDPR. Do not restore Figma parity.
+	// marketingConsent starts false against the Figma dialog, which draws the box
+	// ticked: a pre-ticked box opts the sender in unless they notice and clear it,
+	// which is not consent under GDPR. Do not restore Figma parity here.
 	const {
 		register,
 		handleSubmit,
@@ -97,13 +105,15 @@ export function NotifyForm({ personId, displayName }: { personId: string; displa
 		<form id={NOTIFY_FORM_ID} onSubmit={(e) => void handleSubmit(onSubmit)(e)} noValidate>
 			<div className='flex w-full flex-col gap-4 text-left'>
 				<TextInput
-					label='Your name (optional)'
+					label='Name (optional)'
+					placeholder='First name'
 					autoComplete='name'
 					error={errors.firstname?.message}
 					{...register('firstname')}
 				/>
 				<TextInput
-					label='Your email'
+					label='Email address'
+					placeholder='Email address'
 					type='email'
 					required
 					autoComplete='email'
@@ -114,14 +124,14 @@ export function NotifyForm({ personId, displayName }: { personId: string; displa
 						pattern: { value: EMAIL_PATTERN, message: 'Enter a valid email address' },
 					})}
 				/>
-				<label htmlFor='notify-marketing-consent' className='flex items-start gap-2.5'>
+				<label htmlFor='notify-marketing-consent' className='flex items-start gap-2'>
 					<input
 						id='notify-marketing-consent'
 						type='checkbox'
-						className='mt-0.5 h-5 w-5 shrink-0 rounded border-neutral-300 text-btn-primary-bg accent-btn-primary-bg focus:outline-none focus-visible:ring-2 focus-visible:ring-btn-primary-bg/30'
+						className='mt-1 h-4 w-4 shrink-0 rounded-[4px] border-neutral-300 text-btn-primary-bg accent-btn-primary-bg focus:outline-none focus-visible:ring-2 focus-visible:ring-btn-primary-bg/30'
 						{...register('marketingConsent')}
 					/>
-					<Text as='span' styleType='body-2'>
+					<Text as='span' styleType='caption' className='text-neutral-500'>
 						Sign up for marketing communications from{' '}
 						<a
 							href='https://goodparty.org'
@@ -140,17 +150,29 @@ export function NotifyForm({ personId, displayName }: { personId: string; displa
 						{errors.root.message}
 					</Text>
 				)}
-				<Button
-					parent='ClaimProfileModal'
-					type='submit'
-					styleType='secondary'
-					styleSize='md'
-					isLoading={isSubmitting}
-					disabled={isSubmitting}
-					className='w-fit'
-				>
-					Notify {displayName}
-				</Button>
+				<div className='flex items-center justify-end gap-2'>
+					{onCancel && (
+						<Button
+							parent='ClaimProfileModal'
+							type='button'
+							styleType='outline'
+							styleSize='md'
+							onClick={onCancel}
+						>
+							Cancel
+						</Button>
+					)}
+					<Button
+						parent='ClaimProfileModal'
+						type='submit'
+						styleType='primary'
+						styleSize='md'
+						isLoading={isSubmitting}
+						disabled={isSubmitting}
+					>
+						Submit
+					</Button>
+				</div>
 			</div>
 		</form>
 	);
@@ -164,23 +186,11 @@ export type ClaimProfileModalProps = {
 	persona: Persona;
 	/**
 	 * Most specific place the profile resolves to (city, else county, else
-	 * state). Fills the "[Location]" the Figma voter card opens with for someone
-	 * in office; omit it and that sentence falls back to a generic subject.
+	 * state). Fills the "[Location]" the Figma card opens with for someone in
+	 * office; omit it and that sentence falls back to a generic subject.
 	 */
 	locationLabel?: string | null;
-	/**
-	 * Which trigger to render (the dialog itself is identical):
-	 *  - `banner`      full-width yellow CMS banner (default; legacy section use)
-	 *  - `voter-card`  in-column light-blue prompt aimed at visitors (nudge them to complete their profile)
-	 *  - `owner-card`  in-column light-blue prompt aimed at the person ("Are you …?")
-	 */
-	variant?: 'banner' | 'voter-card' | 'owner-card';
 };
-
-/** Running now — the tense the owner-facing copy is written in. */
-function isRunning(persona: Persona): boolean {
-	return persona === 'candidate' || persona === 'both';
-}
 
 /** Currently serving — the axis the voter-facing copy splits on (see `voterCopy`). */
 function holdsOffice(persona: Persona): boolean {
@@ -190,12 +200,12 @@ function holdsOffice(persona: Persona): boolean {
 /**
  * Voter-facing card copy, verbatim from the unclaimed Figma frames.
  *
- * Note the split is NOT the owner card's "is running" one. The candidate-only
- * frame (D, card 1958:108619) sells casting an informed vote, while both frames
- * for someone already in office — officeholder (E, card 1928:99467) and
- * simultaneous candidate/officeholder (F, card 1928:100987), which are
- * word-for-word identical — sell transparency about their record. So persona
- * `both` takes the office copy, the opposite of how `isRunning` groups it.
+ * The split is on holding office, not on running. The candidate-only frame (D,
+ * card 1958:108619) sells casting an informed vote, while both frames for
+ * someone already in office — officeholder (E, card 1928:99467) and simultaneous
+ * candidate/officeholder (F, card 1928:100987), which are word-for-word
+ * identical — sell transparency about their record. So persona `both` takes the
+ * office copy even though they are also running.
  *
  * `location` fills Figma's "[Location]"; there is no locality on the view, so
  * the caller derives it and a profile that resolves to no place at all keeps the
@@ -217,154 +227,116 @@ function voterCopy(displayName: string, persona: Persona, location: string | nul
 	};
 }
 
-/** In-column light-blue claim prompt (voter- or owner-facing) — a Figma content-well card. */
+/**
+ * The dialog's one line, verbatim from Figma 1901:51851. Exported so it can be
+ * asserted without standing up the Radix dialog, whose click delegation does not
+ * survive JSDOM.
+ *
+ * It asks the reader to nudge someone else. It is deliberately not a pitch to
+ * claim: anyone who opened this dialog has just told us they are not the person.
+ */
+export function notifyDialogTitle(displayName: string): string {
+	return `Ask ${displayName} to complete their profile and contribute to transparency.`;
+}
+
+/**
+ * In-column light-blue notify prompt — the Figma content-well card
+ * (D 1958:108619 / E 1928:99467): a `rounded-3xl` blue-100 panel with centered
+ * 32px heading, 20px body, and one midnight "Send request" button beneath.
+ *
+ * This is the ONLY claim-related card in the content well. The frames put no
+ * owner-facing "are you [Name]?" prompt at the top of the page — the person's
+ * own way in is the claim band below the well (see PersonClaimCTABand) — so do
+ * not reintroduce one here.
+ */
 function ClaimPromptCard({
 	displayName,
 	persona,
 	locationLabel = null,
-	variant,
-	onClaim,
+	onNotify,
 }: {
 	displayName: string;
 	persona: Persona;
 	locationLabel?: string | null;
-	variant: 'voter-card' | 'owner-card';
-	onClaim: VoidFunction;
+	onNotify: VoidFunction;
 }) {
-	const owner = variant === 'owner-card';
-	const voter = voterCopy(displayName, persona, locationLabel);
-	const heading = owner ? `Are you ${displayName}?` : voter.heading;
-	const body = owner
-		? isRunning(persona)
-			? 'Complete your profile now to share why you\u2019re running, your top issues, and how voters can reach you.'
-			: 'Complete your profile now to share your record, your priorities in office, and how constituents can reach you.'
-		: voter.body;
-	const cta = owner ? 'Complete your profile' : 'Send request';
+	const { heading, body } = voterCopy(displayName, persona, locationLabel);
 
 	return (
 		<div
-			className='flex flex-col gap-4 rounded-3xl border border-blue-200 bg-blue-100 p-6'
+			className='flex flex-col items-center gap-6 rounded-3xl bg-blue-100 p-6 text-center text-midnight-900 md:px-10 md:py-12'
 			data-component='ClaimPromptCard'
-			data-variant={variant}
 		>
-			<Text as='h2' styleType='subtitle-1'>
-				{heading}
-			</Text>
-			<Text styleType='body-2'>{body}</Text>
+			<div className='flex flex-col gap-4'>
+				<Text as='h2' styleType='heading-sm'>
+					{heading}
+				</Text>
+				<Text styleType='body-1'>{body}</Text>
+			</div>
 			<Button
 				parent='ClaimProfileModal'
-				styleType='primary'
-				styleSize='md'
+				styleType='secondary'
+				styleSize='lg'
 				className='w-fit'
-				onClick={onClaim}
-				iconRight={owner ? undefined : <IconResolver icon='arrow-up-right' className='h-4 w-4' />}
+				onClick={onNotify}
+				iconRight={<IconResolver icon='arrow-up-right' className='h-4 w-4' />}
 			>
-				{cta}
+				Send request
 			</Button>
 		</div>
 	);
 }
 
-export function ClaimProfileModal({
-	personId,
-	displayName,
-	persona,
-	locationLabel = null,
-	variant = 'banner',
-}: ClaimProfileModalProps) {
+/**
+ * The visitor-facing "ask [Name] to complete their profile" prompt and the
+ * dialog it opens, both from the Figma unclaimed frames.
+ *
+ * Despite the name this is a NOTIFY surface, not a claim one: everything it
+ * submits is a visitor nudging someone else, filed under the `notify` source.
+ * The person's own claim path is entirely in PersonClaimCTABand.
+ */
+export function ClaimProfileModal({ personId, displayName, persona, locationLabel = null }: ClaimProfileModalProps) {
 	const [open, setOpen] = useState(false);
-	const running = isRunning(persona);
-
-	// The owner-facing prompts ("is this you?") pull the person down to the claim
-	// form at the bottom of their own profile rather than opening this dialog, so
-	// there is one place to claim from and the Win/Serve branch happens once, on
-	// submit. If the band is not on the page the dialog is still the fallback.
-	const claimHere = () => {
-		if (!scrollToPersonClaimForm()) setOpen(true);
-	};
-	// The voter-facing prompt is unchanged: it asks a visitor to nudge someone
-	// else, which is the dialog's "Not [Name]?" notify form, not the claim form.
-	const openDialog = () => setOpen(true);
-
-	const headline = `Is this you, ${displayName}?`;
-	const bannerBody = running
-		? 'Claim this profile to share why you\u2019re running, your top issues, and how voters can reach you.'
-		: 'Claim this profile to share your record, your priorities in office, and how constituents can reach you.';
 
 	return (
 		<Dialog.Root open={open} onOpenChange={setOpen}>
-			{variant === 'banner' ? (
-				<ClaimProfileBlock
-					layout='banner'
-					backgroundColor='bright-yellow'
-					headline={headline}
-					body={bannerBody}
-					claimButton={{
-						buttonType: 'button',
-						label: 'Claim your profile',
-						onClick: claimHere,
-						buttonProps: { styleType: 'primary', styleSize: 'md' },
-					}}
-				/>
-			) : (
-				<ClaimPromptCard
-					displayName={displayName}
-					persona={persona}
-					locationLabel={locationLabel}
-					variant={variant}
-					onClaim={variant === 'owner-card' ? claimHere : openDialog}
-				/>
-			)}
+			<ClaimPromptCard
+				displayName={displayName}
+				persona={persona}
+				locationLabel={locationLabel}
+				onNotify={() => setOpen(true)}
+			/>
 
 			<Dialog.Portal>
 				<Dialog.Overlay className='fixed inset-0 z-40 bg-midnight-900/60 backdrop-blur-sm data-[state=open]:animate-in data-[state=open]:fade-in' />
 				<Dialog.Content
-					className='fixed left-1/2 top-1/2 z-50 flex w-[calc(100%-2rem)] max-w-lg -translate-x-1/2 -translate-y-1/2 flex-col gap-6 rounded-2xl bg-white p-6 shadow-xl focus:outline-none sm:p-8'
+					className='fixed left-1/2 top-1/2 z-50 flex w-[calc(100%-2rem)] max-w-[425px] -translate-x-1/2 -translate-y-1/2 flex-col gap-4 rounded-lg border border-neutral-300 bg-white p-6 shadow-lg focus:outline-none'
 					aria-describedby={undefined}
 				>
-					<div className='flex items-start justify-between gap-4'>
-						<Dialog.Title asChild>
-							<Text as='h2' styleType='heading-sm'>
-								Claim your GoodParty.org profile
-							</Text>
-						</Dialog.Title>
-						<Dialog.Close asChild>
-							<Button
-								parent='ClaimProfileModal'
-								styleType='ghost'
-								iconOnly
-								aria-label='Close'
-								iconLeft={<IconResolver icon='x' className='h-5 w-5' />}
-							/>
-						</Dialog.Close>
-					</div>
+					<Dialog.Title asChild>
+						{/*
+						 * Pinned to the frame's 18/28 rather than the `subtitle-2` token,
+						 * which steps up to 20px past 1440. The dialog is a fixed 425px
+						 * panel, so scaling its title with the viewport only costs it a
+						 * third line of wrap.
+						 */}
+						<h2 className='font-secondary pr-6 text-[1.125rem]/[1.75rem] font-semibold text-black'>
+							{notifyDialogTitle(displayName)}
+						</h2>
+					</Dialog.Title>
 
-					<Text styleType='body-2'>
-						If you&apos;re {displayName}, create a free account to verify your identity and take control of
-						this page — add your story, issues, and contact details.
-					</Text>
+					<NotifyForm personId={personId} displayName={displayName} onCancel={() => setOpen(false)} />
 
-					<ButtonLink
-						parent='ClaimProfileModal'
-						href={APP_SIGN_UP_HREF}
-						styleType='primary'
-						styleSize='lg'
-						className='w-full'
-						onClick={() =>
-							trackSignUpClicked({ href: APP_SIGN_UP_HREF, label: 'Claim profile', formId: null })
-						}
-						iconRight={<IconResolver icon='arrow-up-right' className='h-5 w-5' />}
-					>
-						Claim this profile
-					</ButtonLink>
-
-					<div className='flex flex-col gap-4 border-t border-gray-200 pt-6'>
-						<Text styleType='subtitle-2'>Not {displayName}?</Text>
-						<Text styleType='body-2'>
-							Let them know their profile is ready to claim on GoodParty.org.
-						</Text>
-						<NotifyForm personId={personId} displayName={displayName} />
-					</div>
+					<Dialog.Close asChild>
+						<Button
+							parent='ClaimProfileModal'
+							styleType='ghost'
+							iconOnly
+							aria-label='Close'
+							className='absolute right-3 top-3 opacity-70'
+							iconLeft={<IconResolver icon='x' className='h-4 w-4' />}
+						/>
+					</Dialog.Close>
 				</Dialog.Content>
 			</Dialog.Portal>
 		</Dialog.Root>

--- a/src/components/people/PersonClaimCTABand.tsx
+++ b/src/components/people/PersonClaimCTABand.tsx
@@ -23,6 +23,15 @@ const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
  */
 const CLAIM_FORM_ID = 'person-claim-owner';
 
+/**
+ * Verbatim from the Figma band (1922:92593), including its missing final period.
+ * One sentence for everyone: the frames draw the same body on the candidate,
+ * officeholder, and serving-and-running states, so it deliberately does not
+ * branch on `isRunning` the way the routing and the confirmation below do.
+ */
+const CLAIM_BAND_BODY =
+	'Your community deserves accountable leadership. Claim your profile and share your top priorities with residents. Enter your email to get started';
+
 type NotifyValues = { firstname: string; email: string };
 
 export type PersonClaimCTABandProps = {
@@ -105,10 +114,6 @@ export function PersonClaimCTABand({ personId, displayName, isRunning }: PersonC
 		}
 	}
 
-	const body = isRunning
-		? 'Your community deserves accountable leadership. Claim your profile and share why you\u2019re running and your top priorities with residents. Enter your email to get started.'
-		: 'Your community deserves accountable leadership. Claim your profile and share your record and priorities in office with residents. Enter your email to get started.';
-
 	// Both branches speak to the person themselves, not to a visitor — this band is
 	// only ever the subject entering their own address.
 	const successCopy = isRunning
@@ -123,12 +128,12 @@ export function PersonClaimCTABand({ personId, displayName, isRunning }: PersonC
 			data-component='CTABannerBlock'
 		>
 			<Container size='xl'>
-				<div className='flex flex-col items-center gap-6 rounded-2xl bg-blue-100 p-6 text-center text-midnight-900 md:p-12'>
-					<div className='flex max-w-2xl flex-col items-center gap-3 md:gap-4'>
+				<div className='flex flex-col items-center gap-6 rounded-3xl bg-blue-100 p-6 text-center text-midnight-900 lg:px-32 lg:py-40'>
+					<div className='flex flex-col items-center gap-4'>
 						<Text as='h2' styleType='heading-lg'>
 							{`Are you ${displayName}? Complete your profile now.`}
 						</Text>
-						<Text styleType='body-1'>{body}</Text>
+						<Text styleType='body-1'>{CLAIM_BAND_BODY}</Text>
 					</div>
 					{isSuccess ? (
 						<div
@@ -143,17 +148,19 @@ export function PersonClaimCTABand({ personId, displayName, isRunning }: PersonC
 						// `flex flex-col items-center` column: its children do not stretch, so
 						// whichever element is the flex item has to carry `w-full max-w-md` or
 						// the field column collapses to its content width.
-						<div className='w-full max-w-md'>
+						<div className='w-full max-w-[416px]'>
 							<form id={CLAIM_FORM_ID} onSubmit={(e) => void handleSubmit(onSubmit)(e)} noValidate>
 								<div className='flex flex-col gap-4 text-left'>
 									<TextInput
 										label='Name (optional)'
+										placeholder='First name'
 										autoComplete='name'
 										error={errors.firstname?.message}
 										{...register('firstname')}
 									/>
 									<TextInput
 										label='Email address'
+										placeholder='Email address'
 										type='email'
 										required
 										autoComplete='email'
@@ -175,8 +182,8 @@ export function PersonClaimCTABand({ personId, displayName, isRunning }: PersonC
 									<Button
 										parent='PersonClaimCTABand'
 										type='submit'
-										styleType='primary'
-										styleSize='md'
+										styleType='secondary'
+										styleSize='lg'
 										isLoading={isSubmitting}
 										disabled={isSubmitting}
 										className='mx-auto w-fit'

--- a/src/components/people/claimFlow.test.tsx
+++ b/src/components/people/claimFlow.test.tsx
@@ -5,11 +5,12 @@ import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 
 /**
- * Covers the claim flow on an unclaimed person profile: the owner-facing prompt
- * at the top of the content well scrolls down to the claim form rather than
- * opening the dialog, and submitting that form branches on the person's product
- * — Win (currently running) into sign-up, Serve (in office only) into a "a human
- * will be in touch" confirmation.
+ * Covers the claim flow on an unclaimed person profile. Per the Figma frames the
+ * page has exactly two claim-related surfaces and they do different jobs: the
+ * card at the top of the content well is visitor-facing and only opens the
+ * notify dialog, and the band at the bottom is the person's own claim form,
+ * which branches on their product — Win (currently running) into sign-up, Serve
+ * (in office only) into a "a human will be in touch" confirmation.
  *
  * Like claimFormIds.test.tsx these mount components directly instead of driving
  * the Radix dialog, whose click delegation has proven unreliable under JSDOM,
@@ -189,7 +190,7 @@ const winProps = { personId, displayName, isRunning: true };
 /** Serve: in office only (persona `officeholder`). */
 const serveProps = { personId, displayName, isRunning: false };
 
-async function renderProfileClaimSurfaces(variant: 'owner-card' | 'voter-card', isRunning: boolean) {
+async function renderProfileClaimSurfaces(isRunning: boolean) {
 	const [{ ClaimProfileModal }, { PersonClaimCTABand }] = await Promise.all([import('./ClaimProfileModal'), import('./PersonClaimCTABand')]);
 
 	await render(
@@ -200,74 +201,47 @@ async function renderProfileClaimSurfaces(variant: 'owner-card' | 'voter-card', 
 				personId,
 				displayName,
 				persona: isRunning ? 'candidate' : 'officeholder',
-				variant,
 			}),
 			React.createElement(PersonClaimCTABand, { personId, displayName, isRunning }),
 		),
 	);
 }
 
-function claimPromptButton(variant: 'owner-card' | 'voter-card') {
-	return document.querySelector(`[data-component='ClaimPromptCard'][data-variant='${variant}'] button`)!;
+function claimPromptButton() {
+	return document.querySelector(`[data-component='ClaimPromptCard'] button`)!;
 }
 
-describe('the top claim prompt pulls the person down to the claim form', () => {
-	test('the owner prompt scrolls to the claim form instead of opening the dialog', async () => {
-		await renderProfileClaimSurfaces('owner-card', true);
-
-		await click(claimPromptButton('owner-card'));
-
-		expect(scrollCalls).toEqual([{ behavior: 'smooth', id: 'person-claim-form' }]);
-		expect(document.querySelector('[role="dialog"]')).toBeNull();
-	});
-
-	test('the owner prompt moves keyboard focus into the claim form', async () => {
-		await renderProfileClaimSurfaces('owner-card', true);
-
-		await click(claimPromptButton('owner-card'));
-
-		const active = document.activeElement;
-		expect(active?.getAttribute('name')).toBe('firstname');
-		expect(active?.closest('form')?.id).toBe('person-claim-owner');
-	});
-
-	test('the scroll is instant when the visitor asks for reduced motion', async () => {
-		(dom.window as unknown as { matchMedia: unknown }).matchMedia = (query: string) => ({ matches: query.includes('reduce'), media: query });
-
-		await renderProfileClaimSurfaces('owner-card', true);
-		await click(claimPromptButton('owner-card'));
-
-		expect(scrollCalls.map(c => c.behavior)).toEqual(['auto']);
-	});
-
+describe('the top of the content well is notify-only', () => {
 	/**
-	 * Reachable rather than theoretical: the code-default template fallback strips
-	 * the CTA banner block the claim band renders into, which would leave the
-	 * prompt on a page with no form to scroll to. The prompt falls back to the
-	 * dialog there, so it is never a button that does nothing.
+	 * The frames put ONE card at the top of the content well and it is
+	 * visitor-facing. An owner-facing "are you [Name]?" prompt was added here
+	 * once and had to be taken back out; a second card, or this one turning into
+	 * a claim shortcut, is the regression this guards.
 	 */
-	test('the scroll reports failure when the claim band is not on the page', async () => {
-		const { scrollToPersonClaimForm } = await import('./claimFormAnchor');
+	test('the prompt opens the notify dialog rather than the claim form', async () => {
+		await renderProfileClaimSurfaces(true);
 
-		expect(scrollToPersonClaimForm()).toBe(false);
-		expect(scrollCalls).toEqual([]);
-	});
-
-	/**
-	 * The counterpart to the owner-prompt test above: this is the entry point the
-	 * notify form is left with, so it has to be shown opening the dialog, not
-	 * merely not scrolling.
-	 */
-	test('the voter prompt still opens the dialog and its notify form', async () => {
-		await renderProfileClaimSurfaces('voter-card', true);
-
+		expect(document.querySelectorAll(`[data-component='ClaimPromptCard']`)).toHaveLength(1);
 		expect(document.querySelector('[role="dialog"]')).toBeNull();
 
-		await click(claimPromptButton('voter-card'));
+		await click(claimPromptButton());
 
 		expect(document.querySelector('[role="dialog"]')).not.toBeNull();
 		expect(document.querySelector('[role="dialog"] form#person-claim-notify')).not.toBeNull();
+		// Nothing up here reaches the person's own claim form.
 		expect(scrollCalls).toEqual([]);
+		expect(document.querySelector('[role="dialog"] form#person-claim-owner')).toBeNull();
+	});
+
+	test('the dialog closes without submitting when the visitor cancels', async () => {
+		await renderProfileClaimSurfaces(true);
+		await click(claimPromptButton());
+
+		const cancel = [...document.querySelectorAll('[role="dialog"] button')].find(b => b.textContent?.includes('Cancel'))!;
+		await click(cancel);
+
+		expect(document.querySelector('[role="dialog"]')).toBeNull();
+		expect(fetchCalls).toEqual([]);
 	});
 });
 

--- a/src/components/people/claimFormAnchor.ts
+++ b/src/components/people/claimFormAnchor.ts
@@ -1,46 +1,10 @@
 /**
- * The scroll target for the owner-facing "claim your profile" CTAs, which pull
- * the person down to the claim form at the bottom of their profile instead of
- * opening a dialog.
+ * Anchor on the claim band at the bottom of an unclaimed person profile, so the
+ * form can be linked to directly (`/people/<slug>#person-claim-form`).
  *
  * Deliberately NOT the `<form id>`. `person-claim-owner` is HubSpot's key for
- * the collected form and is an external contract; keeping the scroll target on
- * a wrapper means a future layout change can move the anchor without re-keying
- * the form in HubSpot, and vice versa.
+ * the collected form and is an external contract; keeping the anchor on a
+ * wrapper means a future layout change can move it without re-keying the form in
+ * HubSpot, and vice versa.
  */
 export const PERSON_CLAIM_ANCHOR_ID = 'person-claim-form';
-
-const CLAIM_FIELD_SELECTORS = ['#person-claim-owner input[name="firstname"]', '#person-claim-owner input[name="email"]'];
-
-function prefersReducedMotion(): boolean {
-	if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return false;
-	return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-}
-
-/**
- * Scrolls to the claim form and moves keyboard focus into it, so keyboard and
- * screen-reader users land where sighted users are looking.
- *
- * Returns `false` when the band is not on the page. That is reachable: the
- * code-default template fallback strips the CTA banner block the band renders
- * into, which would leave the claim card on a page with no form. Callers fall
- * back to the dialog rather than leaving the button doing nothing.
- */
-export function scrollToPersonClaimForm(): boolean {
-	if (typeof document === 'undefined') return false;
-
-	const anchor = document.getElementById(PERSON_CLAIM_ANCHOR_ID);
-	if (!anchor) return false;
-
-	const field = CLAIM_FIELD_SELECTORS.reduce<HTMLElement | null>(
-		(found, selector) => found ?? document.querySelector<HTMLElement>(selector),
-		null,
-	);
-
-	// Focus first, with preventScroll, so the browser does not jump instantly and
-	// then animate — and so the smooth scroll below is what the user actually sees.
-	(field ?? anchor).focus({ preventScroll: true });
-
-	anchor.scrollIntoView?.({ behavior: prefersReducedMotion() ? 'auto' : 'smooth', block: 'start' });
-	return true;
-}

--- a/src/components/people/claimPromptCopy.test.tsx
+++ b/src/components/people/claimPromptCopy.test.tsx
@@ -5,16 +5,19 @@ import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 
 /**
- * Pins the voter-facing claim prompt card to the Figma unclaimed frames:
- *   D 1958:108619 (candidate only)   E 1928:99467 (elected official only)
- *   F 1928:100987 (serving and running — word-for-word identical to E)
+ * Pins the notify prompt card and its dialog to the Figma unclaimed frames:
+ *   card    D 1958:108619 (candidate only)   E 1928:99467 (elected official only)
+ *           F 1928:100987 (serving and running — word-for-word identical to E)
+ *   dialog  1901:51851
  * Past-election profiles (H 1970:113629) show the voter-guide disclaimer instead
  * of a claim prompt, so no card copy exists for that persona.
  *
- * The copy drifted once already (the shipped card asked "Want to hear from
- * [Name]?" while the frames ask visitors to send a request), which nothing
- * caught because no test read the card's words. The persona split is the part
- * most likely to regress: it is NOT the owner card's running/not-running one.
+ * The copy has drifted twice — first the card asked "Want to hear from [Name]?"
+ * while the frames ask visitors to send a request, then the dialog was rewritten
+ * into a "Claim your GoodParty.org profile" account pitch the frames never had.
+ * Both times nothing caught it because no test read the words. The persona split
+ * is the part most likely to regress next: it splits on holding office, not on
+ * running, so `both` takes the officeholder copy.
  *
  * Like claimFormIds.test.tsx these mount the component directly rather than
  * driving the Radix dialog, whose click delegation has proven unreliable under
@@ -92,7 +95,6 @@ const displayName = 'Example Person';
 
 async function renderPromptCard(options: {
 	persona: 'candidate' | 'officeholder' | 'both';
-	variant?: 'voter-card' | 'owner-card';
 	locationLabel?: string | null;
 }) {
 	const { ClaimProfileModal } = await import('./ClaimProfileModal');
@@ -103,14 +105,13 @@ async function renderPromptCard(options: {
 			displayName,
 			persona: options.persona,
 			locationLabel: options.locationLabel ?? null,
-			variant: options.variant ?? 'voter-card',
 		}),
 	);
 }
 
-function card(variant: 'voter-card' | 'owner-card' = 'voter-card') {
-	const element = document.querySelector(`[data-component='ClaimPromptCard'][data-variant='${variant}']`);
-	if (!element) throw new Error(`expected the ${variant} claim prompt to render`);
+function card() {
+	const element = document.querySelector(`[data-component='ClaimPromptCard']`);
+	if (!element) throw new Error('expected the claim prompt to render');
 	return {
 		heading: element.querySelector('h2')?.textContent ?? '',
 		body: element.querySelector('h2 + div')?.textContent ?? '',
@@ -176,15 +177,95 @@ describe('the voter claim prompt card matches the Figma frames', () => {
 	});
 });
 
-describe('the owner claim prompt card is untouched by the voter copy', () => {
-	/**
-	 * The two cards share a component and sit next to each other in the content
-	 * well, so voter copy leaking into the owner card would be easy to miss.
-	 */
-	test('the owner card keeps its own heading and button', async () => {
-		await renderPromptCard({ persona: 'candidate', variant: 'owner-card', locationLabel: 'Springfield' });
+describe('the notify dialog matches Figma 1901:51851', () => {
+	async function openDialog() {
+		await renderPromptCard({ persona: 'candidate', locationLabel: 'Springfield' });
+		const { NotifyForm } = await import('./ClaimProfileModal');
+		return NotifyForm;
+	}
 
-		expect(card('owner-card').heading).toBe(`Are you ${displayName}?`);
-		expect(card('owner-card').button).toBe('Complete your profile');
+	test('the card is the only claim surface in the content well', async () => {
+		await renderPromptCard({ persona: 'candidate', locationLabel: 'Springfield' });
+
+		expect(document.querySelectorAll(`[data-component='ClaimPromptCard']`)).toHaveLength(1);
+	});
+
+	/**
+	 * The dialog is one sentence asking the visitor to nudge the person. It is
+	 * NOT the "create a free account and take control of this page" pitch that
+	 * replaced it once — that copy sells claiming to a reader who has just told
+	 * us they are somebody else.
+	 */
+	test('the title asks the visitor to nudge the person, not to claim', async () => {
+		const { notifyDialogTitle } = await import('./ClaimProfileModal');
+
+		expect(notifyDialogTitle(displayName)).toBe(
+			`Ask ${displayName} to complete their profile and contribute to transparency.`,
+		);
+	});
+
+	test('the form is name, email, opt-in, Cancel and Submit — nothing else', async () => {
+		const NotifyForm = await openDialog();
+		await render(
+			React.createElement(NotifyForm, {
+				personId: '11111111-1111-4111-8111-111111111111',
+				displayName,
+				onCancel: () => {},
+			}),
+		);
+
+		const labels = [...document.querySelectorAll('label')].map(l => l.textContent?.trim() ?? '');
+		expect(labels[0]).toBe('Name (optional)');
+		expect(labels[1]).toContain('Email address');
+		expect(labels[2]).toContain('Sign up for marketing communications from GoodParty.org');
+
+		const buttons = [...document.querySelectorAll('button')].map(b => b.textContent?.trim());
+		expect(buttons).toEqual(['Cancel', 'Submit']);
+	});
+
+	/** A pre-ticked opt-in is not consent; the frames draw it ticked anyway. */
+	test('the marketing opt-in starts unchecked', async () => {
+		const NotifyForm = await openDialog();
+		await render(
+			React.createElement(NotifyForm, { personId: '11111111-1111-4111-8111-111111111111', displayName }),
+		);
+
+		expect(document.querySelector<HTMLInputElement>('input[type="checkbox"]')?.checked).toBe(false);
+	});
+});
+
+describe('the claim band matches Figma 1922:92593', () => {
+	async function renderBand(isRunning: boolean) {
+		const { PersonClaimCTABand } = await import('./PersonClaimCTABand');
+		await render(
+			React.createElement(PersonClaimCTABand, {
+				personId: '11111111-1111-4111-8111-111111111111',
+				displayName,
+				isRunning,
+			}),
+		);
+	}
+
+	test('the band is the page’s only place to claim, and says so in Figma’s words', async () => {
+		await renderBand(true);
+
+		expect(document.querySelector('h2')?.textContent).toBe(`Are you ${displayName}? Complete your profile now.`);
+		expect(document.querySelector('h2 + div')?.textContent).toBe(
+			'Your community deserves accountable leadership. Claim your profile and share your top priorities with residents. Enter your email to get started',
+		);
+	});
+
+	/**
+	 * The frames draw one body for every unclaimed state. It briefly branched on
+	 * running vs in office, which is invented copy — the branch belongs on the
+	 * routing and the confirmation, both of which are below the fold on submit.
+	 */
+	test('the body does not branch on the person’s product', async () => {
+		await renderBand(true);
+		const running = document.querySelector('h2 + div')?.textContent;
+
+		await renderBand(false);
+
+		expect(document.querySelector('h2 + div')?.textContent).toBe(running);
 	});
 });

--- a/src/components/people/personSectionOverrides.test.ts
+++ b/src/components/people/personSectionOverrides.test.ts
@@ -143,10 +143,15 @@ describe('the claim prompt and the claim form ship together', () => {
 		'x-3412f69c',
 	];
 
-	function claimPromptVariants(slug: string): string[] {
+	/**
+	 * The prompt is the only content card handed a person and a place, so it is
+	 * identified by its props rather than by importing the component — this suite
+	 * runs without a DOM and the component pulls in Radix.
+	 */
+	function claimPrompts(slug: string): { locationLabel?: unknown }[] {
 		return contentCards(slug).flatMap(card => {
-			const variant = (card.content as { props?: { variant?: string } } | undefined)?.props?.variant;
-			return variant ? [variant] : [];
+			const props = (card.content as { props?: Record<string, unknown> } | undefined)?.props;
+			return props && 'personId' in props && 'locationLabel' in props ? [props] : [];
 		});
 	}
 
@@ -158,50 +163,52 @@ describe('the claim prompt and the claim form ship together', () => {
 	}
 
 	/**
-	 * The owner prompt's button scrolls to `#person-claim-form`, and that anchor
-	 * only exists inside PersonClaimCTABand. Both hang off the same `showClaim`
-	 * gate today; this pins the pairing so a future change to either gate cannot
-	 * quietly leave the button scrolling to nothing.
+	 * The prompt asks a visitor to nudge the person; the band is where that
+	 * person actually claims. Both hang off the same `showClaim` gate today, and
+	 * a page carrying one without the other is incoherent either way — a nudge
+	 * leading nowhere, or a claim form on a page that never mentions claiming.
 	 */
-	test('no state renders the owner claim prompt without the claim form below it', () => {
+	test('no state renders the claim prompt without the claim band below it', () => {
 		for (const slug of ALL_STATES) {
-			expect([slug, claimPromptVariants(slug).includes('owner-card')]).toEqual([slug, rendersClaimBand(slug)]);
+			expect([slug, claimPrompts(slug).length > 0]).toEqual([slug, rendersClaimBand(slug)]);
 		}
 	});
 
-	test('the unclaimed states lead with the owner prompt, then the voter prompt', () => {
+	/**
+	 * The frames put exactly ONE card at the top of the content well and it is
+	 * visitor-facing (D 1958:108619, E 1928:99467). An owner-facing "are you
+	 * [Name]?" prompt was added alongside it once and had to be taken back out;
+	 * this is what stops a second one reappearing.
+	 */
+	test('the unclaimed states lead with exactly one claim prompt', () => {
 		for (const slug of ['kim-byrd-b77f912d', 'rob-zotti-d8c578fb', 'tim-ficken-0a951485']) {
-			expect([slug, claimPromptVariants(slug)]).toEqual([slug, ['owner-card', 'voter-card']]);
+			expect([slug, claimPrompts(slug).length]).toEqual([slug, 1]);
 		}
 	});
 
 	// A claimed profile has nothing to claim, and a removed one asked us to stop.
-	test('claimed and removed states show neither prompt', () => {
+	test('claimed and removed states show no prompt', () => {
 		for (const slug of ['allen-slagle-74eee01a', 'x-27255f40', 'x-3412f69c']) {
-			expect([slug, claimPromptVariants(slug)]).toEqual([slug, []]);
+			expect([slug, claimPrompts(slug).length]).toEqual([slug, 0]);
 		}
 	});
 
-	function voterPromptLocation(cards: ReturnType<typeof contentCards>): unknown {
+	function promptLocation(cards: ReturnType<typeof contentCards>): unknown {
 		return cards
-			.map(card => (card.content as { props?: { variant?: string; locationLabel?: unknown } } | undefined)?.props)
-			.find(props => props?.variant === 'voter-card')?.locationLabel;
-	}
-
-	function claimPromptLocation(slug: string): unknown {
-		return voterPromptLocation(contentCards(slug));
+			.map(card => (card.content as { props?: Record<string, unknown> } | undefined)?.props)
+			.find(props => props && 'personId' in props && 'locationLabel' in props)?.['locationLabel'];
 	}
 
 	/**
-	 * The voter prompt for someone in office opens "[Location] deserves greater
+	 * The prompt for someone in office opens "[Location] deserves greater
 	 * transparency" (Figma E 1928:99467, F 1928:100987). Nothing on the view is
 	 * that place — `districtLabel` is a ward, `stateLabel` a two-letter code — so
 	 * it is read back off the breadcrumb, and picking the wrong crumb would name
 	 * the state, or the office, where the frame names the town.
 	 */
-	test('the voter prompt is handed the most specific place in the breadcrumb', () => {
+	test('the prompt is handed the most specific place in the breadcrumb', () => {
 		for (const slug of ['kim-byrd-b77f912d', 'rob-zotti-d8c578fb', 'tim-ficken-0a951485']) {
-			expect([slug, claimPromptLocation(slug)]).toEqual([slug, 'Springfield']);
+			expect([slug, promptLocation(contentCards(slug))]).toEqual([slug, 'Springfield']);
 		}
 	});
 
@@ -228,7 +235,7 @@ describe('the claim prompt and the claim form ship together', () => {
 			}),
 		};
 		const cards = buildPersonSectionOverrides(stateOnly).component_profileContentBlock?.contentCards ?? [];
-		expect(voterPromptLocation(cards)).toBe('Wyoming');
+		expect(promptLocation(cards)).toBe('Wyoming');
 	});
 });
 

--- a/src/components/people/personSectionOverrides.tsx
+++ b/src/components/people/personSectionOverrides.tsx
@@ -706,14 +706,15 @@ export function buildPersonSectionOverrides(view: PersonProfileView): SectionOve
 			: { hidden: true };
 
 	// The Figma content well is one column of cards. For unclaimed empowered pages
-	// two claim cards lead the column: the person-facing "Are you …?" prompt,
-	// whose button scrolls down to the claim form in the band below the well, then
-	// the voter-facing "ask them to complete their profile" prompt, whose button
-	// opens the notify dialog.
-	// Between them and the civics cards: authored cards (empowerment-gated) then
-	// the civics-spine cards (Recent Experience → Other candidates → Nearby
-	// officials → About position → District map) that render on every state.
-	const claimCard = (variant: 'voter-card' | 'owner-card'): ProfileContentCardProps => ({
+	// exactly ONE card leads the column (frames D 1958:108619 / E 1928:99467): the
+	// visitor-facing "ask them to complete their profile" prompt, whose button
+	// opens the notify dialog. The frames put no owner-facing claim prompt up
+	// here — the person's own way in is the claim band below the well — so do not
+	// add a second card.
+	// Below it: authored cards (empowerment-gated) then the civics-spine cards
+	// (Recent Experience → Other candidates → Nearby officials → About position →
+	// District map) that render on every state.
+	const claimCard = (): ProfileContentCardProps => ({
 		raw: true,
 		content: (
 			<ClaimProfileModal
@@ -721,7 +722,6 @@ export function buildPersonSectionOverrides(view: PersonProfileView): SectionOve
 				displayName={view.displayName}
 				persona={view.persona}
 				locationLabel={profileLocationLabel(view)}
-				variant={variant}
 			/>
 		),
 	});
@@ -735,7 +735,7 @@ export function buildPersonSectionOverrides(view: PersonProfileView): SectionOve
 			: {};
 	const contentCards: ProfileContentCardProps[] = [
 		...(view.persona === 'past' ? [pastElectionDisclaimer(view)] : []),
-		...(showClaim ? [claimCard('owner-card'), claimCard('voter-card')] : []),
+		...(showClaim ? [claimCard()] : []),
 		...orderedSectionCards(view, { ...authoredSections, ...buildCivicSections(view) }),
 	];
 	const sidebar = buildSidebar(view);


### PR DESCRIPTION
## Why

The unclaimed person profile had drifted off the design in three places:

1. **An owner-facing card that the frames never had.** The content well led with an invented "Are you [Name]?" prompt above the visitor card, so the page had two large blue panels stacked.
2. **The visitor card was restyled.** The frames draw a borderless `rounded-3xl` blue panel with centered 32px heading, 20px body, and a midnight button. We shipped a bordered box with a left-aligned 20px heading, 16px body, and a blue button.
3. **The dialog had been rewritten.** Figma's dialog is one line — "Ask [Name] to complete their profile and contribute to transparency." — over name, email, opt-in, Cancel/Submit. We shipped "Claim your GoodParty.org profile", an explanatory paragraph, a "Claim this profile" sign-up button, and a "Not [Name]?" sub-form. That copy pitches claiming to a reader who has just told us they are somebody else.

## What changed

Restored all three from the frames, which also settles who each surface talks to: **the content well is notify-only, and claiming happens solely in the band at the bottom.**

| Surface | Figma node |
| --- | --- |
| Prompt card | D `1958:108619`, E `1928:99467` |
| Dialog | `1901:51851` |
| Claim band | `1922:92593` |

Because nothing scrolls to `#person-claim-form` any more, `scrollToPersonClaimForm` goes with the owner card; the anchor stays so the form is still linkable. The dead CMS branch that rendered this component as a yellow banner went too — nothing set `interactive`, and a "Claim your profile" button opening a notify dialog would be incoherent now.

The band's body copy no longer branches on running vs in office. That was invented; the frames draw one sentence for every unclaimed state.

## Knowingly not matching the frames

- **The marketing opt-in stays unchecked.** Figma draws it ticked; a pre-ticked box is not consent. (Pre-existing, from #228.)
- **The band still branches Win/Serve on submit** for routing and its confirmation message. The static frames have no way to draw a post-submit state. (Pre-existing, from #231.)

## Test plan

- [x] `bun run test` — 678 logic + 28 DOM, all passing
- [x] `npx tsc --noEmit` clean, `bun run lint` clean (only pre-existing warnings)
- [x] Rendered states D and E locally at 1440px and compared each surface against its frame
- [x] Browser console clean (only the pre-existing dev-fixture LCP warning and headless WebGL notice)
- [ ] Reviewer: confirm on the preview that the content well has exactly one blue card, and that the only way to claim is the band at the bottom

New tests read the actual words on all three surfaces and assert the content well holds exactly one prompt — the copy drifted twice before, and both times nothing caught it because no test read it.

Made with [Cursor](https://cursor.com)