### PR TITLE
Stop the candidate cards saying we empowered someone

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,12 @@ bower_components
 build/Release
 
 # Dependency directories
+# Both spellings: the trailing slash matches only a real directory, and the
+# worktree workflow this repo uses often symlinks node_modules at a sibling
+# checkout instead of installing into each one. A symlink is a blob, so the
+# slashed form does not cover it and `git add -A` will happily commit a path
+# that is dangling on every other machine.
+node_modules
 node_modules/
 jspm_packages/
 

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/nikao/workspace/goodparty.org/gp-marketing-pledge-copy/node_modules

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/nikao/workspace/goodparty.org/gp-marketing-pledge-copy/node_modules

--- a/src/components/people/personSectionOverrides.tsx
+++ b/src/components/people/personSectionOverrides.tsx
@@ -598,7 +598,22 @@ function buildSidebar(view: PersonProfileView): ElectionsSidebarProps | undefine
 	};
 }
 
-/** Maps interlink cards to CandidatesBlock cards, dropping any without a link. */
+/**
+ * Maps interlink cards to CandidatesBlock cards, dropping any without a link.
+ *
+ * The cards say nothing about GoodParty.org's relationship to the person. They
+ * used to read "Empowered by GoodParty.org", the same claim-keyed line the hero
+ * carried until marketing replaced it with the three pledge lines (2026-08-17,
+ * approved by Emily and Jack — see `pledgeAttribution`); the line was rewritten
+ * on the hero and missed here, on the same page, about other named people.
+ *
+ * They carry none of the three replacements instead of one of them, because
+ * `RelatedPersonCard` has no pledge flag: neither `buildOtherCandidateCards` nor
+ * `buildNearbyOfficialCards` reads one, so the card cannot tell "has not taken
+ * it" from "we did not look". The mark and the yellow frame stay — those follow
+ * `isGoodPartyCandidate` and are branding, not an assertion (Figma draws the
+ * badge on these cards, and `empoweredFirst` still sorts by it).
+ */
 function toCandidateCards(cards: RelatedPersonCard[]): CandidateCard[] {
 	return cards
 		.filter(c => Boolean(c.href))
@@ -608,6 +623,7 @@ function toCandidateCards(cards: RelatedPersonCard[]): CandidateCard[] {
 			partyAffiliation: c.subtitle ?? '',
 			href: c.href!,
 			isGoodPartyCandidate: c.isEmpowered,
+			attribution: 'none' as const,
 			...(c.avatarUrl ? { avatar: c.avatarUrl } : {}),
 		}));
 }

--- a/src/components/people/relatedCardAttribution.test.tsx
+++ b/src/components/people/relatedCardAttribution.test.tsx
@@ -1,0 +1,168 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { JSDOM } from 'jsdom';
+import * as React from 'react';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+/**
+ * Pins that the related-candidate cards on a person profile say nothing about
+ * GoodParty.org's relationship to the people on them.
+ *
+ * They read "Empowered by GoodParty.org" — word for word the line the hero
+ * carried until marketing replaced it with the three pledge lines (2026-08-17,
+ * approved by Emily and Jack; see `pledgeAttributionCopy.test.tsx`). The hero
+ * was rewritten and these were missed, so the retired sentence went on being
+ * published about other named people on the very same page.
+ *
+ * None of the three replacements can go here. `RelatedPersonCard` carries no
+ * pledge flag — neither `buildOtherCandidateCards` nor `buildNearbyOfficialCards`
+ * reads one — so a card cannot tell "has not taken the pledge" from "we never
+ * looked", and the negative line is already false for anyone who pledged through
+ * Serve or by hand rather than on a candidacy.
+ *
+ * The GoodParty badge and yellow frame are branding, not an assertion, and stay
+ * — the same split ProfileHero draws between `showBrandMark` and `attribution`.
+ * They are asserted here too, so a change that dropped the whole GoodParty
+ * treatment cannot pass as a copy fix.
+ *
+ * Mounts the section's own content node, like the other DOM tests in this folder.
+ */
+
+const DOM_GLOBALS = [
+	'Node',
+	'NodeFilter',
+	'Element',
+	'HTMLElement',
+	'HTMLAnchorElement',
+	'DocumentFragment',
+	'DOMRect',
+	'Event',
+	'CustomEvent',
+	'MouseEvent',
+	'KeyboardEvent',
+	'FocusEvent',
+	'MutationObserver',
+] as const;
+
+let dom: JSDOM;
+let root: Root | null = null;
+
+beforeEach(() => {
+	dom = new JSDOM('<!DOCTYPE html><html><body><div id="root"></div></body></html>', {
+		url: 'http://localhost/people/example-person',
+		pretendToBeVisual: true,
+	});
+	const { window } = dom;
+
+	globalThis.window = window as unknown as Window & typeof globalThis;
+	globalThis.document = window.document;
+	globalThis.navigator = window.navigator;
+	globalThis.getComputedStyle = window.getComputedStyle.bind(window);
+
+	for (const name of DOM_GLOBALS) {
+		(globalThis as Record<string, unknown>)[name] = (window as unknown as Record<string, unknown>)[name];
+	}
+
+	(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterEach(async () => {
+	await unmount();
+	dom.window.close();
+});
+
+/** Every case renders more than once, and React allows one root per container. */
+async function unmount() {
+	const current = root;
+	root = null;
+	if (!current) return;
+	await act(async () => {
+		current.unmount();
+	});
+}
+
+async function render(element: React.ReactElement) {
+	await unmount();
+	await act(async () => {
+		root = createRoot(document.getElementById('root')!);
+		root.render(element);
+		await new Promise<void>(resolve => {
+			dom.window.setTimeout(resolve, 0);
+		});
+	});
+}
+
+/**
+ * Renders the profile section whose heading starts with `headingPrefix`, driving
+ * the real `buildPersonSectionOverrides` output rather than hand-built card
+ * props — the mapping is the thing that was wrong, so the test has to go through
+ * it.
+ */
+async function renderSection(slug: string, headingPrefix: string) {
+	const { getDevPersonProfileView } = await import('~/lib/devPeopleProfileFixtures');
+	const { buildPersonSectionOverrides } = await import('./personSectionOverrides');
+
+	const view = getDevPersonProfileView(slug);
+	if (!view) throw new Error(`no dev fixture for ${slug}`);
+	const cards = buildPersonSectionOverrides(view).component_profileContentBlock?.contentCards ?? [];
+	const section = cards.find(card => card.heading?.startsWith(headingPrefix));
+	if (!section) throw new Error(`no "${headingPrefix}…" section on ${slug}`);
+
+	await render(<>{section.content}</>);
+}
+
+function cards(): Element[] {
+	return [...document.querySelectorAll("[data-component='CandidatesCard']")];
+}
+
+/** Cards carrying the GoodParty treatment, by the yellow frame the variant paints. */
+function goodPartyCards(): Element[] {
+	return cards().filter(card => card.className.includes('border-bright-yellow-600'));
+}
+
+/** The GoodParty.org mark, by the viewBox of its artwork. */
+function markCount(scope: ParentNode = document): number {
+	return scope.querySelectorAll("svg[viewBox='35 42 137 116']").length;
+}
+
+describe('the related-candidate cards make no GoodParty.org claim about the people on them', () => {
+	test('a candidate\u2019s "Other Candidates" cards', async () => {
+		await renderSection('allen-slagle-74eee01a', 'Other Candidates');
+
+		// The premise: the fixture really does seed an empowered card here, so the
+		// assertion below cannot pass by there being nothing to say it about.
+		expect(goodPartyCards().length).toBeGreaterThan(0);
+		expect(document.body.textContent).not.toContain('Empowered by GoodParty.org');
+	});
+
+	test('an officeholder\u2019s "Nearby Officials" cards', async () => {
+		await renderSection('tracy-good-ecff49d3', 'Nearby Officials');
+
+		expect(goodPartyCards().length).toBeGreaterThan(0);
+		expect(document.body.textContent).not.toContain('Empowered by GoodParty.org');
+	});
+
+	test('the badge and the yellow frame survive \u2014 only the sentence goes', async () => {
+		await renderSection('allen-slagle-74eee01a', 'Other Candidates');
+
+		for (const card of goodPartyCards()) {
+			expect(markCount(card)).toBe(1);
+		}
+	});
+});
+
+describe('the line is retired on /people, not everywhere', () => {
+	test('the shared card still carries it by default', async () => {
+		// The Sanity claim block's example card still means "Empowered by
+		// GoodParty.org" by the badge; marketing scoped the pledge copy to the
+		// person profiles. A future edit that deletes the string from the shared
+		// component rather than suppressing it on this one surface fails here.
+		const { CandidatesCard } = await import('~/ui/CandidatesCard');
+
+		await render(
+			<CandidatesCard name='Example Person' partyAffiliation='Independent' href='/people/example-person' isGoodPartyCandidate />,
+		);
+
+		expect(document.body.textContent).toContain('Empowered by GoodParty.org');
+	});
+});

--- a/src/components/people/relatedCardAttribution.test.tsx
+++ b/src/components/people/relatedCardAttribution.test.tsx
@@ -145,7 +145,13 @@ describe('the related-candidate cards make no GoodParty.org claim about the peop
 	test('the badge and the yellow frame survive \u2014 only the sentence goes', async () => {
 		await renderSection('allen-slagle-74eee01a', 'Other Candidates');
 
-		for (const card of goodPartyCards()) {
+		// Same premise guard as above, and it earns its place twice over here: an
+		// empty list would make the loop below assert nothing at all, so a class
+		// rename or a fixture change that stopped the frame matching would read as
+		// a pass rather than as the lost coverage it is.
+		const branded = goodPartyCards();
+		expect(branded.length).toBeGreaterThan(0);
+		for (const card of branded) {
 			expect(markCount(card)).toBe(1);
 		}
 	});

--- a/src/lib/devPeopleProfileFixtures.ts
+++ b/src/lib/devPeopleProfileFixtures.ts
@@ -176,8 +176,10 @@ function richExperience(persona: PersonPersona): ExperienceItem[] {
 function relatedCards(prefix: string, count: number, empoweredEvery = 3): RelatedPersonCard[] {
 	const NAMES = ['Garrett Borton', 'Nathan Todd', 'Don Taylor', 'Henry Nessul', 'Vera Huber', 'Gilian Sears', 'Cheri Steinmetz', 'Eric Barlow', 'Marcia Bean', 'Lori Smallwood', 'Serena Lipp', 'Abby Angelos'];
 	// Realistic party mix, but ONLY non-partisan/independent people can be
-	// GoodParty-empowered — a Republican/Democrat card must never show the
-	// "Empowered by GoodParty.org" badge (we only empower non-partisan/3rd-party).
+	// GoodParty-empowered — a Republican/Democrat card must never carry the
+	// GoodParty badge and frame (we only empower non-partisan/3rd-party). The
+	// cards no longer say "Empowered by GoodParty.org" beneath it; see
+	// `toCandidateCards`.
 	const PARTIES = ['Nonpartisan', 'Republican', 'Independent', 'Democrat'];
 	return Array.from({ length: count }, (_, i) => {
 		const subtitle = PARTIES[i % PARTIES.length]!;

--- a/src/ui/CandidatesCard.mdx
+++ b/src/ui/CandidatesCard.mdx
@@ -69,11 +69,21 @@ Flag indicating this is a GoodParty-empowered candidate. When `true`, the card d
 - Yellow border (`border-bright-yellow-600`)
 - Yellow hover background (`hover:bg-bright-yellow-50`)
 - GoodParty logo badge overlay on avatar
-- "Empowered by GoodParty.org" text in gray
+- "Empowered by GoodParty.org" text in gray, unless `attribution` is `'none'`
 
 **Type:** `boolean`
 
 **Default:** `false`
+
+#### `attribution` (optional)
+
+Whether the card states GoodParty.org's relationship to the person. `'none'` keeps the badge and the yellow frame but drops the line.
+
+The `/people` person profiles pass `'none'`: marketing retired the claim-keyed "Empowered by GoodParty.org" framing there on 2026-08-17 in favour of three pledge-keyed lines, and these cards carry no pledge flag to key those to. The Sanity claim block's example card keeps the default.
+
+**Type:** `'empowered' | 'none'`
+
+**Default:** `'empowered'`
 
 #### `className` (optional)
 
@@ -118,7 +128,7 @@ Internal key used by CandidatesBlock for React list rendering.
 - Border: `border-bright-yellow-600` (yellow)
 - Hover: Shadow and yellow background (`hover:shadow-md hover:bg-bright-yellow-50`)
 - Badge: GoodParty logo positioned `absolute -bottom-0.5 -right-0.5` on avatar
-- "Empowered by GoodParty.org": Displayed in `text-neutral-500` (gray), `caption` styleType
+- "Empowered by GoodParty.org": Displayed in `text-neutral-500` (gray), `caption` styleType — suppressed when `attribution` is `'none'`
 
 ## Avatar Fallback
 

--- a/src/ui/CandidatesCard.stories.tsx
+++ b/src/ui/CandidatesCard.stories.tsx
@@ -56,6 +56,17 @@ export const GoodParty: Story = {
 	},
 };
 
+/** How the card renders on a `/people` person profile — badge and frame, no line. */
+export const GoodPartyNoAttribution: Story = {
+	args: {
+		name: 'Firstname Lastname',
+		partyAffiliation: 'Party Affiliation',
+		href: '/people/firstname-lastname',
+		isGoodPartyCandidate: true,
+		attribution: 'none',
+	},
+};
+
 export const GoodPartyWithPhoto: Story = {
 	args: {
 		name: 'Firstname Lastname',

--- a/src/ui/CandidatesCard.tsx
+++ b/src/ui/CandidatesCard.tsx
@@ -36,11 +36,27 @@ export type CandidatesCardProps = {
 	partyAffiliation: string;
 	href: string;
 	isGoodPartyCandidate?: boolean;
+	/**
+	 * Whether the card states GoodParty.org's relationship to the person beneath
+	 * their name. Separate from `isGoodPartyCandidate`, which carries the mark
+	 * and the yellow frame — the same split ProfileHero draws between
+	 * `showBrandMark` and `attribution`: the mark says this is one of our
+	 * candidates, the line makes an assertion about the person.
+	 *
+	 * `/people` passes `'none'`. Marketing retired the claim-keyed "Empowered by
+	 * GoodParty.org" framing on that surface (2026-08-17, approved by Emily and
+	 * Jack) in favour of three pledge lines, and this card carries no pledge
+	 * flag to key those to. The default keeps the line, because the only other
+	 * card that sets `isGoodPartyCandidate` is the Sanity claim block's example
+	 * card, on marketing pages the decision did not cover.
+	 */
+	attribution?: 'empowered' | 'none';
 	_key?: string;
 };
 
 export const CandidatesCard = memo(function CandidatesCard(props: CandidatesCardProps) {
 	const isGoodParty = props.isGoodPartyCandidate === true;
+	const showAttribution = isGoodParty && (props.attribution ?? 'empowered') === 'empowered';
 	const { base, baseStandard, baseGoodParty, avatarWrapper, rightColumn, contentWrapper, content, name, empowered, footerWrapper, link, badge } = styles();
 
 	// Generate initials from name if no avatar
@@ -79,7 +95,7 @@ export const CandidatesCard = memo(function CandidatesCard(props: CandidatesCard
 				</div>
 
 				<div className={footerWrapper()}>
-					{isGoodParty ? (
+					{showAttribution ? (
 						<Text as='p' styleType='caption' className={empowered()}>
 							Empowered by GoodParty.org
 						</Text>

--- a/src/ui/ProfileHero.mdx
+++ b/src/ui/ProfileHero.mdx
@@ -60,11 +60,29 @@ The candidate's profile image as a hosted URL. Used on dynamic candidate profile
 
 #### `isEmpowered` (optional)
 
-When true, shows the GoodParty logo badge on the avatar and the "Empowered by GoodParty.org" attribution. Set from claimed campaign lookup on candidate profile pages.
+When true, shows the GoodParty logo badge on the avatar and the "Empowered by GoodParty.org" attribution. Set from claimed campaign lookup on candidate profile pages. This is the legacy fallback, used only where `attribution` is not passed — today that is `/candidate/[...slug]`.
 
 **Type:** `boolean`
 
 **Default:** `false`
+
+#### `attribution` (optional)
+
+The line under the office. Overrides `isEmpowered` when passed.
+
+The `/people` person profiles pass one of the three pledge values: marketing replaced the claim-keyed "Empowered by GoodParty.org" / "Not Endorsed by GoodParty.org" pair there on 2026-08-17 with statements about the GoodParty.org pledge. `personSectionOverrides.pledgeAttribution` decides which; `pledgeAttributionCopy.test.tsx` pins the wording.
+
+**Type:** `'empowered' | 'pledged' | 'notPledged' | 'pledgeIneligible' | 'none'`
+
+**Default:** derived from `isEmpowered`
+
+#### `showBrandMark` (optional)
+
+Whether the GoodParty.org mark paints, on the portrait and beside the attribution. Separate from `attribution` because the mark says the page is a GoodParty.org profile while the line asserts a fact about the person — on `/people` those come from different inputs (claimed vs pledged).
+
+**Type:** `boolean`
+
+**Default:** `attribution === 'empowered'`
 
 #### `backgroundColor` (optional)
 
@@ -96,7 +114,7 @@ When a profile image is provided (`profileImageUrl` or `profileImage`):
 
 ## Attribution
 
-When `isEmpowered` is true, the component displays "Empowered by GoodParty.org" with the GoodParty logo below the office title. Text color adapts to the background variant (white on midnight, dark on cream).
+The line under the office title comes from `attribution`, falling back to `isEmpowered` ("Empowered by GoodParty.org"). Affirmative lines get the semibold Figma treatment beside the GoodParty logo; the negative and ineligible pledge lines get the grey disclaimer style, so a sentence saying someone has *not* done something cannot read as a badge. Text color adapts to the background variant (white on midnight, dark on cream).
 
 ## Image Fallback
 


### PR DESCRIPTION
## The decision, and where it is written down

**Marketing, 2026-08-17, approved by Emily and Jack:** on the `/people` person profiles, the GoodParty.org attribution line is a statement about the **pledge**, in three exact wordings, replacing the claim-keyed "Empowered by GoodParty.org" / "Not Endorsed by GoodParty.org" pair. Shipped in [#239](https://github.com/thegoodparty/gp-marketing/pull/239) (`b8a9074`).

Cited in-repo at `src/components/people/pledgeAttributionCopy.test.tsx:8-12`, which pins the words, and dated the same way in `PersonClaimCTABand.tsx:15`, `claimFormIds.test.tsx:116` and `personSectionOverrides.tsx:701` — all three other pieces of the same 2026-08-17 round.

**The decision is scoped by surface, explicitly.** #239's body: *"`'empowered'` stays because `/candidate/[...slug]` shares this component and reaches it through the legacy `isEmpowered` fallback. That surface was not part of the request, so it still reads 'Empowered by GoodParty.org' and there is a test pinning that."*

So, answering the question the brief raised: **`'empowered'` is not the stale remnant.** It is reachable (`/candidate/[...slug]/page.tsx:99` passes `isEmpowered` and no `attribution`), deliberate, and test-pinned. The stale remnant is the *card*, which is on a surface the decision did cover.

## What changed, and why nothing replaced it

`toCandidateCards` now passes `attribution: 'none'`, so the related-candidate cards on a person profile — **"Other Candidates for [Position]"** and **"Nearby Officials"** — drop the line.

They carry **nothing** rather than one of the three pledge lines because they have nothing to carry it from: `RelatedPersonCard` has no pledge field, and neither `buildOtherCandidateCards` nor `buildNearbyOfficialCards` reads one. The card literally cannot distinguish "has not taken the pledge" from "we never looked". This is the mismatch the brief predicted, and it is the same mismatch that produced the leftover.

**The badge and the yellow frame stay.** They follow `isGoodPartyCandidate`, Figma draws them on these cards, and `empoweredFirst` still sorts by them. This is #239's own split, applied one component over: the mark says whose candidate this is, the line asserts a fact about the person.

Suppression is **per-surface** (a prop) rather than a deletion from `CandidatesCard`, because the Sanity claim block's example card is the only other thing that sets `isGoodPartyCandidate`, and that is a marketing page the decision did not cover. A test pins the default so a later "just delete the string" cannot quietly retire it there too.

## ⚠️ The false-negative pledge problem — this PR deliberately does not take a position

`Person.isPledged` is rolled up **from candidacies only** (`m_election_api__person.sql`, the `pledged` CTE). It does not include Serve-side elected-office pledges (`ElectedOffice.pledgedAt`), nor the `has_verbal_pledge` / `has_email_pledge` signals that `m_analytics.yaml` folds into the org's own definition of pledged. **"Has Not Taken the GoodParty.org Pledge" is therefore a false statement about some real people today** — the hero already publishes it, and I understand the team is actively deciding what to do about that.

This PR is careful not to make that worse and not to pre-empt the decision:

* It does **not** propagate the negative line onto six more named people per page. If the resolution is "suppress the negative, keep the affirmative and the ineligible" — which is the reading I find most defensible, since those two are true when they render — then this PR is already consistent with it and needs no follow-up.
* If instead the resolution is that the cards should carry pledge lines, that is a **data change first**, not a copy change: `RelatedPersonCard` and both builders would need the flag threaded through. `buildNearbyOfficialCards` could reach it today via `personsById` (`PersonItem.isPledged`); `buildOtherCandidateCards` maps `CandidacyItem` and could not. I deliberately left the data layer alone.

Worth knowing for sizing either option: per `docs/person-spine-pledge-and-claim-linkage-handoff.md`, `is_pledged` is **never written by the ETL** — sampled across 15 states and 69,385 person rows, zero are `true`. So the affirmative line cannot render for anyone in production yet, and the negative renders for everyone.

## Everything I found and deliberately left alone

| left alone | why |
| --- | --- |
| `ProfileHero` `'empowered'` + `ATTRIBUTION_COPY.empowered` | Live and intended on `/candidate/[...slug]`, carved out by name in #239 and pinned by `pledgeAttributionCopy.test.tsx:146`. |
| `personSectionOverrides.tsx` hero `isEmpowered: view.empowered` | **Inert** — `attribution` is always supplied there, so the fallback never fires. But it is not dead weight: `personSectionOverrides.test.ts:462` pins it `false` for the removal states, so if someone later drops `attribution`, a removed profile falling back to "Empowered by GoodParty.org" fails a test instead of shipping. Removing it would delete that net. |
| The Sanity claim block's example card | Marketing pages, outside the 2026-08-17 scope. It never renders on a person profile (`component_claimProfileBlock` is force-suppressed there via `claimed: true`) and `/candidate` uses the banner layout, which draws no example card. **Flagging it anyway** — if marketing wants the illustration to match what `/people` now shows, it is a one-line change plus the Sanity `field_showBadge` default. |
| `positionPageStaticSections.ts:51`, `electionsStaticSections.ts:13` | Different sentences ("See who's been empowered by GoodParty.org…") on elections/position pages, not attribution about a named person. |
| `peopleProfile.ts` `empowered` / `isEmpowered` data semantics | Out of scope by instruction. Note that **production has always rendered this correctly by accident**: both card builders hardcode `isEmpowered: false`, so the retired line only ever appeared under `PEOPLE_DEV_FIXTURES=true` and in Storybook. This is a correctness fix for the day that data lands, not a live copy bug — worth knowing when weighing urgency. |

## Deviations and things I could not verify

* **The frames do draw a line there.** In the person-profile "Other Candidates" cards, the empowered card has a third text node the others lack (`1928:105525`, a `Sub-Title` at the footer row where our line sits). So live now has one fewer line than the frame. Like the pledge copy itself, the new state postdates those frames — #239 noted the same thing — so there is nothing to redraw against yet. Calling it out rather than masking it.
* **I could not read the frame's text**, only the node structure, so I cannot confirm the frame's third line said exactly "Empowered by GoodParty.org" (its node is named `Sub-Title`, where the hero's is named `Empowered Text`).
* **No production screenshots.** As above, the branch is unreachable in prod, so there is nothing live to capture. Verified through the real `buildPersonSectionOverrides` output on dev fixtures instead.

## Also updated

`CandidatesCard.mdx` and `ProfileHero.mdx`. The hero doc still described `isEmpowered` as the whole story and never mentioned `attribution` or `showBrandMark` — a reader would have concluded `/people` still says "Empowered by GoodParty.org". Same rewrite, same miss.

## Tests

`relatedCardAttribution.test.tsx` (new), in the style of `claimPromptCopy.test.tsx` / `pledgeAttributionCopy.test.tsx`. It drives the real `buildPersonSectionOverrides` output rather than hand-built props, since the mapping is what was wrong:

* Other Candidates (state A) and Nearby Officials (state B) contain no "Empowered by GoodParty.org", each **guarded by a premise assertion** that the fixture really does seed an empowered card — otherwise both pass vacuously.
* The badge and yellow frame still render on those cards, so a change that dropped the whole GoodParty treatment cannot pass as a copy fix.
* The shared card still carries the line by default, pinning the suppression as per-surface.

```
npm run typecheck  → clean
npm test           → 845 pass, 0 fail   (logic 794 / dom 51)
```

Baseline on this worktree before the change: **841 pass, 0 fail** (logic 794 / dom 47). So **+4 tests, 0 new failures**. `npm run lint` does not run here — `next lint` reports a plugin conflict resolving `@typescript-eslint` through the symlinked `node_modules`. Environmental; not chased.

## Review round 1

Bugbot and the delegate reviewer both caught that my first commit had tracked this worktree's local `node_modules` symlink — `git add -A` swept it up, and `.gitignore`'s `node_modules/` did not stop it because the trailing slash matches only a real directory while a symlink is stored as a blob. Correct and my error; untracked in `14314e6` with `git rm --cached` so the symlink survives on disk but leaves the index.

Also took their `.gitignore` suggestion, adding the bare `node_modules` beside the slashed form. This repo runs ~20 sibling worktrees that are normally set up with exactly this symlink, so the gap would have caught the next person too.
