### PR TITLE
Pin the removal states (Figma K/L) so they cannot drift

### DIFF
--- a/harness/FOLLOWUPS.md
+++ b/harness/FOLLOWUPS.md
@@ -14,6 +14,18 @@ are excluded from the 3% gate by band class in `config.mjs` (not masked).
 | I | Sidebar rows/icons | Unclaimed → no owner overlay/office, so Current Term, Office Contact, Office Mailing Address and the gov/Instagram contact icons have **no data**; live correctly renders only Election Date / Political Affiliation / Contact(3). Figma shows the full filled template | people-api (owner claim / office data) | data gap — flag |
 | K, L | Sidebar top rows | Removal frames use a **generic full template**: figma K (a candidate, holds no office) still shows a "Current Term" row, and figma L (a non-running officeholder) still shows an "Election Date" row — both factually inapplicable placeholders. Live renders the semantically-correct rows per persona. Removal also suppresses owner content (`links=[]`) by design | design file (per-persona removal frames) + product (removal suppression) | reference artifact + data suppression — flag |
 
+**Re-verified 2026-08-17** (fresh Figma re-export of `1997:118777` / `1997:118283`):
+**K gated 3.18%**, **L gated 2.58%** — both improved from the 4.41 / 4.13 recorded
+below, and no band is structurally missing on either side. K's remaining 0.18pp
+over tolerance is the same reference artifact: its Figma sidebar rows still read
+literally `[#### - ####]` and `[space for BallotReady data]`, i.e. the frame was
+never filled in for this state. **No new parity gap was found**, so K is left
+failing rather than masked — masking it would hide the day the frames are
+redrawn per-persona and the gap becomes real. K/L structure is now pinned in
+`src/components/people/personSectionOverrides.test.ts` instead, which is where
+absence (stripped avatar, pledge, links, authored sections) can actually be
+asserted; the blurred layout score treats all of those as rounding errors.
+
 ## RESOLVED — sidebar rebuilt to the Figma structure
 
 The sidebar was structurally wrong (a card of labeled URL rows + an "About

--- a/harness/config.mjs
+++ b/harness/config.mjs
@@ -6,7 +6,9 @@
 //
 // This file is plain data (no imports) so every harness script can read it.
 
-export const DEV_ORIGIN = 'http://localhost:3009';
+// `bun run dev` serves 3009, but a second checkout (worktree) usually cannot
+// have that port, so allow an override rather than forcing a temporary edit here.
+export const DEV_ORIGIN = process.env.HARNESS_ORIGIN || 'http://localhost:3009';
 
 // Where the cached Figma frame exports live (figma-A.png … figma-L.png).
 // Re-export from Figma into this folder to refresh the source of truth.

--- a/src/components/people/personSectionOverrides.test.ts
+++ b/src/components/people/personSectionOverrides.test.ts
@@ -232,6 +232,135 @@ describe('the claim prompt and the claim form ship together', () => {
 	});
 });
 
+/**
+ * The removal states (Figma K 1997:118776 / desktop 1997:118777, L 1997:118282 /
+ * desktop 1997:118283) are the two frames with a legal obligation behind them:
+ * someone asked us to stop publishing their profile, and we kept the crawlable
+ * civics spine on the understanding that everything they or we authored comes
+ * off. Nothing pinned that, so any of it could have been restored by a change
+ * aimed at another state — the authored slot, the hero photo, the pledge badge
+ * and the contact links are all shared code paths.
+ *
+ * These assert on absence, which is exactly what a visual diff is worst at: the
+ * harness scores K/L on a blurred layout metric where a re-appearing avatar or
+ * pledge pill is a rounding error.
+ */
+describe('the removal states publish the civics spine and nothing else', () => {
+	const REMOVAL_SLUGS = [
+		['K', 'x-27255f40'],
+		['L', 'x-3412f69c'],
+	] as const;
+
+	/** Every authored section a claimed page can render, in any persona. */
+	const AUTHORED_HEADINGS = [
+		'Why I\u2019m Running for Office',
+		'Why I Served',
+		'Campaign Issues',
+		'Top Priorities While in Office',
+		'Accomplishments During This Term',
+		'About Me',
+	];
+
+	test('state K — a removed candidate keeps only the public record', () => {
+		expect(sectionHeadings('x-27255f40')).toEqual([
+			'Recent Experience',
+			'Other Candidates for Springfield City Council',
+			'About Springfield City Council',
+			'District information',
+		]);
+	});
+
+	test('state L — a removed officeholder keeps only the public record', () => {
+		expect(sectionHeadings('x-3412f69c')).toEqual([
+			'Recent Experience',
+			'District information',
+			'About Springfield City Council',
+			'Nearby Officials',
+		]);
+	});
+
+	test('neither removal state renders a single authored section', () => {
+		for (const [state, slug] of REMOVAL_SLUGS) {
+			const headings = sectionHeadings(slug);
+			for (const authored of AUTHORED_HEADINGS) {
+				expect([state, authored, headings.includes(authored)]).toEqual([state, authored, false]);
+			}
+		}
+	});
+
+	test('the removal frames carry no card without a heading', () => {
+		// The claim prompts are the only chrome-less `raw` cards in the well, and
+		// `claimPromptVariants` above already pins that they are gone. This catches
+		// a future raw card (a banner, a notice) being added to every unclaimed
+		// page and silently landing on a page we are meant to have stripped.
+		for (const [state, slug] of REMOVAL_SLUGS) {
+			expect([state, contentCards(slug).filter(card => !card.heading)]).toEqual([state, []]);
+		}
+	});
+
+	test('the hero is stripped of the photo and never reads as endorsed', () => {
+		for (const [state, slug] of REMOVAL_SLUGS) {
+			const view = getDevPersonProfileView(slug);
+			if (!view) throw new Error(`no dev fixture for ${slug}`);
+			const hero = buildPersonSectionOverrides(view).component_profileHero;
+			expect([state, hero?.profileImageUrl]).toEqual([state, undefined]);
+			expect([state, hero?.isEmpowered]).toEqual([state, false]);
+			expect([state, hero?.attribution]).toEqual([state, 'notEndorsed']);
+		}
+	});
+
+	test('the pledge badge is suppressed even though the spine still flags it', () => {
+		// Both removal fixtures seed `isPledged: true`. Pledging is a factual civics
+		// flag, so the only reason it does not paint is the removal — making this
+		// the one assertion that would catch removal being dropped from `pledged`.
+		for (const [state, slug] of REMOVAL_SLUGS) {
+			expect([state, getDevPersonProfileView(slug)?.pledged]).toEqual([state, false]);
+		}
+	});
+
+	test('the CTA band is hidden rather than swapped for the generic sign-up', () => {
+		for (const [state, slug] of REMOVAL_SLUGS) {
+			const view = getDevPersonProfileView(slug);
+			if (!view) throw new Error(`no dev fixture for ${slug}`);
+			expect([state, buildPersonSectionOverrides(view).component_ctaBannerBlock]).toEqual([
+				state,
+				{ hidden: true },
+			]);
+		}
+	});
+
+	test('the sidebar keeps the persona facts and drops every way to contact them', () => {
+		// Contact icons, office email/phone and the mailing address all hang off
+		// `view.links` / `view.officeAddress`, which removal empties. The office
+		// address in particular is a home-adjacent detail on a page the subject
+		// asked us to take down.
+		for (const [state, slug] of REMOVAL_SLUGS) {
+			const view = getDevPersonProfileView(slug);
+			if (!view) throw new Error(`no dev fixture for ${slug}`);
+			const sidebar = buildPersonSectionOverrides(view).component_profileContentBlock?.sidebar;
+			expect([state, sidebar?.contactIcons ?? []]).toEqual([state, []]);
+			expect([state, sidebar?.officeContacts ?? []]).toEqual([state, []]);
+			expect([state, sidebar?.officeAddress ?? []]).toEqual([state, []]);
+			// Party is public record and stays — losing it would be over-stripping.
+			expect([state, Boolean(sidebar?.politicalAffiliation)]).toEqual([state, true]);
+		}
+	});
+
+	test('K shows its election date; L, who is not running, does not', () => {
+		// The Figma removal frames are one generic template that shows both rows on
+		// both states (logged in harness/FOLLOWUPS.md as a reference artifact), so
+		// the harness cannot arbitrate this. Persona correctness is pinned here.
+		const rowLabels = (slug: string) => {
+			const view = getDevPersonProfileView(slug);
+			if (!view) throw new Error(`no dev fixture for ${slug}`);
+			const sidebar = buildPersonSectionOverrides(view).component_profileContentBlock?.sidebar;
+			return (sidebar?.topInfos ?? []).map(info => info.label);
+		};
+		expect(rowLabels('x-27255f40')).toEqual(['Election Date']);
+		expect(rowLabels('x-3412f69c')).toEqual([]);
+	});
+});
+
 describe('card grouping sets the Figma heading levels', () => {
 	/** Headings per white card: the first is the 32/44 one, the rest are 24/32. */
 	function headingsByCard(slug: string): string[][] {


### PR DESCRIPTION
## Why

States **K** (`1997:118776` / desktop `1997:118777`) and **L** (`1997:118282` / desktop `1997:118283`) are the two profile states with a legal obligation behind them: someone asked us to stop publishing their profile, and we kept the crawlable civics spine on the understanding that everything authored comes off — photo, bio, issues, links, pledge badge, office address, claim CTAs.

**Nothing asserted any of that.** Every one of those is a shared code path, so a change aimed at another state could have restored them and no test would have noticed.

The visual harness cannot cover this gap. It scores K/L on a **blurred, downscaled layout metric** — deliberately, so real seeded copy does not dominate — where a re-appearing avatar or pledge pill is a rounding error well inside the 3% tolerance. Absence needs assertions, not pixels.

## Harness run (states K, L)

Ran the existing harness rather than reinventing capture. `/tmp/figma-shots` had been cleared, so both frames were re-exported from Figma at full 1440px width first.

```
state  gated    all     avatar       gate   worst feature band
-----  -------  ------  -----------  -----  ------------------
K       3.18%    10.6%  placeholder  FAIL   body 3%
L       2.58%    10.5%  placeholder   ok    body 3%
```

**L is green. K misses by 0.18pp.** No band is structurally missing on either side (`missing: null` throughout), so the section structure matches the frames.

Both are a solid improvement on the last recorded scores in `FOLLOWUPS.md` (K 4.41, L 4.13).

### No new parity gap — and here is the proof

K's residual is the **already-documented reference artifact** (`FOLLOWUPS.md` row `K, L | Sidebar top rows`): the removal frames are one generic template reused for both states, so K — *a candidate, who holds no office* — is shown a **"Current Term"** row anyway.

The frame gives itself away. Its sidebar placeholders are literally unfilled:

| | Figma K | Live `/people/x-27255f40` |
|---|---|---|
| Row 1 | Election Date · `[space for BallotReady data]` | Election Date · `November 3, 2026` |
| Row 2 | **Current Term · `[#### - ####]`** | *(absent — a candidate holds no seat)* |
| Row 3 | Political Affiliation · `Republican` | Political Affiliation · `Republican` |

Our render is the semantically correct one. The mirror-image artifact is on L, where the same template shows an **"Election Date"** row for an officeholder who is not running.

**I left K failing rather than masking it.** A mask would suppress the signal on the day the frames are redrawn per-persona and the gap becomes real. The honest state is "K is 0.18pp over because the reference is wrong", recorded in `FOLLOWUPS.md`, with the actual behaviour pinned by tests below.

The rest of the `body` residual is the two other logged items: the **voter-density heatmap** (data not wired to seeded people) and Figma lorem vs real seeded copy.

## What is pinned

Added to the existing `src/components/people/personSectionOverrides.test.ts` — same file, same helpers, same style as the state A/B/C/G order tests — rather than a parallel structure:

- **exact content-well order** for K and L
- **no authored section**, checked against every authored heading any persona can produce, so a new one cannot slip through
- **no chrome-less `raw` card**, so a future banner added to unclaimed pages cannot land on a page we are meant to have stripped
- **hero**: no `profileImageUrl`, `isEmpowered: false`, `attribution: 'notEndorsed'`
- **pledge suppressed** — both fixtures seed `isPledged: true`, so removal is the only reason it does not paint. This is the single assertion that catches removal being dropped from `pledged`.
- **CTA band `{ hidden: true }`**, not swapped for the generic sign-up
- **sidebar**: no contact icons, no office email/phone, **no office mailing address** (a home-adjacent detail on a page the subject asked us to take down) — while keeping party, which is public record. Over-stripping is a bug too.
- **persona-correct top rows** (K has Election Date, L has none) — the thing the generic frames cannot arbitrate

### These bite

Verified by mutation, not by assuming. Reverting the two removal guards in `composeView`:

```
- const avatarUrl = removed ? null : (overlay?.avatarUrl ?? person?.headshotUrl ?? null);
- pledged: !removed && (person?.isPledged ?? false),
```

fails **exactly** `the hero is stripped of the photo…` and `the pledge badge is suppressed…`, and nothing else in the 720-test suite. Both mutations reverted; this PR changes no render code.

## Also

`harness/config.mjs` — `DEV_ORIGIN` now honours `HARNESS_ORIGIN`. A second checkout cannot bind port 3009 (the primary one holds it), and the alternative was a temporary local edit to a committed file every time. Default is unchanged.

```bash
HARNESS_ORIGIN=http://localhost:3021 node harness/run.mjs K,L
```

## Test evidence

```
bunx tsc --noEmit  → clean
bun run lint       → 0 errors
bun test           → 712 pass, 4 fail
```

The 4 failures are **pre-existing on a clean `develop` checkout** (baseline 703 pass / 4 fail — same tests: a JSDOM/Radix dialog flake, plus `SITEMAP_BASE_URL` and Playwright-collection errors). This PR is **+9 passing tests, 0 new failures, 0 render-code changes**.

## Independent

No dependency on the person-removal admin PRs or the unpublish fix — different files, and this branch is cut straight from `develop`.
