### PR TITLE
fix(people): case unformatted spine names at display time

### DIFF
--- a/src/lib/peopleProfile.test.ts
+++ b/src/lib/peopleProfile.test.ts
@@ -452,6 +452,36 @@ describe('composeView claim + overlay precedence', () => {
 	});
 });
 
+describe('composeView display name casing', () => {
+	test('cases an unformatted spine name without disturbing the canonical slug', () => {
+		const view = composeView(PID, makePerson({ slug: 'chris-lewis', fullName: 'chris lewis' }), null);
+		expect(view.displayName).toBe('Chris Lewis');
+		expect(view.initials).toBe('CL');
+		expect(view.canonicalSlug).toBe('chris-lewis-11111111');
+	});
+
+	test('composes first/last when the spine has no fullName', () => {
+		const view = composeView(PID, makePerson({ firstName: 'ed', lastName: 'johnson' }), null);
+		expect(view.displayName).toBe('Ed Johnson');
+	});
+
+	test('leaves an already-formatted spine name alone', () => {
+		const view = composeView(PID, makePerson({ fullName: 'Blaine K. Bowman' }), null);
+		expect(view.displayName).toBe('Blaine K. Bowman');
+	});
+
+	// An owner who types their name in lowercase means it; only the spine's
+	// lowercase is the unformatted-data signature.
+	test('never re-cases an owner-authored displayName', () => {
+		const view = composeView(
+			PID,
+			makePerson({ fullName: 'bell hooks' }),
+			makeOverlay({ displayName: 'bell hooks' }),
+		);
+		expect(view.displayName).toBe('bell hooks');
+	});
+});
+
 describe('composeView issues, links, labels', () => {
 	test('keeps only visible issues that have a title, preserving order', () => {
 		const view = composeView(

--- a/src/lib/peopleProfile.ts
+++ b/src/lib/peopleProfile.ts
@@ -16,6 +16,7 @@ import {
 	getStateName,
 } from '~/lib/electionsHelpers';
 import { classifyPartyFrom, isMajorParty, type PartyClass } from '~/lib/party';
+import { formatPersonName } from '~/lib/personName';
 import type { CandidacyItem } from '~/types/elections';
 import type {
 	PersonAccomplishment,
@@ -518,7 +519,7 @@ const PARTY_LABELS: Record<PartyClass, string> = {
 };
 
 function nameOf(first?: string | null, last?: string | null, fallback = ''): string {
-	return [first, last].filter(Boolean).join(' ') || fallback;
+	return formatPersonName([first, last].filter(Boolean).join(' ')) ?? fallback;
 }
 
 /** Maps candidacies sharing a position into "Other Candidates" cards, excluding the subject. */
@@ -565,7 +566,8 @@ export function buildNearbyOfficialCards(
 		if (pid && pid.toLowerCase() === excludePersonId.toLowerCase()) continue;
 		const person = pid ? personsById.get(pid.toLowerCase()) : undefined;
 		const name =
-			person?.fullName ?? nameOf(person?.firstName, person?.lastName, oh.officeTitle ?? '');
+			formatPersonName(person?.fullName) ??
+			nameOf(person?.firstName, person?.lastName, oh.officeTitle ?? '');
 		if (!name) continue;
 		// Dedupe by personId when present, else by name — otherwise null-id rows
 		// with the same office title yield duplicate cards (and colliding React
@@ -700,7 +702,10 @@ export function composeView(
 	const removed = extras.removed ?? false;
 	const claimed = overlay !== null && !removed;
 	const composedName = [person?.firstName, person?.lastName].filter(Boolean).join(' ');
-	const nameFromPerson = person?.fullName ?? (composedName || null);
+	// Casing is applied to the spine name only. The overlay's displayName is
+	// owner-authored, where an all-lowercase value is a deliberate style choice
+	// (bell hooks) rather than the unformatted-data signature it is upstream.
+	const nameFromPerson = formatPersonName(person?.fullName ?? (composedName || null));
 	const displayName = overlay?.displayName ?? nameFromPerson ?? 'Public Official';
 	const office = pickCurrentOffice(person);
 	const persona = resolvePersona(person, office);
@@ -1023,7 +1028,8 @@ export async function loadPersonProfile(personId: string): Promise<PersonProfile
 	const stateCode = office?.state ?? person?.state ?? candidacy?.state ?? null;
 
 	const composedName = [person?.firstName, person?.lastName].filter(Boolean).join(' ');
-	const displayName = overlay?.displayName ?? person?.fullName ?? (composedName || 'Public Official');
+	const displayName =
+		overlay?.displayName ?? formatPersonName(person?.fullName ?? composedName) ?? 'Public Official';
 
 	// The interlink sections are independent; fetch in parallel. Each degrades to
 	// empty on any miss so the core profile always renders.

--- a/src/lib/personName.test.ts
+++ b/src/lib/personName.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from 'bun:test';
+import { formatPersonName } from './personName';
+
+describe('formatPersonName', () => {
+	test('cases the unformatted rows that produced "chris lewis — Candidate"', () => {
+		expect(formatPersonName('chris lewis')).toBe('Chris Lewis');
+		expect(formatPersonName('george leo moniz')).toBe('George Leo Moniz');
+	});
+
+	// The guard that makes this transform safe to apply corpus-wide: anything
+	// already carrying an uppercase letter is evidence of a formatted source.
+	describe('passes already-formatted names through untouched', () => {
+		for (const name of [
+			'McDonald',
+			'Ian McDonald',
+			"O'Brien",
+			"Siobhan O'Brien",
+			'DeAngelo',
+			'Chris DeAngelo',
+			'van der Berg',
+			'Pieter van der Berg',
+			'Blaine K. Bowman',
+			'Smith-Jones',
+			'Mary Smith-Jones',
+			'Martin Luther King Jr.',
+			'Henry Ford III',
+			'LaToya Cantrell',
+			'MacArthur',
+			'Rebecca Reid',
+			'Allen Earl Slagle',
+		]) {
+			test(name, () => {
+				expect(formatPersonName(name)).toBe(name);
+			});
+		}
+	});
+
+	describe('applies name conventions when the source is entirely lowercase', () => {
+		const cases: [string, string][] = [
+			['ian mcdonald', 'Ian McDonald'],
+			['mcgee', 'McGee'],
+			['mccoy', 'McCoy'],
+			["siobhan o'brien", "Siobhan O'Brien"],
+			["chris d'angelo", "Chris D'Angelo"],
+			['mary smith-jones', 'Mary Smith-Jones'],
+			['anne-marie o\'neill-burke', "Anne-Marie O'Neill-Burke"],
+			['henry ford iii', 'Henry Ford III'],
+			['walter carter iv', 'Walter Carter IV'],
+			['blaine k. bowman', 'Blaine K. Bowman'],
+		];
+		for (const [input, expected] of cases) {
+			test(`${input} → ${expected}`, () => {
+				expect(formatPersonName(input)).toBe(expected);
+			});
+		}
+	});
+
+	// Documented losses. An all-lowercase source has already destroyed the
+	// distinction, so these assert the deliberate choice rather than a fix.
+	describe('does not guess where lowercase input is genuinely ambiguous', () => {
+		test('Mac is left as an ordinary word start, because Mackenzie is not MacKenzie', () => {
+			expect(formatPersonName('macdonald')).toBe('Macdonald');
+			expect(formatPersonName('sarah mackenzie')).toBe('Sarah Mackenzie');
+		});
+
+		test('DeAngelo is not reconstructed, because Deangelo is also a real name', () => {
+			expect(formatPersonName('chris deangelo')).toBe('Chris Deangelo');
+		});
+
+		test('particles are capitalized, matching US civic records over Dutch convention', () => {
+			expect(formatPersonName('pieter van der berg')).toBe('Pieter Van Der Berg');
+			expect(formatPersonName('juan de la cruz')).toBe('Juan De La Cruz');
+		});
+	});
+
+	describe('edge cases', () => {
+		test('normalizes the stray whitespace these rows also carry', () => {
+			expect(formatPersonName('  chris   lewis  ')).toBe('Chris Lewis');
+		});
+
+		test('trims but does not re-case a formatted name', () => {
+			expect(formatPersonName('  Blaine K. Bowman ')).toBe('Blaine K. Bowman');
+		});
+
+		test('null-ish and blank input yield null, so callers keep their fallback', () => {
+			expect(formatPersonName(null)).toBeNull();
+			expect(formatPersonName(undefined)).toBeNull();
+			expect(formatPersonName('')).toBeNull();
+			expect(formatPersonName('   ')).toBeNull();
+		});
+
+		test('a name with no cased letters at all is left alone', () => {
+			expect(formatPersonName('小明')).toBe('小明');
+		});
+
+		test('is idempotent', () => {
+			for (const input of ['chris lewis', 'ian mcdonald', "siobhan o'brien", 'henry ford iii']) {
+				const once = formatPersonName(input);
+				expect(formatPersonName(once)).toBe(once);
+			}
+		});
+	});
+});

--- a/src/lib/personName.ts
+++ b/src/lib/personName.ts
@@ -1,0 +1,98 @@
+// Display casing for names sourced from the civics spine. A large share of
+// election-api's Person rows carry an unformatted, entirely-lowercase name
+// ("chris lewis"), which reaches the page title, the hero and the JSON-LD
+// verbatim. The real fix is upstream normalization; this is the display-time
+// guard that keeps an unformatted row from rendering as one.
+
+/**
+ * Only an ENTIRELY lowercase string is re-cased. Any uppercase character is
+ * taken as evidence the source was already formatted, and the value is returned
+ * byte-for-byte.
+ *
+ * This guard is the whole safety argument. Title-casing is lossy — it cannot
+ * distinguish `McDonald` from `Mcdonald`, `DeAngelo` from `Deangelo`, or
+ * `van der Berg` from `Van Der Berg` — so applying it to a correctly-cased name
+ * destroys information that upstream got right. Restricting it to the one input
+ * shape that is unambiguously unformatted means a correct name can never be
+ * made incorrect; the worst case is that an unformatted name stays unformatted.
+ */
+function isUnformatted(name: string): boolean {
+	return /[a-z]/.test(name) && name === name.toLowerCase();
+}
+
+/**
+ * Suffix tokens that are Roman numerals rather than words. Restricted to the
+ * range that actually occurs in personal names — beyond `X` the numerals start
+ * colliding with real surnames (`Li`, `Mi`, `Di` are not numerals, and a longer
+ * list would eventually swallow one).
+ */
+const ROMAN_SUFFIXES = new Set(['ii', 'iii', 'iv', 'vi', 'vii', 'viii', 'ix', 'x']);
+
+/**
+ * `Mc` is capitalized on the following letter (`mcdonald` → `McDonald`) because
+ * the prefix is essentially always patronymic in English-language name data.
+ *
+ * `Mac` deliberately gets no such rule: it is a genuine prefix in `MacArthur`
+ * but an ordinary word-start in `Mackenzie`, `Mackey` and `Macias`, and nothing
+ * in an all-lowercase string distinguishes them. Guessing would corrupt more
+ * names than it repaired, so `macdonald` becomes `Macdonald`.
+ */
+const MC_PREFIX_RE = /^mc([a-z]{2,})$/;
+
+/**
+ * Elided prefixes that capitalize the letter after the apostrophe
+ * (`o'brien` → `O'Brien`, `d'angelo` → `D'Angelo`).
+ *
+ * Only these two, and only in the leading position: an interior apostrophe is
+ * usually a possessive or a contraction inside a transliteration, where
+ * capitalizing the next letter would be wrong.
+ */
+const ELIDED_PREFIX_RE = /^([od])'([a-z].*)$/;
+
+function capitalizeFirst(word: string): string {
+	return word.charAt(0).toUpperCase() + word.slice(1);
+}
+
+/**
+ * Cases one whitespace-delimited token, recursing through hyphens so each half
+ * of a compound surname is capitalized (`smith-jones` → `Smith-Jones`).
+ */
+function formatToken(token: string): string {
+	if (!token) return token;
+	if (ROMAN_SUFFIXES.has(token.replace(/\./g, ''))) return token.toUpperCase();
+	if (token.includes('-')) return token.split('-').map(formatToken).join('-');
+
+	const [, elidedPrefix, elidedRest] = ELIDED_PREFIX_RE.exec(token) ?? [];
+	if (elidedPrefix && elidedRest) {
+		return `${elidedPrefix.toUpperCase()}'${capitalizeFirst(elidedRest)}`;
+	}
+
+	const [, mcRest] = MC_PREFIX_RE.exec(token) ?? [];
+	if (mcRest) return `Mc${capitalizeFirst(mcRest)}`;
+
+	return capitalizeFirst(token);
+}
+
+/**
+ * Formats a display name for rendering, re-casing only unformatted input.
+ *
+ * Nobiliary particles (`van`, `de`, `del`, `di`, …) are capitalized like any
+ * other token rather than being kept lowercase. From an all-lowercase string
+ * there is no way to tell a Dutch tussenvoegsel, which convention lowercases,
+ * from a Hispanic compound surname, which US civic records overwhelmingly
+ * render capitalized — and the latter is far more common in this corpus. A
+ * source that sends `van der Berg` already cased keeps it, via the guard above.
+ *
+ * Whitespace is normalized because the same rows that arrive uncased also
+ * arrive with doubled and trailing spaces.
+ */
+export function formatPersonName(name: string): string;
+export function formatPersonName(name: null | undefined): null;
+export function formatPersonName(name: string | null | undefined): string | null;
+export function formatPersonName(name: string | null | undefined): string | null {
+	if (name == null) return null;
+	const trimmed = name.trim().replace(/\s+/g, ' ');
+	if (!trimmed) return null;
+	if (!isUnformatted(trimmed)) return trimmed;
+	return trimmed.split(' ').map(formatToken).join(' ');
+}


### PR DESCRIPTION
## What's wrong

A large share of election-api `Person` rows carry a name that is entirely lowercase — `chris lewis`, not `Chris Lewis`. Nothing re-cases it, so it reaches the `<title>`, the `<h1>`, the meta description and the `Person` JSON-LD verbatim. This is the "formatting error" marketing spotted last week on the `/people` profiles.

Measured on production: **35% of a random 608-page sample** of the `/people` corpus renders an entirely-lowercase name.

## What this does

Adds `formatPersonName` and applies it to spine-sourced names only.

The safety argument is the guard, not the transform: **only a string that is entirely lowercase is re-cased.** Any uppercase character anywhere is taken as evidence the source was already formatted, and the value is returned unchanged. Title-casing is lossy — it cannot tell `McDonald` from `Mcdonald` or `van der Berg` from `Van Der Berg` — so restricting it to the one input shape that is unambiguously unformatted means a correct name can never be corrupted. The worst case is that an unformatted name stays unformatted.

Within the all-lowercase branch it applies `Mc`, `O'`/`D'`, hyphenated compounds and Roman-numeral suffixes. It deliberately does **not** guess `Mac` (`MacArthur` and `Mackenzie` are indistinguishable once lowercased) or reconstruct `DeAngelo`, and the tests assert those as chosen behaviour rather than gaps.

Owner-authored `displayName` from the gp-api overlay is never touched — an owner who types their name in lowercase means it.

Canonical slugs are unaffected: `slugifyName` lowercases before slugifying, so no URL changes.

## Verification

Rendered through the real pipeline against a mock election-api serving the affected record shape:

| upstream `fullName` | rendered title |
| --- | --- |
| `chris lewis` | `Chris Lewis — Candidate \| GoodParty.org` |
| `dana mcdonald-o'brien iii` | `Dana McDonald-O'Brien III — Candidate \| GoodParty.org` |
| `Blaine K. Bowman` | `Blaine K. Bowman — Candidate \| GoodParty.org` (untouched) |

## Note

This is the display-time guard, not the cure. The names should be normalized in the data platform so every consumer of the persons mart gets them right; a data-team ask is going out separately. This ships the fix today and stays correct after the backfill, because a properly-cased name passes straight through.

## Tests

- `bun run typecheck` — clean
- `bun run test` — 758 pass, 0 fail (36 new)
- `next lint` on changed files — 0 errors

Made with [Cursor](https://cursor.com)