### PR TITLE
Report completed notify submissions to Segment

### DIFF
--- a/src/components/people/ClaimProfileModal.tsx
+++ b/src/components/people/ClaimProfileModal.tsx
@@ -4,7 +4,7 @@ import * as Dialog from '@radix-ui/react-dialog';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 
-import { trackEvent } from '~/lib/analytics';
+import { trackPersonProfileNotifySubmitted } from '~/lib/analytics';
 import { buildClaimRequestBody } from '~/lib/claimRequest';
 import { Button } from '~/ui/Inputs/Button';
 import { TextInput } from '~/ui/Inputs/TextInput';
@@ -80,7 +80,11 @@ export function NotifyForm({
 				}),
 			});
 			if (!res.ok) throw new Error('Submission failed');
-			trackEvent('Person Profile Notify Submitted', { personId });
+			// After the 201, so the count means completed asks. This is the signal
+			// marketing automates on: gp-api's HubSpot counter only ever sees the
+			// subjects that resolve to a single CRM contact — see
+			// trackPersonProfileNotifySubmitted.
+			trackPersonProfileNotifySubmitted({ personId });
 			setIsSuccess(true);
 		} catch {
 			setError('root', { message: 'Something went wrong. Please try again.' });

--- a/src/components/people/claimFlow.test.tsx
+++ b/src/components/people/claimFlow.test.tsx
@@ -47,6 +47,7 @@ let root: Root;
 let scrollCalls: ScrollCall[];
 let navigations: string[];
 let trackedEvents: { name: string; props?: Record<string, unknown> }[];
+let segmentEvents: { name: string; props?: Record<string, unknown> }[];
 let dataLayer: Record<string, unknown>[];
 let fetchCalls: { url: string; body: Record<string, unknown> }[];
 let fetchOk: boolean;
@@ -69,6 +70,7 @@ beforeEach(() => {
 	scrollCalls = [];
 	navigations = [];
 	trackedEvents = [];
+	segmentEvents = [];
 	dataLayer = [];
 	fetchCalls = [];
 	fetchOk = true;
@@ -98,6 +100,9 @@ beforeEach(() => {
 
 	(window as unknown as { amplitude: unknown }).amplitude = {
 		track: (name: string, props?: Record<string, unknown>) => trackedEvents.push({ name, props }),
+	};
+	(window as unknown as { analytics: unknown }).analytics = {
+		track: (name: string, props?: Record<string, unknown>) => segmentEvents.push({ name, props }),
 	};
 	(window as unknown as { dataLayer: unknown }).dataLayer = dataLayer;
 
@@ -147,6 +152,25 @@ async function click(element: Element) {
 		element.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true, cancelable: true }));
 		await flush();
 	});
+}
+
+/**
+ * Types into a react-hook-form field.
+ *
+ * The value goes through the prototype setter so it bypasses the setter React
+ * installs on the element, which is what makes React's value tracker notice a
+ * change. `input` is what React listens to normally; the focus and `keyup` are
+ * what its Internet Explorer fallback listens to (see the shims in
+ * `beforeEach`). Firing all of them makes this work whichever path React took,
+ * and the tracker means only one change is delivered either way.
+ */
+function setInputValue(input: HTMLInputElement, value: string) {
+	const setter = Object.getOwnPropertyDescriptor(dom.window.HTMLInputElement.prototype, 'value')!.set!;
+	input.focus();
+	setter.call(input, value);
+	input.dispatchEvent(new dom.window.Event('input', { bubbles: true }));
+	input.dispatchEvent(new dom.window.KeyboardEvent('keyup', { bubbles: true }));
+	input.dispatchEvent(new dom.window.Event('change', { bubbles: true }));
 }
 
 const personId = '11111111-1111-4111-8111-111111111111';
@@ -252,5 +276,77 @@ describe('the claim band hands the candidate to Win sign-up', () => {
 		await click(cta);
 
 		expect(fetchCalls).toEqual([]);
+	});
+});
+
+/**
+ * The notify count marketing automates on.
+ *
+ * gp-api also files these into the subject's HubSpot `candidate_profile_requests`,
+ * but only for a subject the civics mart resolves to exactly one HubSpot contact —
+ * a person with none, or with an ambiguous cluster, is skipped without an error
+ * anywhere. Notify is aimed at exactly those thinly-known people, so the CRM
+ * number is a lower bound of unknown tightness and this event is the honest one.
+ *
+ * The form is mounted directly rather than through the dialog, as in
+ * claimFormIds.test.tsx: Radix's click delegation is unreliable under JSDOM and
+ * the submission path is identical either way.
+ */
+describe('a completed notify submission is reported to marketing', () => {
+	const NOTIFY_EVENT = 'Person Profile Notify Submitted';
+	const email = 'visitor@example.com';
+
+	async function submitNotifyForm() {
+		const { NotifyForm } = await import('./ClaimProfileModal');
+		await render(React.createElement(NotifyForm, { personId, displayName }));
+
+		const form = document.querySelector<HTMLFormElement>('form#person-claim-notify')!;
+
+		await act(async () => {
+			setInputValue(form.querySelector<HTMLInputElement>('input[name="email"]')!, email);
+			await flush();
+		});
+		await act(async () => {
+			form.dispatchEvent(new dom.window.Event('submit', { bubbles: true, cancelable: true }));
+			await flush();
+			await flush();
+		});
+	}
+
+	test('fires to Segment with the subject and the page, once gp-api has accepted it', async () => {
+		await submitNotifyForm();
+
+		expect(fetchCalls).toHaveLength(1);
+		expect(segmentEvents).toEqual([
+			{ name: NOTIFY_EVENT, props: { personId, page_path: '/people/example-person' } },
+		]);
+	});
+
+	/**
+	 * Amplitude carried this event before Segment did. Both sinks are kept, and
+	 * kept identical, so a marketing audience and a product funnel built on the
+	 * same name cannot disagree about what a notify is.
+	 */
+	test('fires the same event to Amplitude', async () => {
+		await submitNotifyForm();
+
+		expect(trackedEvents.filter(e => e.name === NOTIFY_EVENT)).toEqual([
+			{ name: NOTIFY_EVENT, props: { personId, page_path: '/people/example-person' } },
+		]);
+	});
+
+	/**
+	 * Firing on click instead of on the response would make the number "people who
+	 * pressed Submit", which is not what a nudge count means and is not something
+	 * an automation can act on.
+	 */
+	test('stays silent when gp-api rejects the submission', async () => {
+		fetchOk = false;
+
+		await submitNotifyForm();
+
+		expect(fetchCalls).toHaveLength(1);
+		expect(segmentEvents).toEqual([]);
+		expect(trackedEvents.filter(e => e.name === NOTIFY_EVENT)).toEqual([]);
 	});
 });

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -6,6 +6,20 @@ export function trackEvent(eventName: string, eventProperties?: Record<string, u
 	window.amplitude?.track(eventName, eventProperties);
 }
 
+/**
+ * The Segment sink, which is a different destination set from {@link trackEvent}'s
+ * Amplitude — Segment is what marketing builds automation on, because its HubSpot
+ * destination lands events on the CRM side without anyone shipping code.
+ *
+ * The snippet in `~/ui/Segment` is the stub queue, so `analytics.track` exists and
+ * buffers from the moment the inline script runs; a call made before analytics.js
+ * finishes downloading is replayed, not dropped.
+ */
+export function trackSegmentEvent(eventName: string, eventProperties?: Record<string, unknown>): void {
+	if (typeof window === 'undefined') return;
+	window.analytics?.track(eventName, eventProperties);
+}
+
 /** Click-to-call MOFU CTA (component_clickToCallBlock). */
 export function trackClickToCallCtaViewed(props: { page_path: string | null }): void {
 	trackEvent('Click to Call CTA Viewed', { page_path: props.page_path });
@@ -17,6 +31,38 @@ export function trackClickToCallCtaClicked(props: { page_path: string | null }):
 
 export function trackClickToCallPhoneSubmitted(props: { page_path: string | null }): void {
 	trackEvent('Click to Call Phone Submitted', { page_path: props.page_path });
+}
+
+/**
+ * A completed notify submission on an unclaimed /people profile: a visitor has
+ * asked us to nudge `personId` to finish their profile, and gp-api has accepted
+ * the lead. Call it on success, never on click — the point of the number is
+ * completed asks.
+ *
+ * It goes to Segment as well as Amplitude because the CRM-side count marketing
+ * would otherwise automate on, the HubSpot contact property
+ * `candidate_profile_requests`, is only a lower bound. gp-api writes it solely
+ * when the SUBJECT resolves to exactly one HubSpot contact in the civics person
+ * mart (`mart_civics.people.hs_contact_id`, which the mart nulls for a person
+ * whose identity cluster carries zero or several contacts), and it deliberately
+ * mints nothing for a person the CRM has never seen — see
+ * `CrmPersonProfilesService.syncClaimRequestCount` in gp-api. Notify exists for
+ * the people we hold the least data on, so the population that write skips is
+ * the population the number is meant to describe, and it skips them without an
+ * error anywhere: the call is detached from the request and swallows its own
+ * failures. Segment sees every completed submission whatever the CRM knows.
+ *
+ * `page_path` is passed explicitly, as in {@link trackSignUpClicked}. Nothing in
+ * this module attaches it, and Segment's snippet puts the path in event
+ * *context* rather than in properties, so a property-keyed audience would not
+ * find it otherwise.
+ */
+export function trackPersonProfileNotifySubmitted(props: { personId: string }): void {
+	const pagePath = typeof window !== 'undefined' ? window.location.pathname : null;
+	const properties = { personId: props.personId, page_path: pagePath ?? null };
+
+	trackEvent('Person Profile Notify Submitted', properties);
+	trackSegmentEvent('Person Profile Notify Submitted', properties);
 }
 
 /**

--- a/src/types/segment.d.ts
+++ b/src/types/segment.d.ts
@@ -1,0 +1,19 @@
+declare global {
+	interface Window {
+		/**
+		 * Segment's analytics.js, installed by the inline snippet in `~/ui/Segment`.
+		 * Optional because that snippet runs `afterInteractive`, so anything firing
+		 * during hydration can still find it absent.
+		 *
+		 * Only the methods this app calls are declared. The snippet exposes the full
+		 * analytics.js surface; widen this as call sites need it rather than
+		 * importing Segment's types, which would pull the SDK into the bundle for a
+		 * script we load from their CDN.
+		 */
+		analytics?: {
+			track(eventName: string, eventProperties?: Record<string, unknown>): void;
+		};
+	}
+}
+
+export {};


### PR DESCRIPTION
## What this is

Marketing asked whether the HubSpot property that counts notify requests is being incremented properly, and if not, to fire a Segment event they can automate on instead.

**Verdict: the property is empty. Nothing has been written to it since the counter shipped, so no automation can be built on it today.** The code that writes it is sound; it simply has not run.

## The production signal

Measured against the `grafanacloud-prom` datasource.

- **`person_profile_claim_request_crm_sync_count_total` has zero samples.** An instant query returns nothing, and a range query at daily resolution from `now-90d` to `now` returns nothing.
- **This is not a telemetry gap.** `person_profile_public_request_count_total` is declared in the same module, on the same meter, behind the same `isOtelEnabled()` gate, and reports normally over `now-30d` — 171,777 / 80,462 / 304,497 / 72,546 across consecutive two-day buckets. Metrics from this service reach Prometheus. It also means `PublicPersonProfilesController` is mounted and serving in that deployment, since the GET being counted there and the POST the notify form targets are the same controller.
- **`person_profile_mutation_count_total` totals 8, all time.** Person profiles are read enormously and written almost never.

Two things sharpen that, and one caveat blunts it.

**The branch never executed — this is not a failed HubSpot write.** `syncClaimRequestCount` records exactly one sample on every exit path, including `skipped` when HubSpot is unconfigured and `no_contact` when the subject resolves to no CRM contact. Zero samples under *any* `result` value therefore means the method never ran, which means the `dto.source === ProfileClaimRequestSource.notify` branch in the controller never ran. A missing HubSpot token, a warehouse outage, or the `hs_contact_id` gap described below would all have produced series; none did.

**The window is about 8 days, not 90.** The instrumentation was added by the same PR as the counter (omni #1235, merged 2026-08-12), so it could not have recorded anything before that date whatever happened upstream. The 90-day query is empty largely because the metric did not exist for 82 of those days. The production deploy date was not verified from here, so the real observation window is 8 days or less.

**Caveat.** Most Prometheus client libraries do not export a labelled counter until a label combination is first observed. "No series" is consistent with "never incremented" and does not by itself prove the code path is unreachable.

### What this does not establish

It does **not** show that the notify form is broken, and the evidence cannot tell these apart:

1. No visitor has completed a notify submission in the window.
2. Submissions are being completed but are not reaching gp-api.
3. Submissions are reaching gp-api without `source: 'notify'`. The DTO leaves `source` optional and deliberately undefaulted, so such a request stores a perfectly good lead row and then skips the counter branch, emitting no metric at all.

Given that writes to person profiles total 8 across all time, a handful of days with no completed notify submissions is unremarkable rather than alarming.

The cheapest way to separate them is a single read against gp-api's Postgres: `select source, count(*) from person_profile_claim_request group by source`. Rows with a null `source` point at (3); no rows at all narrows to (1) or (2).

### Two dead ends, so nobody repeats them

- **Loki does not carry gp-api's request logs.** A control query for `public-person-profiles` across 7.2M scanned lines over 30 days in `grafanacloud-logs` returns nothing. The absence of `claim-request` there is evidence of nothing.
- **`person_profile_mutation_count_total` is labelled `action`**, not `operation` / `type` / `result` / `status`. Querying the latter returns empty label sets and looks like missing instrumentation. Its values are `create`, `update`, `publish`, `unpublish`, `delete`, `set_issues`, alongside `environment`.

## The structural gap, for when volume exists

Separately from the counter being empty, the write is partial by construction. It only fires for a subject the civics person mart resolves to **exactly one** HubSpot contact: `mart_civics.people.hs_contact_id` is null both for a person the CRM has never seen and for a person whose identity cluster carries several, and `CrmPersonProfilesService.syncClaimRequestCount` deliberately creates nothing in that case — a visitor nudging someone should not mint a CRM record for them. Notify exists for the people we hold the least data on, so the subjects it would skip are disproportionately the subjects the number is about, and it skips them silently: the call is detached from the request and swallows its own errors so a HubSpot outage can never fail a visitor's submission.

That is the right trade for the visitor and the wrong one for anyone reading the number. It is not why the property is empty today — there has been nothing for it to drop — but it is what would bite once submissions start arriving.

For completeness, everything about the arithmetic is right, which is why **this PR does not touch gp-api**:

- Not a read-modify-write. It recomputes `count(ProfileClaimRequest where personId, source=notify)` from our own Postgres and writes that total wholesale, so concurrent submissions cannot lose an increment, a retried timeout cannot double-count, and any later submission repairs a drifted value.
- No null / first-write hazard. `count()` is always a number; the first notify writes `"1"`, and the property is number-typed in HubSpot with the API taking it as a string.
- Right object. It writes the **subject's** contact, not the submitter's.
- Correctly wired. The proxy route posts `/v1/public-person-profiles/claim-request` with `personId` / `requesterEmail` / `requesterName` / `marketingConsent` / `source`, which is exactly what gp-api's strict Zod DTO accepts.

## The event

Fired from `NotifyForm` after gp-api returns, never on click, so the number means completed asks.

```
Person Profile Notify Submitted
  personId   string  the subject being notified about (civics gp_person_id)
  page_path  string  e.g. /people/jane-rivera-1a2b3c4d
```

Sent to Segment (`window.analytics.track`) and, unchanged, to Amplitude, under the same name and the same properties so a marketing audience and a product funnel cannot disagree about what a notify is. `page_path` is passed explicitly, as `trackSignUpClicked` does: nothing in the analytics module attaches it, and Segment's snippet puts the path in event *context* rather than in properties, where a property-keyed audience would not find it.

Beyond giving marketing a number they can automate on, this is also the instrument that settles the ambiguity above. It fires client-side on gp-api's acceptance, so from the next deploy onward, silence means nobody is completing the form and traffic means submissions are landing — a distinction nothing we have today can make.

## Also worth knowing

`source: 'owner'` has had no caller since #234/#239 retired the band's form for a link into Win sign-up. The value is still exercised by `claimRequest.test.ts` and `route.test.ts`, and gp-api still stores and discriminates on it, but no production code path sends it. Left in place: it is what keeps a future owner-side form from being counted as visitor demand, and `claimFlow.test.tsx` already pins that the band posts nothing.

## Test plan

- [x] `npm test` — 804 pass, 0 fail (develop is 801; three added here)
- [x] `npm run typecheck` clean
- [ ] `npm run lint` — could not run in this worktree: its `node_modules` is a symlink, which makes `next lint` resolve `@typescript-eslint` twice and bail. Reproduces identically on pristine `develop` in the same worktree, so it is the symlink and not this change; CI's real install is the check that matters.
- New tests cover: the Segment event fires with `personId` + `page_path` once gp-api has accepted the submission, the Amplitude event still fires identically, and neither fires when gp-api rejects it.
