### PR TITLE
Match the claim card's type to the frame by value, not by name

### DIFF
--- a/harness/FOLLOWUPS.md
+++ b/harness/FOLLOWUPS.md
@@ -270,6 +270,31 @@ intentional? Until that is decided, parity work uses exact values for
 shadcn-derived components. This section is the evidence base — append each new
 "Figma value has no gp-marketing token" case as the loop finds it.
 
+- **Type scale: the SAME name is a different size, and a percentage vs a fixed
+  line-height.** Figma calls the unclaimed content-well card's heading
+  (`1958:108619`) `heading-lg`, but its value is **32/44**; gp-marketing's
+  `heading-lg` is **48/60**. Mapping that name across put the card on
+  `heading-sm`, which only reaches 32px at ≥1440 and carries a **125%**
+  line-height — so it rendered 32/40 at desktop and **24/30** on mobile, where
+  the frame is still 32/44. RESOLVED for this card by using the repo's flat
+  `section-heading` (32/44, deliberately absent from the stepped `@media`
+  blocks — see `_styles/typography.css`), which is the by-value match. The
+  general trap stands: `heading-*` here is a RESPONSIVE ramp, the Figma styles
+  are FLAT, so a name match is a size match at exactly one breakpoint.
+- **`body-1` line-height is a percentage here and fixed in Figma.** Figma's
+  `body 1` is 20/28 desktop and **18/28** mobile — the line-height does not
+  scale. gp-marketing's `--text-body-1--line-height: 140%`, so at the 18px
+  mobile step it computes to **25.2px**, 2.8px tight. Not patched: `body-1` is
+  site-wide type, and overriding it on one card would make that card disagree
+  with every paragraph beside it. Owner: design-system/tokens — decide whether
+  `body-1` should carry a fixed line-height per step.
+- **Button label line-height.** Figma `typography/sm` is 14/20; the shared
+  `Button` renders 14/**21** (default 1.5). One pixel per line on every button
+  on the site — a `Button` change, not a per-surface one.
+- **CTA band panel width.** Figma's CTA Block module is **1280** wide (80px page
+  margin at 1440); live `Container size='xl'` renders **1200** (120px margin),
+  so the blue panel is 40px narrower each side. Shared by the claimed CTA too,
+  so it is a container-token decision rather than a people-profile fix.
 - **Hero band gradient blue `#26498f`** (ProfileHero, Figma frame A `1901:50311`:
   `linear-gradient(156.73deg, #0b1529 68.4%, #26498f 125.1%)`). RESOLVED: promoted
   to the `--goodparty-blue-bright` token (`hsl(220 58% 35%)`, == `#26498f`; a

--- a/src/components/people/ClaimProfileModal.tsx
+++ b/src/components/people/ClaimProfileModal.tsx
@@ -248,6 +248,14 @@ export function notifyDialogTitle(displayName: string): string {
  * owner-facing "are you [Name]?" prompt at the top of the page — the person's
  * own way in is the claim band below the well (see PersonClaimCTABand) — so do
  * not reintroduce one here.
+ *
+ * The heading is `section-heading`, NOT `heading-sm`. Figma names this type
+ * style `heading-lg`, but its value is 32/44 and gp-marketing's `heading-lg` is
+ * 48/60 — the scales do not line up, so tokens have to be matched by value (see
+ * harness/FOLLOWUPS.md). `heading-sm` was the earlier by-name guess: it reaches
+ * 32px only at ≥1440 and carries a 125% line-height, so it rendered 32/40 on
+ * desktop and 24/30 on the mobile artboard, where the frame is still 32/44.
+ * `section-heading` is the flat 32/44 the frames use on both artboards.
  */
 function ClaimPromptCard({
 	displayName,
@@ -267,8 +275,8 @@ function ClaimPromptCard({
 			className='flex flex-col items-center gap-6 rounded-3xl bg-blue-100 p-6 text-center text-midnight-900 md:px-10 md:py-12'
 			data-component='ClaimPromptCard'
 		>
-			<div className='flex flex-col gap-4'>
-				<Text as='h2' styleType='heading-sm'>
+			<div className='flex flex-col gap-3 md:gap-4'>
+				<Text as='h2' styleType='section-heading'>
 					{heading}
 				</Text>
 				<Text styleType='body-1'>{body}</Text>
@@ -277,7 +285,7 @@ function ClaimPromptCard({
 				parent='ClaimProfileModal'
 				styleType='secondary'
 				styleSize='lg'
-				className='w-fit'
+				className='w-full md:w-fit'
 				onClick={onNotify}
 				iconRight={<IconResolver icon='arrow-up-right' className='h-4 w-4' />}
 			>


### PR DESCRIPTION
Follow-up to #234, found while verifying its result against the frames with the `marketing-ui-clone` workflow (element geometry and computed styles) rather than the raster harness, which the skill warns is blind to exactly this class of error.

## The defect

The in-column claim card's heading was on `heading-sm`. That was a by-name guess: Figma names the style `heading-lg`, and gp-marketing's `heading-lg` is 48/60, so `heading-sm` looked like the nearer match. The two scales do not line up.

| | desktop (1440) | mobile (375) |
|---|---|---|
| Figma frame (D 1958:108619 / E 1928:99467) | 32/44 | 32/44 |
| `heading-sm` as shipped | 32/40 | 24/30 |
| `section-heading` (this PR) | 32/44 | 32/44 |

`heading-sm` is a responsive ramp carrying a 125% line-height, so it only reaches 32px at ≥1440 and still lands 4px short on leading; on the mobile artboard it collapses to 24/30 where the frame is still 32/44. `section-heading` is the repo's flat 32/44 and is deliberately excluded from the stepped media queries in `typography.css` for this exact reason.

Two other things off the mobile artboard: the text block's gap is 12px there (16px from `md` up), and the button is full-width.

## Not fixed here

Three remaining divergences are shared-token decisions rather than bugs in this card, so patching them here would fix one surface and desync the rest. Logged in `harness/FOLLOWUPS.md` for a design-system call:

- `body-1` uses a percentage line-height where Figma fixes it in px
- the `Button` label's 21px leading
- the 1200px container against the frame's 1280px CTA panel

## Test plan

- [x] `npm run typecheck`
- [x] `npm test` — 801 pass, 0 fail
- [x] Heading measured at 32/44 on both the 1440 and 375 artboards

Made with [Cursor](https://cursor.com)