### PR TITLE
Stop asking people to claim a profile they already own

### DIFF
--- a/src/components/people/personSectionOverrides.tsx
+++ b/src/components/people/personSectionOverrides.tsx
@@ -664,7 +664,12 @@ function profileLocationLabel(view: PersonProfileView): string | null {
 export function buildPersonSectionOverrides(view: PersonProfileView): SectionOverrides {
 	// Past-election profiles (G claimed, H unclaimed) lead with the past-election
 	// disclaimer, NOT the claim CTA — so exclude persona 'past' from the claim gate.
-	const showClaim = view.empowered && !view.claimed && view.persona !== 'past';
+	// `unpublished` is excluded too: the profile is already claimed, it just isn't
+	// live, so "Are you …? Claim your profile" addresses someone who owns it and
+	// the voter-facing prompt asks the reader to nudge a person who already
+	// decided. This is the only difference from the equivalent `absent` page.
+	const showClaim =
+		view.empowered && !view.claimed && !view.unpublished && view.persona !== 'past';
 	// The pledge explainer is claimed content across every persona (Figma A/B/C/G
 	// all show it once claimed). Unclaimed empowered pages lead with the claim
 	// prompt instead, so it stays hidden there.
@@ -728,9 +733,12 @@ export function buildPersonSectionOverrides(view: PersonProfileView): SectionOve
 	// Authored slot: claimed pages show real owner content; unclaimed but
 	// empowered pages (Figma D/E/F/H) show muted placeholder prompt cards in the
 	// same slot; major-party (I/J) and removed (K/L) pages show neither.
+	// Unpublished pages are excluded as well — every placeholder ends in "once
+	// they claim their profile", so leaving them in would restate the claim
+	// prompt the block above just suppressed.
 	const authoredSections = view.claimed
 		? buildAuthoredSections(view)
-		: view.empowered
+		: view.empowered && !view.unpublished
 			? buildAuthoredPlaceholderSections(view)
 			: {};
 	const contentCards: ProfileContentCardProps[] = [

--- a/src/components/people/unpublishedProfileSections.test.tsx
+++ b/src/components/people/unpublishedProfileSections.test.tsx
@@ -1,0 +1,120 @@
+/**
+ * Pins the one behaviour that separates an unpublished profile from an
+ * unclaimed one: no claim affordances.
+ *
+ * The bug this guards was invisible from the API layer — gp-api 404'd for both
+ * "never claimed" and "unpublished", so a person who deliberately hid their own
+ * profile got "Are you [Name]?" on their own page, plus a card asking voters to
+ * pester them into finishing it. Asserting on `view.unpublished` alone would not
+ * have caught it, because the flag is only worth anything if the section builder
+ * reads it. So these assertions read the composed section overrides.
+ *
+ * Structure is compared against the `absent` view of the SAME fixture rather
+ * than a hand-written list of expected cards: the point is that unpublished
+ * differs from unclaimed in exactly one respect, and a literal list would go
+ * stale the next time the civics spine gains a card.
+ */
+import { describe, expect, test } from 'bun:test';
+import { isValidElement, type ReactElement, type ReactNode } from 'react';
+import { buildPersonSectionOverrides } from './personSectionOverrides';
+import {
+	composeView,
+	type PersonProfileView,
+} from '~/lib/peopleProfile';
+import {
+	PERSON_ID,
+	UNPUBLISHED_FIXTURES,
+	viewForFixture,
+	type StateFixture,
+} from '~/testing/peopleProfileFixtures';
+
+/** The same spine with no overlay at all — a person nobody has claimed. */
+function absentView(fixture: StateFixture): PersonProfileView {
+	return composeView(PERSON_ID, fixture.person, null, {});
+}
+
+/**
+ * Every string rendered inside a section, including deep inside the claim
+ * prompt components, so a claim CTA cannot hide behind a nested element.
+ */
+function collectText(node: ReactNode): string[] {
+	if (node == null || typeof node === 'boolean') return [];
+	if (typeof node === 'string' || typeof node === 'number') return [String(node)];
+	if (Array.isArray(node)) return node.flatMap(child => collectText(child as ReactNode));
+	if (isValidElement(node)) {
+		const el = node as ReactElement<Record<string, unknown>>;
+		const props = el.props ?? {};
+		// Component elements are not rendered here, so their copy lives in props
+		// (displayName, variant, heading, …) rather than in children.
+		return Object.entries(props).flatMap(([key, value]) =>
+			key === 'children' || typeof value !== 'string' ? collectText(value as ReactNode) : [value],
+		);
+	}
+	return [];
+}
+
+function cardShapes(view: PersonProfileView): string[] {
+	const overrides = buildPersonSectionOverrides(view);
+	return (overrides.component_profileContentBlock?.contentCards ?? []).map(
+		card => card.heading ?? (card.raw ? 'raw' : (card.cardType ?? 'untitled')),
+	);
+}
+
+function claimPromptVariants(view: PersonProfileView): string[] {
+	const overrides = buildPersonSectionOverrides(view);
+	return (overrides.component_profileContentBlock?.contentCards ?? [])
+		.flatMap(card => collectText(card.content))
+		.filter(text => text === 'owner-card' || text === 'voter-card');
+}
+
+describe('an unpublished profile suppresses every claim affordance', () => {
+	for (const fixture of UNPUBLISHED_FIXTURES) {
+		describe(fixture.description, () => {
+			const view = viewForFixture(fixture);
+
+			test('renders no owner or voter claim prompt card', () => {
+				expect(claimPromptVariants(view)).toEqual([]);
+			});
+
+			test('hides the CTA band instead of offering the claim form', () => {
+				expect(buildPersonSectionOverrides(view).component_ctaBannerBlock).toEqual({ hidden: true });
+			});
+
+			test('drops the "once they claim their profile" placeholder cards', () => {
+				const text = cardShapes(view).join(' ');
+				expect(text).not.toContain('Why');
+				expect(text).not.toContain('About');
+			});
+
+			test('keeps the hero neutral rather than claiming endorsement', () => {
+				const hero = buildPersonSectionOverrides(view).component_profileHero;
+				expect(hero?.attribution).toBe('notEndorsed');
+			});
+		});
+	}
+});
+
+describe('an unpublished profile is otherwise the unclaimed page', () => {
+	for (const fixture of UNPUBLISHED_FIXTURES) {
+		test(`${fixture.description} keeps its civics spine`, () => {
+			const unpublished = cardShapes(viewForFixture(fixture));
+			const absent = cardShapes(absentView(fixture));
+
+			// The civics spine is the public record, which the person unpublishing
+			// their profile does not retract — unlike a removal (K/L), which does.
+			expect(unpublished).toContain('Recent Experience');
+			// Nothing is invented: unpublished only ever drops cards.
+			expect(absent).toEqual(expect.arrayContaining(unpublished));
+
+			// Claim prompts and their authored placeholders only exist on the
+			// empowered branch, so that is the only branch where the column shrinks.
+			// The major-party fixture is here to prove the suppression is keyed on
+			// `unpublished` and not silently riding on `empowered`.
+			if (fixture.expected.empowered) {
+				expect(unpublished.length).toBeLessThan(absent.length);
+			} else {
+				expect(unpublished).toEqual(absent);
+			}
+		});
+	}
+});

--- a/src/lib/electionsApi.ts
+++ b/src/lib/electionsApi.ts
@@ -379,23 +379,29 @@ export async function getVoterDensityForDistrict(
 /**
  * Result of resolving a person's product overlay (gp-api). The distinction
  * matters for the render gate:
- *  - `live`   → an owner has claimed + published a profile; enrich the page.
- *  - `absent` → no published overlay (never claimed, or unpublished draft); the
- *               page still renders as an unclaimed, programmatic-SEO profile
- *               from the election-api spine, with claim CTAs.
- *  - `gone`   → the owner deleted their profile; suppress the page entirely.
+ *  - `live`        → an owner has claimed + published a profile; enrich the page.
+ *  - `absent`      → nobody has claimed this person; the page still renders as an
+ *                    unclaimed, programmatic-SEO profile from the election-api
+ *                    spine, with claim CTAs.
+ *  - `unpublished` → someone owns a profile here but it is not live. Renders the
+ *                    same spine page as `absent`, minus every claim CTA — they
+ *                    already claimed it, so asking them to claim it is wrong, and
+ *                    asking voters to nudge them to finish it is worse.
+ *  - `gone`        → the owner deleted their profile; suppress the page entirely.
  */
 export type PublicPersonProfileResult =
 	| { status: 'live'; profile: PublicPersonProfile }
 	| { status: 'absent' }
+	| { status: 'unpublished' }
 	| { status: 'gone' }
 	| { status: 'removed' };
 
 /**
  * The product-owned overlay for a person's public profile (gp-api). gp-api
- * returns 200 (live), 404 (never created / unpublished), or 410 (deleted). We
- * map those to the render-gate outcomes above; any transient/5xx failure falls
- * back to `absent` so the spine page still renders instead of 404-ing.
+ * returns 200 (live, removed, or unpublished), 404 (never created), or 410
+ * (deleted). We map those to the render-gate outcomes above; any transient/5xx
+ * failure falls back to `absent` so the spine page still renders instead of
+ * 404-ing.
  */
 export async function getPublicPersonProfileStatus(
 	personId: string,
@@ -410,6 +416,9 @@ export async function getPublicPersonProfileStatus(
 				// Privacy takedown: gp-api answers 200 with { removed: true } and no
 				// authored content. Render the minimal "removal requested" states.
 				if (profile.removed === true) return { status: 'removed' };
+				// Checked after `removed` because a takedown outranks the owner's own
+				// publish state, and gp-api only ever sends one of the two markers.
+				if (profile.unpublished === true) return { status: 'unpublished' };
 				return { status: 'live', profile };
 			}
 			if (res.status === 410) return { status: 'gone' };

--- a/src/lib/peopleProfile.states.test.ts
+++ b/src/lib/peopleProfile.states.test.ts
@@ -18,6 +18,7 @@ import {
 	fixtureForState,
 	PERSON_ID,
 	STATE_FIXTURES,
+	UNPUBLISHED_FIXTURES,
 } from '~/testing/peopleProfileFixtures';
 
 const originalFetch = globalThis.fetch;
@@ -43,6 +44,7 @@ describe('public profile — 12-state data-flow matrix', () => {
 			expect(view.majorParty).toBe(e.majorParty);
 			expect(view.empowered).toBe(e.empowered);
 			expect(view.removed).toBe(e.removed);
+			expect(view.unpublished).toBe(e.unpublished);
 			expect(view.pledged).toBe(e.pledged);
 
 			// Content gating (what actually paints).
@@ -67,6 +69,48 @@ describe('public profile — removal SEO signal', () => {
 			// noindex is applied in the page metadata from view.removed; assert the
 			// flag that drives it matches the spec for every state.
 			expect(fixture.expected.removed).toBe(fixture.expected.noindex);
+		}
+	});
+});
+
+describe('public profile — unpublished overlay', () => {
+	for (const fixture of UNPUBLISHED_FIXTURES) {
+		test(`${fixture.description} resolves like its ${fixture.state} counterpart`, async () => {
+			globalThis.fetch = buildPeopleFetchMock(fixture) as unknown as typeof fetch;
+
+			const view = await loadPersonProfile(PERSON_ID);
+			expect(view).not.toBeNull();
+			if (!view) return;
+
+			const e = fixture.expected;
+			// Layout-driving axes are untouched: an unpublished profile still renders
+			// the unclaimed spine page, so anything that changes here is a regression
+			// in blast radius, not a fix.
+			expect(view.state).toBe(fixture.state);
+			expect(view.claimed).toBe(false);
+			expect(view.empowered).toBe(e.empowered);
+			expect(view.removed).toBe(false);
+			expect(view.unpublished).toBe(true);
+
+			// The spine survives — unlike removal (K/L), this is not a takedown.
+			expect(view.avatarUrl).not.toBeNull();
+			expect(view.bio).not.toBeNull();
+			expect(view.recentExperience.length).toBeGreaterThan(0);
+
+			// Nothing the owner drafted may leak through the marker.
+			expect(view.issues).toEqual([]);
+			expect(view.whyRunning).toBeNull();
+			expect(view.accomplishments).toEqual([]);
+			expect(assertNoPii(view)).toEqual([]);
+		});
+	}
+
+	test('stays indexable — the spine page predates the person signing up', () => {
+		// Deliberately unlike removal: only the CTAs were wrong, so the SEO signal
+		// is left alone. Pinned so a future "unpublished means hide it" reading
+		// cannot quietly deindex a legitimate programmatic-SEO page.
+		for (const fixture of UNPUBLISHED_FIXTURES) {
+			expect(fixture.expected.noindex).toBe(false);
 		}
 	});
 });

--- a/src/lib/peopleProfile.ts
+++ b/src/lib/peopleProfile.ts
@@ -189,6 +189,13 @@ export interface PersonProfileView {
 	majorParty: boolean;
 	/** True when the person requested removal (states K/L). */
 	removed: boolean;
+	/**
+	 * True when someone owns a profile here that is not live. Orthogonal to the
+	 * Figma state letter — the page keeps its normal unclaimed layout and spine
+	 * content — but every "claim this profile" affordance is suppressed, because
+	 * the person it would address has already claimed it.
+	 */
+	unpublished: boolean;
 	/** True when the page uses the empowerment/pledge/claim framing. */
 	empowered: boolean;
 	/** True when the person has taken the GoodParty pledge (renders a badge). */
@@ -658,6 +665,7 @@ export function buildBreadcrumbTrail(params: {
 
 export interface ComposeExtras {
 	removed?: boolean;
+	unpublished?: boolean;
 	positionId?: string | null;
 	electionDate?: string | null;
 	positionDescription?: string | null;
@@ -698,6 +706,10 @@ export function composeView(
 	extras: ComposeExtras = {},
 ): PersonProfileView {
 	const removed = extras.removed ?? false;
+	// Deliberately not folded into `claimed` or the state letter: an unpublished
+	// page is still the unclaimed spine layout, so it keeps the person's public
+	// record. Only the claim affordances differ.
+	const unpublished = extras.unpublished ?? false;
 	const claimed = overlay !== null && !removed;
 	const composedName = [person?.firstName, person?.lastName].filter(Boolean).join(' ');
 	const nameFromPerson = person?.fullName ?? (composedName || null);
@@ -752,6 +764,7 @@ export function composeView(
 		partyClass,
 		majorParty,
 		removed,
+		unpublished,
 		empowered,
 		// Pledge is a factual spine flag; suppress it on removed (K/L) pages along
 		// with the rest of the authored/empowerment framing.
@@ -989,6 +1002,7 @@ export async function loadPersonProfile(personId: string): Promise<PersonProfile
 	if (overlayResult.status === 'gone') return null;
 
 	const removed = overlayResult.status === 'removed';
+	const unpublished = overlayResult.status === 'unpublished';
 	const overlay = overlayResult.status === 'live' ? overlayResult.profile : null;
 
 	// Unclaimed and no removal: only render if the data team has a canonical
@@ -1037,6 +1051,7 @@ export async function loadPersonProfile(personId: string): Promise<PersonProfile
 
 	return composeView(personId, person, overlay, {
 		removed,
+		unpublished,
 		positionId,
 		electionDate,
 		positionDescription,

--- a/src/testing/peopleProfileFixtures.ts
+++ b/src/testing/peopleProfileFixtures.ts
@@ -30,7 +30,8 @@ export type OverlayFixture =
 	| { status: 'live'; profile: PublicPersonProfile }
 	| { status: 'absent' }
 	| { status: 'gone' }
-	| { status: 'removed' };
+	| { status: 'removed' }
+	| { status: 'unpublished' };
 
 export interface StateFixture {
 	state: ProfileState;
@@ -47,6 +48,12 @@ export interface ExpectedFacts {
 	majorParty: boolean;
 	empowered: boolean;
 	removed: boolean;
+	/**
+	 * The owner has a profile that is not live. Orthogonal to the state letter —
+	 * it suppresses claim affordances without changing the layout — so it is
+	 * false across all twelve Figma states and only set by UNPUBLISHED_FIXTURES.
+	 */
+	unpublished: boolean;
 	pledged: boolean;
 	hasAvatar: boolean;
 	hasBio: boolean;
@@ -186,6 +193,7 @@ const claimedFacts = (persona: PersonPersona, pledged: boolean): ExpectedFacts =
 	majorParty: false,
 	empowered: true,
 	removed: false,
+	unpublished: false,
 	pledged,
 	hasAvatar: true,
 	hasBio: true,
@@ -202,6 +210,7 @@ const unclaimedIndepFacts = (persona: PersonPersona): ExpectedFacts => ({
 	majorParty: false,
 	empowered: true,
 	removed: false,
+	unpublished: false,
 	pledged: false,
 	hasAvatar: true, // spine headshot
 	hasBio: true, // spine bioText
@@ -215,6 +224,7 @@ const unclaimedMajorFacts = (persona: PersonPersona): ExpectedFacts => ({
 	majorParty: true,
 	empowered: false,
 	removed: false,
+	unpublished: false,
 	pledged: false,
 	hasAvatar: true,
 	hasBio: true,
@@ -231,6 +241,7 @@ const removedFacts = (persona: PersonPersona, majorParty: boolean): ExpectedFact
 	majorParty,
 	empowered: false,
 	removed: true,
+	unpublished: false,
 	pledged: false, // suppressed on removal even though the spine flag is set
 	hasAvatar: false, // stripped
 	hasBio: false, // stripped
@@ -345,6 +356,37 @@ export const STATE_FIXTURES: StateFixture[] = [
 	},
 ];
 
+// ----- unpublished overlays (not Figma states) -------------------------------
+
+/**
+ * An owner exists but their profile is not live, so gp-api answers 200
+ * `{ unpublished: true }` instead of the 404 it used to send. This is NOT a
+ * thirteenth Figma state: the page renders its normal unclaimed layout and full
+ * civics spine, so these reuse the same fixtures as D and I. The only thing
+ * that changes is that every claim affordance is suppressed, which the state
+ * letter cannot express — hence a separate list rather than a matrix row.
+ *
+ * Both an empowered (D) and a major-party (I) base are covered because the
+ * claim prompts only exist on the empowered branch; without the I case a
+ * regression that gated on `empowered` alone would look fixed.
+ */
+export const UNPUBLISHED_FIXTURES: StateFixture[] = [
+	{
+		state: 'D',
+		description: 'Unpublished profile — independent candidate spine',
+		person: spine({ Candidacies: [candidacy()] }),
+		overlay: { status: 'unpublished' },
+		expected: { ...unclaimedIndepFacts('candidate'), unpublished: true },
+	},
+	{
+		state: 'I',
+		description: 'Unpublished profile — major-party candidate spine',
+		person: spine({ Candidacies: [candidacy({ party: 'Republican' })] }),
+		overlay: { status: 'unpublished' },
+		expected: { ...unclaimedMajorFacts('candidate'), unpublished: true },
+	},
+];
+
 export function fixtureForState(state: ProfileState): StateFixture {
 	const found = STATE_FIXTURES.find((f) => f.state === state);
 	if (!found) throw new Error(`No fixture for state ${state}`);
@@ -358,10 +400,16 @@ export function fixtureForState(state: ProfileState): StateFixture {
  * integration matrix asserts on.
  */
 export function viewFor(state: ProfileState): PersonProfileView {
-	const fixture = fixtureForState(state);
+	return viewForFixture(fixtureForState(state));
+}
+
+/** `viewFor` for fixtures that are not a Figma state (see UNPUBLISHED_FIXTURES). */
+export function viewForFixture(fixture: StateFixture): PersonProfileView {
 	const overlay = fixture.overlay.status === 'live' ? fixture.overlay.profile : null;
-	const removed = fixture.overlay.status === 'removed';
-	return composeView(PERSON_ID, fixture.person, overlay, { removed });
+	return composeView(PERSON_ID, fixture.person, overlay, {
+		removed: fixture.overlay.status === 'removed',
+		unpublished: fixture.overlay.status === 'unpublished',
+	});
 }
 
 // ----- fetch mock ------------------------------------------------------------
@@ -400,6 +448,8 @@ export function buildPeopleFetchMock(
 					return jsonResponse({}, 404) as unknown as Response;
 				case 'removed':
 					return jsonResponse({ personId: PERSON_ID, removed: true }) as unknown as Response;
+				case 'unpublished':
+					return jsonResponse({ personId: PERSON_ID, unpublished: true }) as unknown as Response;
 				case 'live':
 					return jsonResponse(fixture.overlay.profile) as unknown as Response;
 			}

--- a/src/types/people.ts
+++ b/src/types/people.ts
@@ -129,6 +129,12 @@ export interface PublicPersonProfile {
 	personId: string;
 	/** Privacy takedown flag from gp-api. When true, render the minimal K/L states. */
 	removed?: boolean;
+	/**
+	 * The person owns a profile that is not live (draft, or deliberately
+	 * unpublished). gp-api sends this instead of a 404 so we can tell them apart
+	 * from someone who never claimed; every authored field is null either way.
+	 */
+	unpublished?: boolean;
 	displayName: string | null;
 	roleTitleOverride: string | null;
 	bioOverride: string | null;


### PR DESCRIPTION
## The bug

gp-api returns 404 both for a person nobody has ever claimed and for an owner whose profile is unpublished, and `getPublicPersonProfileStatus` maps 404 → `status: 'absent'` → "unclaimed programmatic SEO page".

So someone who claimed their profile and then **deliberately unpublished it** was served, on their own page:

- **"Are you [Name]?" → "Complete your profile"** — addressed to the person who already owns it
- **"Ask [Name] to complete their profile"** — a voter-facing card asking strangers to pester someone who already decided
- the full-width claim CTA band with the inline claim form
- muted placeholder cards ("… will appear here once they claim their profile")

## The change

gp-api now sends `200 { unpublished: true }` (companion PR below). This threads it through:

`PublicPersonProfileResult` gains `{ status: 'unpublished' }` → `loadPersonProfile` → `ComposeExtras` → `PersonProfileView.unpublished` → `buildPersonSectionOverrides` suppresses:

- both claim prompt cards (owner + voter)
- the claim CTA band (falls through to `{ hidden: true }`)
- the authored placeholder cards — their copy ends *"once they claim their profile"*, so leaving them in would restate the prompt we just removed

**Everything else is deliberately unchanged.** Same layout, same Figma state letter, same civics spine (headshot, bio, Recent Experience, Other Candidates, Nearby Officials, district map). This is not a takedown — unlike removal (K/L), the person has not asked us to strip their public record, they have just declined to publish an overlay on top of it.

### `unpublished` is a flag, not a 13th state

It is orthogonal to the A–L state letter: an unpublished profile still resolves to D (or I, or E…) depending on persona and party, and renders that layout. Only the claim affordances differ. Modelling it as a new letter would have implied a new Figma frame that does not exist, so `ExpectedFacts.unpublished` is `false` across all twelve matrix rows and the new cases live in their own short list.

### Indexing and sitemap: intentionally untouched

The brief called this out and I want to confirm it explicitly: **no change to `robots`, `generateMetadata`, or sitemap membership.** The spine page legitimately predates the person ever signing up and is built from public civics data; only the CTAs were wrong. There is a test pinning `noindex: false` so a future reading of "unpublished means hide it" cannot quietly deindex a legitimate page.

## Tests (+13, extending the existing matrix)

Extended `src/testing/peopleProfileFixtures.ts` rather than adding a parallel structure:

- `OverlayFixture` gains `{ status: 'unpublished' }`, and `buildPeopleFetchMock` serves the real `200 { unpublished: true }` payload
- `ExpectedFacts.unpublished` added, `false` on all twelve states
- new `UNPUBLISHED_FIXTURES` — the **D** (empowered) and **I** (major-party) spines. The I case is not padding: it proves the suppression is keyed on `unpublished` and is not silently riding on `empowered`, which a D-only test would not catch.
- `viewFor` refactored into `viewForFixture` so non-state fixtures compose the same way

`src/lib/peopleProfile.states.test.ts` — drives the real fetch → `loadPersonProfile` → view flow: state letter, `claimed`, `empowered` unchanged; spine survives; `issues`/`whyRunning`/`accomplishments` empty; `assertNoPii` clean; stays indexable.

`src/components/people/unpublishedProfileSections.test.tsx` (new) — asserting on `view.unpublished` alone would not have caught this bug, since the flag is worthless unless the section builder reads it. So these read the composed section overrides: no claim prompt of either variant, CTA band `{ hidden: true }`, no placeholder cards, hero stays `notEndorsed`. It compares against the `absent` view of the *same* fixture rather than a hand-written card list, so it will not go stale the next time the spine gains a card.

```
bunx tsc --noEmit  → clean
bun run lint       → 0 errors
bun test           → 716 pass, 4 fail
```

The 4 failures are **pre-existing on a clean `develop` checkout** (verified by stashing: baseline is 703 pass / 4 fail — same tests). They are a JSDOM/Radix dialog flake in `claimFlow.test.tsx` plus `SITEMAP_BASE_URL` and Playwright-collection errors. This PR is +13 passing tests and 0 new failures.

## 🚨 Deploy this BEFORE the gp-api side

Old gp-marketing + new gp-api is a broken combination: the current code treats *any* 200 that is not `removed` as `status: 'live'`, so it would render an unpublished person's page as a **claimed** profile with "Empowered by GoodParty.org" and no content.

This PR is a **no-op until gp-api starts sending the marker**, so it is safe to ship first and must be.

**Companion (merge second):** [thegoodparty/omni#1284](https://github.com/thegoodparty/omni/pull/1284).

## Note on the harness fixtures

`src/lib/devPeopleProfileFixtures.ts` (used by `harness/` with `PEOPLE_DEV_FIXTURES=true`) is unchanged — it has no unpublished fixture, so the visual harness does not cover this case. Worth adding if we want a pinned screenshot of it, but that is a separate change from the bug fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> User-facing public profile UX and gp-api contract; deploy marketing before gp-api ships the marker to avoid misclassifying unpublished as live claimed profiles.
> 
> **Overview**
> Fixes person pages for owners who **claimed but unpublished** their profile: they were shown the same claim CTAs as never-claimed people because gp-api used to 404 for both cases.
> 
> **API → view:** gp-api `200 { unpublished: true }` maps to a new `unpublished` overlay status (separate from `absent` / 404). That flows through `loadPersonProfile` into `PersonProfileView.unpublished` without changing `claimed` or the A–L layout state — the page stays the unclaimed spine with public civics data.
> 
> **UI:** `buildPersonSectionOverrides` gates on `!view.unpublished` to drop owner/voter claim cards, the claim CTA band, and authored placeholder cards whose copy says “once they claim their profile.” Hero stays **not endorsed**; indexing/SEO behavior is unchanged.
> 
> **Tests:** `UNPUBLISHED_FIXTURES` (empowered D + major-party I), integration tests on `loadPersonProfile`, and section-level tests that compare unpublished vs `absent` for the same fixture.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 756e9e703b4a083bdb3bf0cf06ed0da57e035418. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->