### PR TITLE
fix(people): keep contentless profiles out of the index and the sitemap

### DIFF
--- a/src/app/people/[slug]/page.tsx
+++ b/src/app/people/[slug]/page.tsx
@@ -8,7 +8,7 @@ import {
 } from '~/lib/schema';
 import {
 	extractPersonId,
-	isThinProfile,
+	isIndexableProfile,
 	loadPersonProfile,
 	type PersonProfileView,
 } from '~/lib/peopleProfile';
@@ -138,7 +138,7 @@ export async function generateMetadata({
 	// "Duplicate, Google chose different canonical than user". Both keep
 	// `follow: true` so the civics interlinks on the page still carry crawl
 	// signal to the election and profile pages they point at.
-	const indexable = !view.removed && !isThinProfile(view);
+	const indexable = isIndexableProfile(view);
 
 	return {
 		title,

--- a/src/app/people/[slug]/page.tsx
+++ b/src/app/people/[slug]/page.tsx
@@ -8,6 +8,7 @@ import {
 } from '~/lib/schema';
 import {
 	extractPersonId,
+	isThinProfile,
 	loadPersonProfile,
 	type PersonProfileView,
 } from '~/lib/peopleProfile';
@@ -130,13 +131,20 @@ export async function generateMetadata({
 		view.bio ??
 		`${view.displayName}${view.roleTitle ? `, ${view.roleTitle}` : ''} on GoodParty.org.`;
 
+	// Two different reasons to stay out of the index, one directive. A person who
+	// requested removal keeps a crawlable, stripped URL (K/L) but should not be
+	// actively surfaced; a profile with no differentiating content yet is a
+	// near-duplicate of every other one, which is what Google clustered under
+	// "Duplicate, Google chose different canonical than user". Both keep
+	// `follow: true` so the civics interlinks on the page still carry crawl
+	// signal to the election and profile pages they point at.
+	const indexable = !view.removed && !isThinProfile(view);
+
 	return {
 		title,
 		description,
 		alternates: { canonical },
-		// A person who requested removal keeps a crawlable, stripped URL (K/L) but
-		// should not be actively indexed/surfaced.
-		...(view.removed ? { robots: { index: false, follow: true } } : {}),
+		...(indexable ? {} : { robots: { index: false, follow: true } }),
 		openGraph: {
 			type: 'profile',
 			siteName: SITE_NAME,

--- a/src/app/people/[slug]/page.tsx
+++ b/src/app/people/[slug]/page.tsx
@@ -131,13 +131,10 @@ export async function generateMetadata({
 		view.bio ??
 		`${view.displayName}${view.roleTitle ? `, ${view.roleTitle}` : ''} on GoodParty.org.`;
 
-	// Two different reasons to stay out of the index, one directive. A person who
-	// requested removal keeps a crawlable, stripped URL (K/L) but should not be
-	// actively surfaced; a profile with no differentiating content yet is a
-	// near-duplicate of every other one, which is what Google clustered under
-	// "Duplicate, Google chose different canonical than user". Both keep
-	// `follow: true` so the civics interlinks on the page still carry crawl
-	// signal to the election and profile pages they point at.
+	// `follow: true` on both suppression paths (see isIndexableProfile for what
+	// they are): the page stops competing in the index, but its civics
+	// interlinks keep carrying crawl signal to the election and profile pages
+	// they point at.
 	const indexable = isIndexableProfile(view);
 
 	return {

--- a/src/lib/peopleProfile.states.test.ts
+++ b/src/lib/peopleProfile.states.test.ts
@@ -93,6 +93,7 @@ function bareCivicsSpine(person: PersonItem): PersonItem {
 		linkedinUrl: null,
 		facebookUrl: null,
 		twitterUrl: null,
+		instagramUrl: null,
 	};
 }
 

--- a/src/lib/peopleProfile.states.test.ts
+++ b/src/lib/peopleProfile.states.test.ts
@@ -11,7 +11,8 @@
  * so the Storybook stories render the exact same data.
  */
 import { afterEach, describe, expect, test } from 'bun:test';
-import { loadPersonProfile } from './peopleProfile';
+import type { PersonItem } from '~/types/people';
+import { isIndexableProfile, loadPersonProfile } from './peopleProfile';
 import {
 	assertNoPii,
 	buildPeopleFetchMock,
@@ -19,6 +20,7 @@ import {
 	PERSON_ID,
 	STATE_FIXTURES,
 	UNPUBLISHED_FIXTURES,
+	viewForFixture,
 } from '~/testing/peopleProfileFixtures';
 
 const originalFetch = globalThis.fetch;
@@ -70,6 +72,65 @@ describe('public profile — removal SEO signal', () => {
 			// flag that drives it matches the spec for every state.
 			expect(fixture.expected.removed).toBe(fixture.expected.noindex);
 		}
+	});
+});
+
+/**
+ * The fixture spine minus every field a real unclaimed record routinely lacks:
+ * the BallotReady bio and headshot, and the social/website columns the link rail
+ * is built from. What survives is the civics spine alone — an office term
+ * and/or a candidacy — which is the shape the contentless-profile suppression
+ * has to reason about. The enriched fixtures pass the thinness test on their
+ * bio and photo, so asserting on them unstripped would prove nothing about the
+ * design state itself.
+ */
+function bareCivicsSpine(person: PersonItem): PersonItem {
+	return {
+		...person,
+		bioText: null,
+		headshotUrl: null,
+		websiteUrl: null,
+		linkedinUrl: null,
+		facebookUrl: null,
+		twitterUrl: null,
+	};
+}
+
+/**
+ * The indexing directive for all twelve Figma states plus the two unpublished
+ * overlays, asserted against the same hand-written `expected.noindex` column the
+ * rest of the matrix is specified by.
+ *
+ * This exists because suppressing contentless profiles is a rule that can only
+ * fail in one direction that matters: quietly withholding a legitimate design
+ * state. Every claimed state (A–C, G) is safe by construction — isThinProfile
+ * short-circuits on `claimed` — so the risk is concentrated in the unclaimed
+ * ones, and the past-election states in particular, where a concluded race no
+ * longer makes someone a current candidate. Stripping each fixture to its
+ * civics spine first is what makes the assertion mean "the state is
+ * indexable", rather than "this fixture happened to carry a headshot".
+ */
+describe('public profile — indexing directive across the 12 states', () => {
+	for (const fixture of [...STATE_FIXTURES, ...UNPUBLISHED_FIXTURES]) {
+		test(`state ${fixture.state} — ${fixture.description}`, () => {
+			const view = viewForFixture({ ...fixture, person: bareCivicsSpine(fixture.person) });
+
+			expect(isIndexableProfile(view)).toBe(!fixture.expected.noindex);
+		});
+	}
+
+	// The counterweight: with the civics spine gone too, there is nothing left to
+	// tell the page apart, and that — not the design state — is what suppression
+	// keys on. Without this the matrix above would also pass if isThinProfile
+	// were `() => false`.
+	test('the same spine with no office and no candidacy is the shape that is withheld', () => {
+		const bare = fixtureForState('D');
+		const view = viewForFixture({
+			...bare,
+			person: { ...bareCivicsSpine(bare.person), Candidacies: [], OfficeHolders: [] },
+		});
+
+		expect(isIndexableProfile(view)).toBe(false);
 	});
 });
 

--- a/src/lib/peopleProfile.test.ts
+++ b/src/lib/peopleProfile.test.ts
@@ -56,6 +56,7 @@ function makePerson(p: Partial<PersonItem> = {}): PersonItem {
 		linkedinUrl: null,
 		facebookUrl: null,
 		twitterUrl: null,
+		instagramUrl: null,
 		state: null,
 		...p,
 	};
@@ -630,6 +631,22 @@ describe('isThinProfile', () => {
 					composeView(PID, makePerson({ ...thinPerson, websiteUrl: 'https://x.example' }), null),
 				),
 			).toBe(false);
+		});
+
+		// Instagram is the one link in election-api's `urls[]` block that
+		// buildLinks did not fall back to the spine for, so a person whose only
+		// public link was an Instagram reached this predicate looking contentless.
+		// Asserting the link too, not just the verdict: the verdict alone would
+		// still pass if the URL were counted but never rendered.
+		test('an Instagram on the spine, which the link rail used to drop', () => {
+			const view = composeView(
+				PID,
+				makePerson({ ...thinPerson, instagramUrl: 'https://instagram.com/chris' }),
+				null,
+			);
+
+			expect(view.links.map((l) => l.kind)).toEqual(['instagram']);
+			expect(isThinProfile(view)).toBe(false);
 		});
 	});
 

--- a/src/lib/peopleProfile.test.ts
+++ b/src/lib/peopleProfile.test.ts
@@ -524,6 +524,95 @@ describe('isThinProfile', () => {
 		expect(isThinProfile(view)).toBe(true);
 	});
 
+	// The dbt mart wraps the BallotReady office columns in nullif(x, '') because
+	// "the S3 feed uses '' (not null) for absent values" — but only some of them.
+	// m_election_api__office_holder.sql does it for office_title and skips
+	// position_name, so '' is a value this feed genuinely sends, and under
+	// `officeName ?? positionId` that '' is the answer: the positionId behind it
+	// is never consulted and a profile whose race resolved gets withheld.
+	test('an empty-string position name does not mask a resolved position', () => {
+		const view = composeView(
+			PID,
+			makePerson({ fullName: 'chris lewis', Candidacies: [{ id: 'c1', positionName: '' }] }),
+			null,
+			{ positionId: 'pos-1' },
+		);
+
+		expect(view.officeName).toBe('');
+		expect(isThinProfile(view)).toBe(false);
+	});
+
+	// Same feed, same reason, one field over: m_election_api__person.sql nullif()s
+	// the social URLs beside it but not bio_text, so a blank bio has to read as
+	// the absence it is rather than as content that keeps the page in the index.
+	test('a whitespace-only spine bio is not content', () => {
+		const view = composeView(PID, makePerson({ fullName: 'chris lewis', bioText: '   ' }), null);
+
+		expect(isThinProfile(view)).toBe(true);
+	});
+
+	/**
+	 * The sitemap builder derives the same signal from the candidacy and
+	 * officeholder sweeps, so it drops any URL those feeds name no office for. If
+	 * this predicate could withhold a page those feeds DO name, the sitemap would
+	 * advertise a URL that renders noindex — trading the current GSC report for
+	 * "Submitted URL marked noindex". These pin the link that prevents it, which
+	 * is `recentExperience` rather than `officeName`: the sweeps see every row,
+	 * while the view names only the row primaryCandidacy/pickCurrentOffice chose.
+	 */
+	describe('anything the civics feeds name keeps the page indexable', () => {
+		test('a named candidacy the view did not choose', () => {
+			const view = composeView(
+				PID,
+				makePerson({
+					fullName: 'chris lewis',
+					// primaryCandidacy prefers a slugged row, so it picks the unnamed
+					// one; the sitemap's sweep sees both.
+					Candidacies: [
+						{ id: 'c1', slug: 'unnamed-race', positionName: null },
+						{ id: 'c2', positionName: 'Mayor' },
+					],
+				}),
+				null,
+			);
+
+			expect(view.officeName).toBeNull();
+			expect(isThinProfile(view)).toBe(false);
+		});
+
+		// #227 stopped a concluded race from making someone a current candidate,
+		// which is a persona change only — the race still names the seat. Worth
+		// pinning because a page whose only civics row is in the past is exactly
+		// the shape that looks discardable, and it is a legitimate voter-guide
+		// page carrying a real office, an election date and a disclaimer.
+		test('a concluded race that still names the seat', () => {
+			const view = composeView(
+				PID,
+				makePerson({
+					fullName: 'chris lewis',
+					Candidacies: [
+						{ id: 'c1', positionName: 'Mayor', Race: { electionDate: '2020-11-03' } },
+					],
+				}),
+				null,
+			);
+
+			expect(view.persona).toBe('candidate');
+			expect(isThinProfile(view)).toBe(false);
+		});
+
+		test('an office term the view could not title', () => {
+			const view = composeView(
+				PID,
+				makePerson({ fullName: 'chris lewis', OfficeHolders: [makeOffice({ isCurrent: true })] }),
+				null,
+			);
+
+			expect(view.officeName).toBeNull();
+			expect(isThinProfile(view)).toBe(false);
+		});
+	});
+
 	describe('any single signal keeps the page indexable', () => {
 		test('a spine bio', () => {
 			expect(isThinProfile(composeView(PID, makePerson({ ...thinPerson, bioText: 'A bio.' }), null))).toBe(false);

--- a/src/lib/peopleProfile.test.ts
+++ b/src/lib/peopleProfile.test.ts
@@ -7,6 +7,7 @@ import {
 	buildPersonSlugFromBase,
 	composeView,
 	extractPersonId,
+	isThinProfile,
 	resolveProfileState,
 	type PersonPersona,
 } from './peopleProfile';
@@ -480,6 +481,83 @@ describe('composeView display name casing', () => {
 			makeOverlay({ displayName: 'bell hooks' }),
 		);
 		expect(view.displayName).toBe('bell hooks');
+	});
+});
+
+describe('isThinProfile', () => {
+	// The shape behind the 1,792 GSC flagged: a name, a state, and nothing else.
+	const thinPerson = makePerson({ fullName: 'chris lewis', state: 'VA' });
+
+	test('an unclaimed profile with no office and no content is thin', () => {
+		const view = composeView(PID, thinPerson, null);
+		expect(view.roleTitle).toBe('Candidate');
+		expect(isThinProfile(view)).toBe(true);
+	});
+
+	test('a candidacy that names a position is enough to differentiate', () => {
+		const view = composeView(
+			PID,
+			makePerson({ fullName: 'chris lewis', Candidacies: [{ id: 'c1', positionName: 'Mayor' }] }),
+			null,
+		);
+		expect(isThinProfile(view)).toBe(false);
+	});
+
+	test('an office term is enough to differentiate', () => {
+		const view = composeView(
+			PID,
+			makePerson({
+				fullName: 'chris lewis',
+				OfficeHolders: [makeOffice({ isCurrent: true, officeTitle: 'City Council' })],
+			}),
+			null,
+		);
+		expect(isThinProfile(view)).toBe(false);
+	});
+
+	test('a candidacy with a null position name does not differentiate', () => {
+		const view = composeView(
+			PID,
+			makePerson({ fullName: 'chris lewis', Candidacies: [{ id: 'c1', positionName: null }] }),
+			null,
+		);
+		expect(isThinProfile(view)).toBe(true);
+	});
+
+	describe('any single signal keeps the page indexable', () => {
+		test('a spine bio', () => {
+			expect(isThinProfile(composeView(PID, makePerson({ ...thinPerson, bioText: 'A bio.' }), null))).toBe(false);
+		});
+
+		test('a headshot', () => {
+			expect(
+				isThinProfile(composeView(PID, makePerson({ ...thinPerson, headshotUrl: 'p.png' }), null)),
+			).toBe(false);
+		});
+
+		test('an outbound link', () => {
+			expect(
+				isThinProfile(
+					composeView(PID, makePerson({ ...thinPerson, websiteUrl: 'https://x.example' }), null),
+				),
+			).toBe(false);
+		});
+	});
+
+	// An owner asked for this page; the claimed population is far too small to
+	// drive clustering, so it is never withheld from the index.
+	test('a claimed profile is never thin, even with nothing else on it', () => {
+		const view = composeView(PID, thinPerson, makeOverlay({}));
+		expect(view.claimed).toBe(true);
+		expect(isThinProfile(view)).toBe(false);
+	});
+
+	// Removal already sets noindex on its own; both rules agreeing here means the
+	// K/L pages cannot be re-indexed by one rule while the other suppresses them.
+	test('a removed profile stripped back to the bare spine is thin', () => {
+		const view = composeView(PID, thinPerson, makeOverlay({ bioOverride: 'gone' }), { removed: true });
+		expect(view.removed).toBe(true);
+		expect(isThinProfile(view)).toBe(true);
 	});
 });
 

--- a/src/lib/peopleProfile.ts
+++ b/src/lib/peopleProfile.ts
@@ -519,7 +519,15 @@ function buildLinks(
 	const email = overlay?.publicEmail ?? office?.officeEmail ?? null;
 	// Owner's public line wins; their office-line override precedes the spine's.
 	const phone = overlay?.publicPhone ?? overlay?.officePhone ?? office?.officePhone ?? null;
-	const instagram = overlay?.instagramUrl ?? null;
+	// Instagram reads the spine like its four siblings below. It was the one
+	// public link in election-api's `urls[]` block the spine fallback skipped, so
+	// an unclaimed person whose only public link was an Instagram rendered no
+	// link rail at all — and, since isThinProfile reads `links` as the identity
+	// signal, was withheld from the index for having no content while we held a
+	// URL that no other profile in the corpus shares.
+	const instagram = overlay?.instagramUrl ?? person?.instagramUrl ?? null;
+	// No spine fallback: TikTok is owner-authored only. BallotReady's urls[] has
+	// no tiktok type, so there is no spine column to read.
 	const tiktok = overlay?.tiktokUrl ?? null;
 	const facebook = overlay?.facebookUrl ?? person?.facebookUrl ?? null;
 	const twitter = overlay?.twitterUrl ?? person?.twitterUrl ?? null;

--- a/src/lib/peopleProfile.ts
+++ b/src/lib/peopleProfile.ts
@@ -240,6 +240,38 @@ export interface PersonProfileView {
 	updatedAt: string;
 }
 
+/**
+ * Whether the profile carries anything that tells it apart from the rest of the
+ * unclaimed corpus.
+ *
+ * A profile with no resolved office, no authored content, no photo and no links
+ * renders a name and a state inside ~114KB of site chrome, and nothing else.
+ * Sampling the URLs Google flagged put 200 of 200 in that shape and within 817
+ * bytes of each other (0.7%), while profiles that do resolve an office spread
+ * across 78% of their size — so the flagged pages are not merely similar, they
+ * are the same document with the name swapped. That is what makes Google
+ * cluster them and elect its own canonical; the canonical tag itself is correct
+ * and self-referential, so nothing about it is worth changing.
+ *
+ * The test is deliberately generous — any single signal is enough to keep the
+ * page indexable — and it is recomputed from the view on every render, so a
+ * page returns to the index on its own once the data team backfills its office.
+ * There is no list to maintain and nothing to re-index by hand.
+ */
+export function isThinProfile(view: PersonProfileView): boolean {
+	// An owner who claimed and published asked for this page to exist; the
+	// population is small enough that indexing it can never drive clustering.
+	if (view.claimed) return false;
+	const hasOffice = Boolean(view.officeName ?? view.positionId);
+	const hasAuthoredContent =
+		Boolean(view.bio ?? view.whyRunning) ||
+		view.issues.length > 0 ||
+		view.accomplishments.length > 0;
+	const hasIdentity = Boolean(view.avatarUrl) || view.links.length > 0;
+	const hasPublicRecord = view.recentExperience.length > 0;
+	return !hasOffice && !hasAuthoredContent && !hasIdentity && !hasPublicRecord;
+}
+
 function pickCurrentOffice(person: PersonItem | null): PersonOfficeHolder | null {
 	const offices = person?.OfficeHolders ?? [];
 	if (offices.length === 0) return null;

--- a/src/lib/peopleProfile.ts
+++ b/src/lib/peopleProfile.ts
@@ -241,6 +241,20 @@ export interface PersonProfileView {
 }
 
 /**
+ * Whether a spine string carries an actual value.
+ *
+ * Shared with the sitemap builder so both halves of the indexing decision
+ * normalize the civics feed the same way. The feed has three spellings for
+ * "absent" — null, '' and whitespace — because the BallotReady S3 export writes
+ * '' rather than null and the dbt mart only nullif()s some of the columns it
+ * lands (see isThinProfile). Anything that tests one of these fields for
+ * presence has to collapse all three or the two rules drift apart.
+ */
+export function hasText(value: string | null | undefined): boolean {
+	return Boolean(value?.trim());
+}
+
+/**
  * Whether the profile carries anything that tells it apart from the rest of the
  * unclaimed corpus.
  *
@@ -262,14 +276,44 @@ export function isThinProfile(view: PersonProfileView): boolean {
 	// An owner who claimed and published asked for this page to exist; the
 	// population is small enough that indexing it can never drive clustering.
 	if (view.claimed) return false;
-	const hasOffice = Boolean(view.officeName ?? view.positionId);
+	// Every signal goes through `hasText`, and the alternatives are `||` rather
+	// than `??`, because the upstream feed spells "absent" three ways. The dbt
+	// mart wraps some BallotReady columns in nullif(x, '') and not others —
+	// m_election_api__office_holder.sql does it for office_title but not for
+	// position_name, and m_election_api__person.sql does it for neither bio_text
+	// nor headshot_url — so '' arrives as a value. Under `??` that '' is the
+	// answer: `officeName ?? positionId` returns '' and never consults the
+	// positionId, so a profile with a resolved race would be suppressed.
+	const hasOffice = hasText(view.officeName) || hasText(view.positionId);
 	const hasAuthoredContent =
-		Boolean(view.bio ?? view.whyRunning) ||
+		hasText(view.bio) ||
+		hasText(view.whyRunning) ||
 		view.issues.length > 0 ||
 		view.accomplishments.length > 0;
-	const hasIdentity = Boolean(view.avatarUrl) || view.links.length > 0;
+	const hasIdentity = hasText(view.avatarUrl) || view.links.length > 0;
+	// Load-bearing beyond its own line: this is what makes the sitemap's
+	// projection of this rule safe. buildRecentExperience emits a row for every
+	// office term and every named candidacy — the same two feeds the sitemap
+	// sweeps — so anything the sitemap counts as an office lands here even when
+	// `hasOffice` above misses it (the sitemap sees every row; the view's
+	// officeName is only the one `pickCurrentOffice`/`primaryCandidacy` chose).
+	// Narrowing this to, say, current terms only would silently reopen the
+	// "sitemap advertises a page that renders noindex" direction.
 	const hasPublicRecord = view.recentExperience.length > 0;
 	return !hasOffice && !hasAuthoredContent && !hasIdentity && !hasPublicRecord;
+}
+
+/**
+ * Whether the page asks to be indexed.
+ *
+ * Two unrelated reasons to say no — a privacy removal (Figma K/L) keeps a
+ * crawlable URL it should not advertise, and a contentless profile is a
+ * near-duplicate of every other one — resolved into the single directive
+ * `generateMetadata` emits. It lives here rather than inline at the call site so
+ * the 12-state matrix asserts the expression that actually ships.
+ */
+export function isIndexableProfile(view: PersonProfileView): boolean {
+	return !view.removed && !isThinProfile(view);
 }
 
 function pickCurrentOffice(person: PersonItem | null): PersonOfficeHolder | null {

--- a/src/lib/sitemap-entries.test.ts
+++ b/src/lib/sitemap-entries.test.ts
@@ -399,15 +399,49 @@ describe('fetchPeopleSitemapEntries', () => {
 		]);
 	});
 
-	// Blank-but-present is the same absence as null, and trimming here keeps the
-	// sitemap agreeing with the renderer, which treats '' as no office too.
-	test('treats a whitespace-only position name as no office', async () => {
-		mockUpstream({
-			persons: [{ id: aliceId, slug: 'alice-smith', state: 'WY' }],
-			candidacies: { WY: [{ personId: aliceId, positionName: '   ' }] },
-		});
+	// Blank-but-present is the same absence as null. It is not a hypothetical:
+	// the dbt mart wraps office_title in nullif(x, '') because "the S3 feed uses
+	// '' (not null) for absent values", and leaves position_name alone. Both
+	// sides of the decision route these through the same `hasText`, so the
+	// renderer reads a blank the same way.
+	for (const blank of ['', '   ']) {
+		test(`treats a ${blank === '' ? 'empty' : 'whitespace-only'} position name as no office`, async () => {
+			mockUpstream({
+				persons: [{ id: aliceId, slug: 'alice-smith', state: 'WY' }],
+				candidacies: { WY: [{ personId: aliceId, positionName: blank }] },
+			});
 
-		expect(await fetchPeopleSitemapEntries(base, 'a')).toEqual([]);
+			expect(await fetchPeopleSitemapEntries(base, 'a')).toEqual([]);
+		});
+	}
+
+	/**
+	 * Pins the two column projections, because a name election-api does not know
+	 * is not a soft failure: its query schemas are `.strict()` and validate
+	 * `columns` against an allow-list built from the Prisma scalar-field enum, so
+	 * a typo is a 400, and `fetchElectionJsonOrThrow` turns that into a failed
+	 * shard rather than a partial sitemap. Asserting the request here is what
+	 * makes the projection reviewable against those schemas without a token.
+	 */
+	test('projects only the columns the thinness signal needs', async () => {
+		const urls = mockUpstream({
+			persons: [{ id: aliceId, slug: 'alice-smith', state: 'WY' }],
+			candidacies: { WY: [aliceId] },
+		});
+		await fetchPeopleSitemapEntries(base, 'a');
+
+		const columnsFor = (path: string): Set<string> =>
+			new Set(
+				urls
+					.filter((u) => new URL(u).pathname.endsWith(path))
+					.map((u) => new URL(u).searchParams.get('columns') ?? ''),
+			);
+
+		expect(columnsFor('/v1/candidacies')).toEqual(new Set(['personId,positionName']));
+		expect(columnsFor('/v1/officeholders')).toEqual(
+			new Set(['personId,positionName,officeTitle']),
+		);
+		expect(columnsFor('/v1/persons')).toEqual(new Set(['id,slug']));
 	});
 
 	// The one case where the sitemap must not apply the office test: an owner who

--- a/src/lib/sitemap-entries.test.ts
+++ b/src/lib/sitemap-entries.test.ts
@@ -59,14 +59,37 @@ describe('fetchPeopleSitemapEntries', () => {
 	type MockPerson = { id: string; slug: string; state: string | null };
 
 	/**
+	 * A row on the candidacy / officeholder feeds. The bare-string form is a row
+	 * that names an office, which is the ordinary case; the object form exists to
+	 * model the rows that carry a personId and nothing else — the shape behind
+	 * the flagged near-duplicate pages.
+	 */
+	type MockLink = string | { personId: string; positionName?: string | null; officeTitle?: string | null };
+
+	function linkRow(link: MockLink): {
+		personId: string;
+		positionName: string | null;
+		officeTitle: string | null;
+	} {
+		if (typeof link === 'string') {
+			return { personId: link, positionName: 'Mayor', officeTitle: null };
+		}
+		return {
+			personId: link.personId,
+			positionName: link.positionName ?? null,
+			officeTitle: link.officeTitle ?? null,
+		};
+	}
+
+	/**
 	 * Stands in for the four upstream feeds the band reads. `state: null` models
 	 * the ~8% of the real table that no `?state=` sweep can reach, which is the
 	 * whole reason the candidacy/officeholder union exists.
 	 */
 	function mockUpstream(opts: {
 		persons: MockPerson[];
-		candidacies?: Record<string, string[]>;
-		officeholders?: Record<string, string[]>;
+		candidacies?: Record<string, MockLink[]>;
+		officeholders?: Record<string, MockLink[]>;
 		published?: { personId: string; updatedAt?: string }[];
 		unlisted?: { personId: string }[];
 		unlistedStatus?: number;
@@ -108,11 +131,11 @@ describe('fetchPeopleSitemapEntries', () => {
 			}
 			if (url.pathname.endsWith('/v1/candidacies')) {
 				const state = url.searchParams.get('state') ?? '';
-				return json((opts.candidacies?.[state] ?? []).map((personId) => ({ personId })));
+				return json((opts.candidacies?.[state] ?? []).map(linkRow));
 			}
 			if (url.pathname.endsWith('/v1/officeholders')) {
 				const state = url.searchParams.get('state') ?? '';
-				return json((opts.officeholders?.[state] ?? []).map((personId) => ({ personId })));
+				return json((opts.officeholders?.[state] ?? []).map(linkRow));
 			}
 			return json([]);
 		}) as typeof fetch;
@@ -133,7 +156,10 @@ describe('fetchPeopleSitemapEntries', () => {
 	// programmatic page is the destination now, so it has to be listed even
 	// though gp-api knows nothing about it.
 	test('lists people who have never been claimed', async () => {
-		mockUpstream({ persons: [{ id: aliceId, slug: 'alice-smith', state: 'WY' }] });
+		mockUpstream({
+			persons: [{ id: aliceId, slug: 'alice-smith', state: 'WY' }],
+			candidacies: { WY: [aliceId] },
+		});
 
 		const entries = await fetchPeopleSitemapEntries(base, 'a');
 
@@ -147,7 +173,7 @@ describe('fetchPeopleSitemapEntries', () => {
 				{ id: bobId, slug: 'bob-jones', state: null },
 				{ id: carolId, slug: 'carol-diaz', state: null },
 			],
-			candidacies: { WY: [bobId] },
+			candidacies: { WY: [aliceId, bobId] },
 			officeholders: { MT: [carolId] },
 		});
 
@@ -211,6 +237,7 @@ describe('fetchPeopleSitemapEntries', () => {
 				{ id: aliceId, slug: 'alice-smith', state: 'WY' },
 				{ id: bobId, slug: 'bob-jones', state: 'WY' },
 			],
+			candidacies: { WY: [aliceId, bobId] },
 			unlisted: [{ personId: bobId }],
 		});
 
@@ -226,6 +253,7 @@ describe('fetchPeopleSitemapEntries', () => {
 	test('matches unlisted ids case-insensitively, since the id is a uuid from another service', async () => {
 		mockUpstream({
 			persons: [{ id: aliceId, slug: 'alice-smith', state: 'WY' }],
+			candidacies: { WY: [aliceId] },
 			unlisted: [{ personId: aliceId.toUpperCase() }],
 		});
 
@@ -238,6 +266,7 @@ describe('fetchPeopleSitemapEntries', () => {
 				{ id: aliceId, slug: 'alice-smith', state: 'WY' },
 				{ id: bobId, slug: 'bob-jones', state: 'WY' },
 			],
+			candidacies: { WY: [bobId] },
 			published: [{ personId: aliceId, updatedAt: '2026-01-15T00:00:00.000Z' }],
 		});
 
@@ -277,7 +306,10 @@ describe('fetchPeopleSitemapEntries', () => {
 		expect(await fetchPeopleSitemapEntries(base, 'a')).toEqual([]);
 
 		clearPeopleSitemapCache();
-		mockUpstream({ persons: [{ id: aliceId, slug: 'alice-smith', state: 'WY' }] });
+		mockUpstream({
+			persons: [{ id: aliceId, slug: 'alice-smith', state: 'WY' }],
+			candidacies: { WY: [aliceId] },
+		});
 
 		expect((await fetchPeopleSitemapEntries(base, 'a')).map((e) => e.url)).toEqual([
 			`${base}/people/alice-smith-aaaaaaaa`,
@@ -317,7 +349,75 @@ describe('fetchPeopleSitemapEntries', () => {
 		});
 		await expect(fetchPeopleSitemapEntries(base, 'a')).rejects.toThrow();
 
+		mockUpstream({
+			persons: [{ id: aliceId, slug: 'alice-smith', state: 'WY' }],
+			candidacies: { WY: [aliceId] },
+		});
+
+		expect((await fetchPeopleSitemapEntries(base, 'a')).map((e) => e.url)).toEqual([
+			`${base}/people/alice-smith-aaaaaaaa`,
+		]);
+	});
+
+	// The GSC "Duplicate, Google chose different canonical than user" cohort: the
+	// page renders noindex because it has nothing on it, so advertising it would
+	// only swap that report for "Submitted URL marked noindex".
+	test('omits a person whose civics feeds name no office', async () => {
+		mockUpstream({
+			persons: [
+				{ id: aliceId, slug: 'alice-smith', state: 'WY' },
+				{ id: bobId, slug: 'bob-jones', state: 'WY' },
+			],
+			candidacies: { WY: [aliceId, { personId: bobId, positionName: null }] },
+		});
+
+		const [aShard, bShard] = await Promise.all([
+			fetchPeopleSitemapEntries(base, 'a'),
+			fetchPeopleSitemapEntries(base, 'b'),
+		]);
+
+		expect(aShard.map((e) => e.url)).toEqual([`${base}/people/alice-smith-aaaaaaaa`]);
+		expect(bShard).toEqual([]);
+	});
+
+	// A person reachable only by the state sweep has no candidacy or officeholder
+	// row at all, so there is no office to render and nothing to index.
+	test('omits a person who appears on no civics feed at all', async () => {
 		mockUpstream({ persons: [{ id: aliceId, slug: 'alice-smith', state: 'WY' }] });
+
+		expect(await fetchPeopleSitemapEntries(base, 'a')).toEqual([]);
+	});
+
+	test('an officeholder row that carries only officeTitle still counts as an office', async () => {
+		mockUpstream({
+			persons: [{ id: aliceId, slug: 'alice-smith', state: 'WY' }],
+			officeholders: { WY: [{ personId: aliceId, officeTitle: 'City Council' }] },
+		});
+
+		expect((await fetchPeopleSitemapEntries(base, 'a')).map((e) => e.url)).toEqual([
+			`${base}/people/alice-smith-aaaaaaaa`,
+		]);
+	});
+
+	// Blank-but-present is the same absence as null, and trimming here keeps the
+	// sitemap agreeing with the renderer, which treats '' as no office too.
+	test('treats a whitespace-only position name as no office', async () => {
+		mockUpstream({
+			persons: [{ id: aliceId, slug: 'alice-smith', state: 'WY' }],
+			candidacies: { WY: [{ personId: aliceId, positionName: '   ' }] },
+		});
+
+		expect(await fetchPeopleSitemapEntries(base, 'a')).toEqual([]);
+	});
+
+	// The one case where the sitemap must not apply the office test: an owner who
+	// claimed and published gets an indexable page regardless of the spine, so
+	// dropping it here would hide the only pages with authored content.
+	test('keeps a claimed person who has no office on any feed', async () => {
+		mockUpstream({
+			persons: [{ id: aliceId, slug: 'alice-smith', state: 'WY' }],
+			published: [{ personId: aliceId, updatedAt: '2026-01-15T00:00:00.000Z' }],
+		});
 
 		expect((await fetchPeopleSitemapEntries(base, 'a')).map((e) => e.url)).toEqual([
 			`${base}/people/alice-smith-aaaaaaaa`,

--- a/src/lib/sitemap-entries.ts
+++ b/src/lib/sitemap-entries.ts
@@ -651,12 +651,17 @@ export async function fetchStateElectionSitemapEntries(
 
 type PeopleSitemapPerson = { id?: string; slug?: string | null };
 
-type PeopleSitemapData = {
+type PersonEnumeration = {
+	persons: PeopleSitemapPerson[];
+	/** personIds the civics feeds give a named office or race — see fetchAllPersons. */
+	personIdsWithOffice: Set<string>;
+};
+
+type PeopleSitemapData = PersonEnumeration & {
 	/** personId → updatedAt, for the published subset only; also marks "claimed". */
 	updatedByPersonId: Map<string, string | undefined>;
 	/** personIds whose page must never be advertised — see the loader for why. */
 	unlistedPersonIds: Set<string>;
-	persons: PeopleSitemapPerson[];
 };
 
 /**
@@ -678,6 +683,13 @@ const PERSON_ID_BATCH = 150;
  * live page renders.
  */
 const ENUMERATION_CONCURRENCY = 8;
+
+/** Projected row from the candidacy / officeholder sweeps in fetchAllPersons. */
+type LinkedFeedRow = {
+	personId?: string;
+	positionName?: string | null;
+	officeTitle?: string | null;
+};
 
 async function mapWithConcurrency<T, R>(
 	items: readonly T[],
@@ -713,8 +725,15 @@ async function mapWithConcurrency<T, R>(
  *
  * If election-api ever grows a cursor or a dedicated enumeration feed, this
  * whole dance collapses into a single paged read.
+ *
+ * The candidacy and officeholder sweeps double as the thinness signal. They are
+ * already walked for the union above, and they are the same two feeds the
+ * profile renderer resolves an office from, so asking them for the position
+ * name alongside the personId answers "does this person's page have anything on
+ * it" for the whole corpus at the cost of one extra projected column — rather
+ * than 216k profile loads.
  */
-async function fetchAllPersons(): Promise<PeopleSitemapPerson[]> {
+async function fetchAllPersons(): Promise<PersonEnumeration> {
 	const tags = [PEOPLE_SITEMAP_CACHE_TAG];
 	const states = [...US_STATE_CODES];
 	const byId = new Map<string, PeopleSitemapPerson>();
@@ -732,25 +751,29 @@ async function fetchAllPersons(): Promise<PeopleSitemapPerson[]> {
 		}
 	}
 
-	const linkedFeeds: { path: string; state: string }[] = states.flatMap((state) => [
-		{ path: 'v1/candidacies', state },
-		{ path: 'v1/officeholders', state },
-	]);
+	// Columns differ per feed because the two models name the office differently:
+	// a candidacy carries only positionName, an office term can carry either that
+	// or officeTitle (the renderer reads both, so the sitemap has to as well).
+	const linkedFeeds: { path: string; state: string; columns: string }[] = states.flatMap(
+		(state) => [
+			{ path: 'v1/candidacies', state, columns: 'personId,positionName' },
+			{ path: 'v1/officeholders', state, columns: 'personId,positionName,officeTitle' },
+		],
+	);
 	const linked = await mapWithConcurrency(
 		linkedFeeds,
 		ENUMERATION_CONCURRENCY,
-		async ({ path, state }) =>
-			fetchElectionJsonOrThrow<{ personId?: string }>(
-				path,
-				{ state, columns: 'personId' },
-				tags,
-			),
+		async ({ path, state, columns }) =>
+			fetchElectionJsonOrThrow<LinkedFeedRow>(path, { state, columns }, tags),
 	);
 	const unseen = new Set<string>();
+	const personIdsWithOffice = new Set<string>();
 	for (const rows of linked) {
 		for (const row of rows) {
 			const id = row.personId?.toLowerCase();
-			if (id && !byId.has(id)) unseen.add(id);
+			if (!id) continue;
+			if (row.positionName?.trim() || row.officeTitle?.trim()) personIdsWithOffice.add(id);
+			if (!byId.has(id)) unseen.add(id);
 		}
 	}
 
@@ -770,7 +793,7 @@ async function fetchAllPersons(): Promise<PeopleSitemapPerson[]> {
 		}
 	}
 
-	return [...byId.values()];
+	return { persons: [...byId.values()], personIdsWithOffice };
 }
 
 let cachedPeopleSitemapData: Promise<PeopleSitemapData> | null = null;
@@ -793,7 +816,7 @@ export function clearPeopleSitemapCache(): void {
 async function getCachedPeopleSitemapData(): Promise<PeopleSitemapData> {
 	if (!cachedPeopleSitemapData) {
 		const load = (async (): Promise<PeopleSitemapData> => {
-			const [published, unlisted, persons] = await Promise.all([
+			const [published, unlisted, enumeration] = await Promise.all([
 				fetchGpApiJsonOrThrow<{ personId?: string; updatedAt?: string }>(
 					'v1/public-person-profiles/published',
 					[PEOPLE_SITEMAP_CACHE_TAG],
@@ -819,7 +842,7 @@ async function getCachedPeopleSitemapData(): Promise<PeopleSitemapData> {
 				if (row.personId) unlistedPersonIds.add(row.personId.toLowerCase());
 			}
 
-			return { updatedByPersonId, unlistedPersonIds, persons };
+			return { updatedByPersonId, unlistedPersonIds, ...enumeration };
 		})();
 		cachedPeopleSitemapData = load;
 		// Settle via two-arg `then`, not `finally`: the upstream reads throw now, and
@@ -855,19 +878,35 @@ async function getCachedPeopleSitemapData(): Promise<PeopleSitemapData> {
  * crawlers at someone who asked to be left alone, and an owner-deleted profile
  * has no page to reach at all — gp-api answers 410 and the route 404s.
  *
+ * People whose civics feeds name no office are dropped for the same reason at
+ * one remove: their page renders `noindex` (see isThinProfile) because it has
+ * no content to tell it apart from every other one, and a sitemap that keeps
+ * advertising them would simply trade "Duplicate, Google chose different
+ * canonical" for "Submitted URL marked noindex".
+ *
+ * That test is a projection of the renderer's, not a copy of it — the sitemap
+ * sees offices and claims but not photos or links. The asymmetry is the safe
+ * one: a page this drops but the renderer indexes only loses its sitemap entry
+ * and is still reachable by crawl, whereas the harmful direction (advertising a
+ * page that renders noindex) cannot happen, because everything the renderer
+ * treats as differentiating beyond an office implies either a claim, which is
+ * checked here, or an office, which is what was checked.
+ *
  * Upstream fetches are shared across shards via getCachedPeopleSitemapData.
  */
 export async function fetchPeopleSitemapEntries(
 	baseUrl: string,
 	shard?: string,
 ): Promise<MetadataRoute.Sitemap> {
-	const { updatedByPersonId, unlistedPersonIds, persons } = await getCachedPeopleSitemapData();
+	const { updatedByPersonId, unlistedPersonIds, persons, personIdsWithOffice } =
+		await getCachedPeopleSitemapData();
 
 	const entries: MetadataRoute.Sitemap = [];
 	for (const p of persons) {
 		if (!p.id || !p.slug) continue;
 		const personId = p.id.toLowerCase();
 		if (unlistedPersonIds.has(personId)) continue;
+		if (!updatedByPersonId.has(personId) && !personIdsWithOffice.has(personId)) continue;
 		// When a shard is requested, only emit people whose slug falls in it. The
 		// canonical URL appends the 8-hex id suffix but shares the base's first
 		// char, so sharding on the base is equivalent.

--- a/src/lib/sitemap-entries.ts
+++ b/src/lib/sitemap-entries.ts
@@ -11,7 +11,7 @@ import {
 	resolveElectionPositionFromRaceSlug,
 	stripCountySuffix as stripCountySuffixFromHelpers,
 } from '~/lib/electionsHelpers';
-import { buildPersonSlugFromBase } from '~/lib/peopleProfile';
+import { buildPersonSlugFromBase, hasText } from '~/lib/peopleProfile';
 import { FAQ_BASE_PATH, getFaqSitemapEntries } from '~/lib/faqSlugs';
 import { fetchElectionApiJsonCached } from '~/lib/electionApiFetch';
 import { allFaqsQuery } from '~/sanity/groq';
@@ -754,6 +754,15 @@ async function fetchAllPersons(): Promise<PersonEnumeration> {
 	// Columns differ per feed because the two models name the office differently:
 	// a candidacy carries only positionName, an office term can carry either that
 	// or officeTitle (the renderer reads both, so the sitemap has to as well).
+	//
+	// Both projections are checked against election-api at origin/main: each
+	// endpoint's Zod schema takes a param literally named `columns` and validates
+	// it against an allow-list built from the Prisma scalar-field enum, so a name
+	// this service does not have is a 400 rather than a silently ignored filter —
+	// and `personId`, `positionName` and `officeTitle` are all scalars on those
+	// two models (candidacies.schema.ts, officeHolders.schema.ts). The schemas
+	// are `.strict()`, which is why the param is `columns` here and the
+	// `placeColumns`/`raceColumns` used elsewhere in this file would 400.
 	const linkedFeeds: { path: string; state: string; columns: string }[] = states.flatMap(
 		(state) => [
 			{ path: 'v1/candidacies', state, columns: 'personId,positionName' },
@@ -772,7 +781,7 @@ async function fetchAllPersons(): Promise<PersonEnumeration> {
 		for (const row of rows) {
 			const id = row.personId?.toLowerCase();
 			if (!id) continue;
-			if (row.positionName?.trim() || row.officeTitle?.trim()) personIdsWithOffice.add(id);
+			if (hasText(row.positionName) || hasText(row.officeTitle)) personIdsWithOffice.add(id);
 			if (!byId.has(id)) unseen.add(id);
 		}
 	}
@@ -885,12 +894,29 @@ async function getCachedPeopleSitemapData(): Promise<PeopleSitemapData> {
  * canonical" for "Submitted URL marked noindex".
  *
  * That test is a projection of the renderer's, not a copy of it — the sitemap
- * sees offices and claims but not photos or links. The asymmetry is the safe
- * one: a page this drops but the renderer indexes only loses its sitemap entry
- * and is still reachable by crawl, whereas the harmful direction (advertising a
- * page that renders noindex) cannot happen, because everything the renderer
- * treats as differentiating beyond an office implies either a claim, which is
- * checked here, or an office, which is what was checked.
+ * sees offices and claims but not photos, links or bios. The asymmetry runs one
+ * way only, and it is worth being precise about why, because the argument is
+ * not "an office implies an office".
+ *
+ * Harmful direction (advertise a URL that renders `noindex`) — impossible. This
+ * band lists a person only when gp-api says they published, which makes the
+ * view `claimed` and short-circuits isThinProfile, or when some row on the
+ * candidacy/officeholder sweeps named an office. In that second case the
+ * renderer's escape hatch is `recentExperience`, not `officeName`:
+ * buildRecentExperience emits a row for every office term and every candidacy
+ * carrying a positionName, which is exactly the set these sweeps see, so
+ * `hasPublicRecord` holds even when the one candidacy `primaryCandidacy` picked
+ * happens to be the unnamed one. peopleProfile.test.ts pins that link.
+ *
+ * Benign direction (drop a URL the renderer would index) — real, and accepted.
+ * A person can be dropped here and indexed there in three shapes: an office
+ * term with dates but no title at all (the sweeps see no name; the renderer
+ * still lists a dated "Public office" row), a photo/bio/link with no office,
+ * and a civics row whose own `state` column is null so no `?state=` sweep
+ * reaches it. The cost is the sitemap entry, not the indexing: the page still
+ * renders `index` and is still linked from the profile and election interlinks,
+ * so a crawler finds it anyway. The reverse would put us straight into
+ * "Submitted URL marked noindex", which is the report we are trying to leave.
  *
  * Upstream fetches are shared across shards via getCachedPeopleSitemapData.
  */

--- a/src/testing/peopleProfileFixtures.ts
+++ b/src/testing/peopleProfileFixtures.ts
@@ -131,6 +131,7 @@ function spine(over: Partial<PersonItem> = {}): PersonItem {
 		linkedinUrl: null,
 		facebookUrl: null,
 		twitterUrl: null,
+		instagramUrl: null,
 		state: 'CA',
 		isPledged: false,
 		...over,

--- a/src/types/people.ts
+++ b/src/types/people.ts
@@ -69,6 +69,7 @@ export interface PersonItem {
 	linkedinUrl: string | null;
 	facebookUrl: string | null;
 	twitterUrl: string | null;
+	instagramUrl: string | null;
 	state: string | null;
 	/** Took the GoodParty pledge (ETL-sourced, read-only). */
 	isPledged?: boolean;


### PR DESCRIPTION
## What Google actually reported

GSC flagged **1,792 `/people/*` URLs** as "Duplicate, Google chose different canonical than user".

**It is not the canonical tag.** Every affected page carries a correct self-referential canonical and a matching `og:url`; there is no competing URL on our side (`/people/<name>` without the id suffix 404s, as do the legacy `/candidate/*` paths). I re-verified this across a 200-URL sample: 200/200 self-canonical, 0 with a robots directive.

**It is that the pages are the same document.** Sampling 200 of the flagged URLs and 608 unflagged control URLs from the sitemap:

| | flagged (n=200) | control (n=608) |
| --- | --- | --- |
| no office resolved (bare "Candidate") | **100%** | 36.3% |
| entirely-lowercase name | 99.0% | 35.4% |
| no headshot / no bio / no links | 100% | not measured |
| distinct `<title>` templates | **1** | 388 |

Split by whether an office resolves, the size distribution separates completely:

- **no office** — 113,619–114,436 bytes, a **0.7% spread** across 200 different people
- **office resolved** — 121,664–216,516 bytes, a **78% spread**

A flagged page's unique content is a name and a state, inside ~114KB of shared site chrome. There is no "Election Date", no party, no position, no Recent Experience, no Other Candidates. That near-identity is what makes Google cluster them and elect its own canonical.

## Two corrections to the initial diagnosis

1. **This is not 1,792 pages.** 36% of a random control sample is in the same shape and simply has not been crawled and clustered yet. 1,792 is the leading edge.
2. **Casing is not the cause.** 100% of flagged pages lack an office; only 99% are lowercase, and two flagged pages are properly cased and flagged anyway. Fixing casing (#240) changes ~11 characters in a 114KB document and would not have declustered a single one. The two defects are strongly correlated upstream — in 808 sampled pages only one lowercase name had a resolvable office — but the duplicate-content cause is the missing office.

## What this does

Adds `isThinProfile`, and where it holds:

- `generateMetadata` emits `robots: { index: false, follow: true }`, reusing the directive removed profiles already set rather than inventing a mechanism. `follow: true` keeps the civics interlinks passing crawl signal.
- The sitemap drops the URL, so this does not just trade the current report for "Submitted URL marked noindex".

The test is deliberately generous — an office, a bio, a photo, a link, a prior term or a claim is each enough to keep the page indexable — and it is recomputed from live data on every render. **A page returns to the index by itself once election-api backfills its office.** There is no list to maintain and nothing to re-index by hand.

### Why noindex rather than enriching the title

Enrichment was the alternative, and the data rules it out: state is the *only* other populated field on these records (100% have it, 0% have anything else). Keying 78k pages off 51 state names leaves ~1,500 identical pages per state. That is lipstick, and Google would still cluster it.

### Why not the `unlisted` feed

`GET /v1/public-person-profiles/unlisted` is gp-api's privacy-takedown and owner-delete list. Thinness is a data-completeness fact owned by election-api, and routing it through a privacy list would mean a data backfill has to write into a takedown feed. Instead the sitemap builder derives the signal itself, off the candidacy and officeholder sweeps it **already walks** to build the person union — one extra projected column, no extra requests, versus 216k profile loads.

## How the feed spells "absent", and the bug that came from it

The first cut of the predicate asked `Boolean(view.officeName ?? view.positionId)`. That reads as "an office name, or failing that a position id", but `??` falls through only on null/undefined — so an `officeName` of `''` is *the answer*, it is falsy, and the resolved `positionId` behind it is never consulted. A profile whose race actually resolved would have been withheld from the index for having no office.

`''` is not hypothetical here. The dbt mart wraps the BallotReady office columns in `nullif(x, '')` because, in its own comment, "the S3 feed uses `''` (not null) for absent values on these" — and it applies that to `office_title` but **not** to `position_name` (`m_election_api__office_holder.sql`), nor to `bio_text` or `headshot_url` (`m_election_api__person.sql`). So `''` arrives on exactly the fields this predicate reads.

`Boolean(view.bio ?? view.whyRunning)` had the same shape. That one is unreachable today — `whyRunning` only exists on a claimed view, which short-circuits before the check — but nothing enforces that invariant, so it is fixed rather than documented as safe.

## A third input the predicate never saw

Same class of defect, one layer up: election-api's `Person` carries five public links in one block — website, linkedin, facebook, twitter, instagram, all from BallotReady's typed `urls[]` — and `buildLinks` fell back to the spine for four of them. Instagram was read from the gp-api overlay alone, so an unclaimed person, who by definition has no overlay, rendered no link for a URL we hold.

Cosmetic until this PR made `links` an indexing input. `isThinProfile` reads a non-empty link rail as the identity signal, so a person whose only differentiating fact was an Instagram arrived here looking contentless. It now reads the spine like its siblings, and no extra `hasText` treatment: the mart builds `instagram_url` the same way the other four are built, and puts it inside the same `nullif('')` block on the office-feed fallback, so it is exactly as blank-prone as they are.

Two things the same sweep cleared rather than changed. The office feed's own socials need no separate fallback — the mart already coalesces them into the person columns, latest term wins, which is why `buildLinks` reads only `websiteUrl` off the office row. And `Person.degrees` / `Person.experiences` are returned by the API and read nowhere here; `experiences` in particular is Recent Experience material and would be a genuine content signal, but surfacing it is a new profile section rather than a predicate input, so it is a follow-up rather than part of this change.

One pre-existing gap left alone deliberately: `buildLinks` gates on truthiness, so a whitespace-only URL still becomes a link. That can only keep a page in the index, never withhold one, and tightening it would change the rendered link rail on every profile — out of scope for an indexing change.

Every signal now goes through a shared `hasText` that the sitemap builder imports too, so null, `''` and whitespace mean the same thing on both sides of the decision by construction rather than by coincidence.

## The 12 Figma states

`isThinProfile` short-circuits on `claimed`, so A–C and G are safe by construction; the risk is in the unclaimed states, and particularly the past-election ones after #227 stopped treating a concluded race as a current candidacy. The matrix is now asserted in CI (`peopleProfile.states.test.ts`) against the same hand-written `expected.noindex` column the rest of the state matrix is specified by, with **each fixture first stripped to its civics spine** — bio, headshot and social columns removed — because otherwise the assertion would be riding on a fixture headshot rather than saying anything about the state.

| state | | indexable | what carries it |
| --- | --- | --- | --- |
| A / B / C / G | claimed | yes | `claimed` short-circuit |
| D | unclaimed candidate | yes | candidacy `positionName` |
| E | unclaimed officeholder | yes | office term → `officeName` from `positionName ?? officeTitle` |
| F | unclaimed candidate + officeholder | yes | either |
| H | unclaimed past officeholder | yes | `pickCurrentOffice` falls back to the most recent term, so the title survives |
| I / J | unclaimed major-party | yes | candidacy / office term |
| K / L | removal requested | **no** — already `noindex` via `view.removed` | unchanged; the new predicate agrees rather than overriding |
| — | unpublished overlay (D/I spines) | yes | the spine survives; `unpublished` is not a takedown |

No legitimate state was being suppressed, before or after. #227 turned out to be a persona change only — a concluded race still names the seat through `primaryCandidacy`, so a past-election profile keeps its office — but it is pinned by test now rather than by inspection.

## Sitemap: the two rules cannot disagree in the direction that hurts

The sitemap derives the same signal from the candidacy and officeholder sweeps. That is a projection of the renderer's rule, not a copy: the sitemap sees offices and claims but not photos, links or bios.

**Harmful direction (advertise a URL that renders `noindex`) — impossible.** The band lists a person only when gp-api says they published, which makes the view `claimed`, or when some swept row named an office. The original PR justified the second case as "an office implies an office", which is not quite right — the sweeps see *every* row while the view's `officeName` is only the one `primaryCandidacy` / `pickCurrentOffice` chose, and those can differ. What actually carries the guarantee is `recentExperience`, which `buildRecentExperience` builds from every office term and every named candidacy — precisely the set the sweeps see. That is now documented as load-bearing and pinned by test, because narrowing it later (to current terms, say) would reopen "Submitted URL marked noindex" silently.

**Benign direction (drop a URL the renderer indexes) — real, and accepted.** Three shapes: an office term with dates but no title at all, a photo/bio/link with no office, and a civics row whose own `state` column is nullable so no `?state=` sweep reaches it. The cost is the sitemap entry, not the indexing — the page still renders `index` and is still linked from the profile and election interlinks.

## Expected effect

`0.363 × 216,021 ≈ 78k`, and that is an **upper bound on both halves, not a point estimate**:

- **Sitemap** drops a person when no swept row names an office. The 36.3% statistic is "no office resolved *on the rendered page*", which is narrower — a page can read "Candidate" while a sibling row the sweeps see does name a seat — so fewer than 78k are dropped.
- **`noindex`** additionally requires no photo, no bio, no link and no prior term. That was 100% true of the flagged sample but was not measured on the control, so the `noindex` set is a strict subset of the dropped set and is smaller again.

Sampling error on 36.3% at n=608 is ±3.8pp at 95%, so the corpus-level figure is ~70k–87k before either narrowing.

Both come back automatically, with real titles, as office data lands.

## ~~One thing to confirm before merge~~ — resolved

The original PR could not verify `columns=personId,positionName` on `v1/candidacies` and `columns=personId,positionName,officeTitle` on `v1/officeholders` against the live API, since election-api now enforces M2M auth. Checked statically against election-api at `origin/main` instead, which settles it:

- Both endpoints take a query param literally named `columns` (`candidacies.schema.ts`, `officeHolders.schema.ts`), and both schemas are `.strict()` — which is also why the `placeColumns` / `raceColumns` used elsewhere in this file would 400 here.
- `columns` is validated against an allow-list built from the Prisma scalar-field enum, so a name the service does not have is a 400, not a silently ignored filter.
- `personId`, `positionName` and `officeTitle` are all scalars on those two models (`candidacy.prisma`, `officeHolder.prisma`), and neither is on a PII exclusion list.
- The `columns` param on both of these endpoints already ships on `develop` (the union sweep sends `columns=personId`); only the added column names were new.

A test pins the exact query strings so the projection stays reviewable against those schemas without a token. Residual risk is now limited to the deployed election-api differing from `origin/main`.

## Counting

Nothing in the band computes a total that the drop rule can skew. `generate-sitemaps.ts` skips empty shards (`entries.length === 0 → continue`) and counts from the entries it actually emitted, so no empty files and no off-by-one in the file count. `PERSON_ID_BATCH` is 150 against a documented upstream cap of 500. The shard band arithmetic is unchanged and already pinned (`getSitemapIds` is contiguous, 27 shards starting after the state band).

One consequence worth naming: the served `/api/sitemap-index` lists all 79 ids unconditionally, so a shard the drop rule empties is still referenced and answers an empty `<urlset>`. That is valid and benign, and the alternative — loading the whole people band to render the index — would make one upstream blip take out `/sitemap.xml` entirely, which is exactly the failure mode the dynamic band was designed to avoid.

## Verification

Rendered through the real pipeline against a mock election-api serving the affected record shape:

| record | robots | title |
| --- | --- | --- |
| lowercase name, no office | `noindex, follow` | `Chris Lewis — Candidate \| GoodParty.org` |
| **same person + a named race** | **(none — indexable)** | `Chris Lewis — Candidate for Virginia House of Delegates - District 12 \| GoodParty.org` |
| formatted name, still no office | `noindex, follow` | `Blaine K. Bowman — Candidate \| GoodParty.org` |

The last row is the important one: the noindex keys on thin content, not on casing.

## Tests

- `npm run typecheck` — clean
- `npm test` — 838 pass, 0 fail
- `npm run lint` — 0 errors (pre-existing warnings only)
