### PR TITLE
Release: person profile claim surfaces, pledge copy, and indexing

### DIFF
--- a/harness/FOLLOWUPS.md
+++ b/harness/FOLLOWUPS.md
@@ -270,6 +270,31 @@ intentional? Until that is decided, parity work uses exact values for
 shadcn-derived components. This section is the evidence base — append each new
 "Figma value has no gp-marketing token" case as the loop finds it.
 
+- **Type scale: the SAME name is a different size, and a percentage vs a fixed
+  line-height.** Figma calls the unclaimed content-well card's heading
+  (`1958:108619`) `heading-lg`, but its value is **32/44**; gp-marketing's
+  `heading-lg` is **48/60**. Mapping that name across put the card on
+  `heading-sm`, which only reaches 32px at ≥1440 and carries a **125%**
+  line-height — so it rendered 32/40 at desktop and **24/30** on mobile, where
+  the frame is still 32/44. RESOLVED for this card by using the repo's flat
+  `section-heading` (32/44, deliberately absent from the stepped `@media`
+  blocks — see `_styles/typography.css`), which is the by-value match. The
+  general trap stands: `heading-*` here is a RESPONSIVE ramp, the Figma styles
+  are FLAT, so a name match is a size match at exactly one breakpoint.
+- **`body-1` line-height is a percentage here and fixed in Figma.** Figma's
+  `body 1` is 20/28 desktop and **18/28** mobile — the line-height does not
+  scale. gp-marketing's `--text-body-1--line-height: 140%`, so at the 18px
+  mobile step it computes to **25.2px**, 2.8px tight. Not patched: `body-1` is
+  site-wide type, and overriding it on one card would make that card disagree
+  with every paragraph beside it. Owner: design-system/tokens — decide whether
+  `body-1` should carry a fixed line-height per step.
+- **Button label line-height.** Figma `typography/sm` is 14/20; the shared
+  `Button` renders 14/**21** (default 1.5). One pixel per line on every button
+  on the site — a `Button` change, not a per-surface one.
+- **CTA band panel width.** Figma's CTA Block module is **1280** wide (80px page
+  margin at 1440); live `Container size='xl'` renders **1200** (120px margin),
+  so the blue panel is 40px narrower each side. Shared by the claimed CTA too,
+  so it is a container-token decision rather than a people-profile fix.
 - **Hero band gradient blue `#26498f`** (ProfileHero, Figma frame A `1901:50311`:
   `linear-gradient(156.73deg, #0b1529 68.4%, #26498f 125.1%)`). RESOLVED: promoted
   to the `--goodparty-blue-bright` token (`hsl(220 58% 35%)`, == `#26498f`; a

--- a/harness/FOLLOWUPS.md
+++ b/harness/FOLLOWUPS.md
@@ -14,6 +14,18 @@ are excluded from the 3% gate by band class in `config.mjs` (not masked).
 | I | Sidebar rows/icons | Unclaimed → no owner overlay/office, so Current Term, Office Contact, Office Mailing Address and the gov/Instagram contact icons have **no data**; live correctly renders only Election Date / Political Affiliation / Contact(3). Figma shows the full filled template | people-api (owner claim / office data) | data gap — flag |
 | K, L | Sidebar top rows | Removal frames use a **generic full template**: figma K (a candidate, holds no office) still shows a "Current Term" row, and figma L (a non-running officeholder) still shows an "Election Date" row — both factually inapplicable placeholders. Live renders the semantically-correct rows per persona. Removal also suppresses owner content (`links=[]`) by design | design file (per-persona removal frames) + product (removal suppression) | reference artifact + data suppression — flag |
 
+**Re-verified 2026-08-17** (fresh Figma re-export of `1997:118777` / `1997:118283`):
+**K gated 3.18%**, **L gated 2.58%** — both improved from the 4.41 / 4.13 recorded
+below, and no band is structurally missing on either side. K's remaining 0.18pp
+over tolerance is the same reference artifact: its Figma sidebar rows still read
+literally `[#### - ####]` and `[space for BallotReady data]`, i.e. the frame was
+never filled in for this state. **No new parity gap was found**, so K is left
+failing rather than masked — masking it would hide the day the frames are
+redrawn per-persona and the gap becomes real. K/L structure is now pinned in
+`src/components/people/personSectionOverrides.test.ts` instead, which is where
+absence (stripped avatar, pledge, links, authored sections) can actually be
+asserted; the blurred layout score treats all of those as rounding errors.
+
 ## RESOLVED — sidebar rebuilt to the Figma structure
 
 The sidebar was structurally wrong (a card of labeled URL rows + an "About

--- a/harness/config.mjs
+++ b/harness/config.mjs
@@ -6,7 +6,9 @@
 //
 // This file is plain data (no imports) so every harness script can read it.
 
-export const DEV_ORIGIN = 'http://localhost:3009';
+// `bun run dev` serves 3009, but a second checkout (worktree) usually cannot
+// have that port, so allow an override rather than forcing a temporary edit here.
+export const DEV_ORIGIN = process.env.HARNESS_ORIGIN || 'http://localhost:3009';
 
 // Where the cached Figma frame exports live (figma-A.png … figma-L.png).
 // Re-export from Figma into this folder to refresh the source of truth.

--- a/src/PageSections/ClaimProfileBlockSection.tsx
+++ b/src/PageSections/ClaimProfileBlockSection.tsx
@@ -3,7 +3,6 @@ import { isButtonType, transformButton } from '~/lib/buttonTransformer';
 import type { TokenMap } from '~/lib/resolveTokens';
 import { resolveSectionText } from '~/lib/resolveSectionText';
 import { ClaimProfileBlock } from '~/ui/ClaimProfileBlock';
-import { ClaimProfileModal } from '~/components/people/ClaimProfileModal';
 import { stegaClean } from 'next-sanity';
 
 type Props = Extract<Sections, { _type: 'component_claimProfileBlock' }> & {
@@ -40,21 +39,6 @@ export function resolveClaimProfileBlockText(
 export function ClaimProfileBlockSection({ claimProfileOverride, tokens, ...section }: Props) {
 	const bgValue = stegaClean(section.claimProfileBlockDesignSettings?.field_blockColorCreamMidnight);
 	const backgroundColor = resolveClaimProfileBlockBackgroundColor(bgValue);
-
-	// Person profiles: render the interactive claim/notify modal so the "notify"
-	// form posts the real personId to the claim-request endpoint. Falls through
-	// to the static CMS banner for regular marketing pages.
-	if (claimProfileOverride?.interactive && claimProfileOverride.personId) {
-		return (
-			<section data-section='Claim Profile Block'>
-				<ClaimProfileModal
-					personId={claimProfileOverride.personId}
-					displayName={claimProfileOverride.displayName ?? 'this candidate'}
-					persona={claimProfileOverride.persona ?? 'candidate'}
-				/>
-			</section>
-		);
-	}
 
 	const ctaButton = section.ctaAction;
 	const claimButton = ctaButton && isButtonType(ctaButton) ? transformButton(ctaButton) : undefined;

--- a/src/PageSections/ProfileHeroSection.tsx
+++ b/src/PageSections/ProfileHeroSection.tsx
@@ -33,6 +33,7 @@ export function ProfileHeroSection({ profileHeroOverride, tokens: _tokens, ...se
 				isEmpowered={profileHeroOverride?.isEmpowered}
 				tags={profileHeroOverride?.tags}
 				attribution={profileHeroOverride?.attribution}
+				showBrandMark={profileHeroOverride?.showBrandMark}
 			/>
 		</section>
 	);

--- a/src/PageSections/index.tsx
+++ b/src/PageSections/index.tsx
@@ -118,11 +118,15 @@ export type SectionOverrides = {
 		/** Persona tag pills shown above the name (e.g. "Candidate", "Incumbent"). */
 		tags?: string[];
 		/**
-		 * Attribution line under the office. `empowered` → "Empowered by GoodParty.org"
-		 * (logo + text); `notEndorsed` → grey "Not Endorsed by GoodParty.org"; `none` →
+		 * Attribution line under the office. `empowered` → "Empowered by
+		 * GoodParty.org" (the /candidate framing); the three `pledge` variants are
+		 * the /people ones and state whether the person has taken the GoodParty.org
+		 * pledge, or is ineligible for it as a major-party affiliate; `none` →
 		 * nothing. When omitted, falls back to `isEmpowered`.
 		 */
-		attribution?: 'empowered' | 'notEndorsed' | 'none';
+		attribution?: 'empowered' | 'pledged' | 'notPledged' | 'pledgeIneligible' | 'none';
+		/** GoodParty.org logo on the portrait and beside the attribution line. */
+		showBrandMark?: boolean;
 	};
 	component_goodPartyOrgPledge?: {
 		hidden?: boolean;

--- a/src/PageSections/index.tsx
+++ b/src/PageSections/index.tsx
@@ -184,13 +184,6 @@ export type SectionOverrides = {
 		candidateName?: string;
 		partyAffiliation?: string;
 		layout?: 'card' | 'banner';
-		// When set, render the interactive claim/notify modal (which posts the
-		// personId to the claim-request endpoint → ProfileClaimRequest) instead of
-		// the static CMS banner. Populated for unclaimed person profiles.
-		interactive?: boolean;
-		personId?: string;
-		displayName?: string;
-		persona?: 'candidate' | 'officeholder' | 'both' | 'past';
 	};
 };
 

--- a/src/app/people/[slug]/page.tsx
+++ b/src/app/people/[slug]/page.tsx
@@ -8,6 +8,7 @@ import {
 } from '~/lib/schema';
 import {
 	extractPersonId,
+	isIndexableProfile,
 	loadPersonProfile,
 	type PersonProfileView,
 } from '~/lib/peopleProfile';
@@ -130,13 +131,17 @@ export async function generateMetadata({
 		view.bio ??
 		`${view.displayName}${view.roleTitle ? `, ${view.roleTitle}` : ''} on GoodParty.org.`;
 
+	// `follow: true` on both suppression paths (see isIndexableProfile for what
+	// they are): the page stops competing in the index, but its civics
+	// interlinks keep carrying crawl signal to the election and profile pages
+	// they point at.
+	const indexable = isIndexableProfile(view);
+
 	return {
 		title,
 		description,
 		alternates: { canonical },
-		// A person who requested removal keeps a crawlable, stripped URL (K/L) but
-		// should not be actively indexed/surfaced.
-		...(view.removed ? { robots: { index: false, follow: true } } : {}),
+		...(indexable ? {} : { robots: { index: false, follow: true } }),
 		openGraph: {
 			type: 'profile',
 			siteName: SITE_NAME,

--- a/src/components/people/ClaimProfileModal.tsx
+++ b/src/components/people/ClaimProfileModal.tsx
@@ -4,7 +4,7 @@ import * as Dialog from '@radix-ui/react-dialog';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 
-import { trackEvent } from '~/lib/analytics';
+import { trackPersonProfileNotifySubmitted } from '~/lib/analytics';
 import { buildClaimRequestBody } from '~/lib/claimRequest';
 import { Button } from '~/ui/Inputs/Button';
 import { TextInput } from '~/ui/Inputs/TextInput';
@@ -80,7 +80,11 @@ export function NotifyForm({
 				}),
 			});
 			if (!res.ok) throw new Error('Submission failed');
-			trackEvent('Person Profile Notify Submitted', { personId });
+			// After the 201, so the count means completed asks. This is the signal
+			// marketing automates on: gp-api's HubSpot counter only ever sees the
+			// subjects that resolve to a single CRM contact — see
+			// trackPersonProfileNotifySubmitted.
+			trackPersonProfileNotifySubmitted({ personId });
 			setIsSuccess(true);
 		} catch {
 			setError('root', { message: 'Something went wrong. Please try again.' });

--- a/src/components/people/ClaimProfileModal.tsx
+++ b/src/components/people/ClaimProfileModal.tsx
@@ -4,14 +4,12 @@ import * as Dialog from '@radix-ui/react-dialog';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 
-import { APP_SIGN_UP_HREF, trackEvent, trackSignUpClicked } from '~/lib/analytics';
+import { trackEvent } from '~/lib/analytics';
 import { buildClaimRequestBody } from '~/lib/claimRequest';
-import { ClaimProfileBlock } from '~/ui/ClaimProfileBlock';
-import { Button, ButtonLink } from '~/ui/Inputs/Button';
+import { Button } from '~/ui/Inputs/Button';
 import { TextInput } from '~/ui/Inputs/TextInput';
 import { IconResolver } from '~/ui/IconResolver';
 import { Text } from '~/ui/Text';
-import { scrollToPersonClaimForm } from './claimFormAnchor';
 
 const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
@@ -40,15 +38,25 @@ const NOTIFY_FORM_ID = 'person-claim-notify';
 type NotifyValues = { firstname: string; email: string; marketingConsent: boolean };
 
 /**
- * The "Not [Name]?" form in the dialog body. Exported so the HubSpot id contract
- * can be asserted directly (see claimFormIds.test.tsx) without standing up
- * Radix's dialog, whose event delegation does not survive JSDOM.
+ * The dialog body from Figma 1901:51851 — name, email, marketing opt-in, and a
+ * Cancel/Submit footer. Exported so the HubSpot id contract can be asserted
+ * directly (see claimFormIds.test.tsx) without standing up Radix's dialog, whose
+ * event delegation does not survive JSDOM; `onCancel` is therefore optional so
+ * the form renders outside a `Dialog.Root` too.
  */
-export function NotifyForm({ personId, displayName }: { personId: string; displayName: string }) {
+export function NotifyForm({
+	personId,
+	displayName,
+	onCancel,
+}: {
+	personId: string;
+	displayName: string;
+	onCancel?: VoidFunction;
+}) {
 	const [isSuccess, setIsSuccess] = useState(false);
-	// marketingConsent starts false against the Figma dialog (1901:51851), which
-	// draws the box ticked: a pre-ticked box opts the sender in unless they notice
-	// and clear it, which is not consent under GDPR. Do not restore Figma parity.
+	// marketingConsent starts false against the Figma dialog, which draws the box
+	// ticked: a pre-ticked box opts the sender in unless they notice and clear it,
+	// which is not consent under GDPR. Do not restore Figma parity here.
 	const {
 		register,
 		handleSubmit,
@@ -97,13 +105,15 @@ export function NotifyForm({ personId, displayName }: { personId: string; displa
 		<form id={NOTIFY_FORM_ID} onSubmit={(e) => void handleSubmit(onSubmit)(e)} noValidate>
 			<div className='flex w-full flex-col gap-4 text-left'>
 				<TextInput
-					label='Your name (optional)'
+					label='Name (optional)'
+					placeholder='First name'
 					autoComplete='name'
 					error={errors.firstname?.message}
 					{...register('firstname')}
 				/>
 				<TextInput
-					label='Your email'
+					label='Email address'
+					placeholder='Email address'
 					type='email'
 					required
 					autoComplete='email'
@@ -114,14 +124,14 @@ export function NotifyForm({ personId, displayName }: { personId: string; displa
 						pattern: { value: EMAIL_PATTERN, message: 'Enter a valid email address' },
 					})}
 				/>
-				<label htmlFor='notify-marketing-consent' className='flex items-start gap-2.5'>
+				<label htmlFor='notify-marketing-consent' className='flex items-start gap-2'>
 					<input
 						id='notify-marketing-consent'
 						type='checkbox'
-						className='mt-0.5 h-5 w-5 shrink-0 rounded border-neutral-300 text-btn-primary-bg accent-btn-primary-bg focus:outline-none focus-visible:ring-2 focus-visible:ring-btn-primary-bg/30'
+						className='mt-1 h-4 w-4 shrink-0 rounded-[4px] border-neutral-300 text-btn-primary-bg accent-btn-primary-bg focus:outline-none focus-visible:ring-2 focus-visible:ring-btn-primary-bg/30'
 						{...register('marketingConsent')}
 					/>
-					<Text as='span' styleType='body-2'>
+					<Text as='span' styleType='caption' className='text-neutral-500'>
 						Sign up for marketing communications from{' '}
 						<a
 							href='https://goodparty.org'
@@ -140,17 +150,29 @@ export function NotifyForm({ personId, displayName }: { personId: string; displa
 						{errors.root.message}
 					</Text>
 				)}
-				<Button
-					parent='ClaimProfileModal'
-					type='submit'
-					styleType='secondary'
-					styleSize='md'
-					isLoading={isSubmitting}
-					disabled={isSubmitting}
-					className='w-fit'
-				>
-					Notify {displayName}
-				</Button>
+				<div className='flex items-center justify-end gap-2'>
+					{onCancel && (
+						<Button
+							parent='ClaimProfileModal'
+							type='button'
+							styleType='outline'
+							styleSize='md'
+							onClick={onCancel}
+						>
+							Cancel
+						</Button>
+					)}
+					<Button
+						parent='ClaimProfileModal'
+						type='submit'
+						styleType='primary'
+						styleSize='md'
+						isLoading={isSubmitting}
+						disabled={isSubmitting}
+					>
+						Submit
+					</Button>
+				</div>
 			</div>
 		</form>
 	);
@@ -164,23 +186,11 @@ export type ClaimProfileModalProps = {
 	persona: Persona;
 	/**
 	 * Most specific place the profile resolves to (city, else county, else
-	 * state). Fills the "[Location]" the Figma voter card opens with for someone
-	 * in office; omit it and that sentence falls back to a generic subject.
+	 * state). Fills the "[Location]" the Figma card opens with for someone in
+	 * office; omit it and that sentence falls back to a generic subject.
 	 */
 	locationLabel?: string | null;
-	/**
-	 * Which trigger to render (the dialog itself is identical):
-	 *  - `banner`      full-width yellow CMS banner (default; legacy section use)
-	 *  - `voter-card`  in-column light-blue prompt aimed at visitors (nudge them to complete their profile)
-	 *  - `owner-card`  in-column light-blue prompt aimed at the person ("Are you …?")
-	 */
-	variant?: 'banner' | 'voter-card' | 'owner-card';
 };
-
-/** Running now — the tense the owner-facing copy is written in. */
-function isRunning(persona: Persona): boolean {
-	return persona === 'candidate' || persona === 'both';
-}
 
 /** Currently serving — the axis the voter-facing copy splits on (see `voterCopy`). */
 function holdsOffice(persona: Persona): boolean {
@@ -190,12 +200,12 @@ function holdsOffice(persona: Persona): boolean {
 /**
  * Voter-facing card copy, verbatim from the unclaimed Figma frames.
  *
- * Note the split is NOT the owner card's "is running" one. The candidate-only
- * frame (D, card 1958:108619) sells casting an informed vote, while both frames
- * for someone already in office — officeholder (E, card 1928:99467) and
- * simultaneous candidate/officeholder (F, card 1928:100987), which are
- * word-for-word identical — sell transparency about their record. So persona
- * `both` takes the office copy, the opposite of how `isRunning` groups it.
+ * The split is on holding office, not on running. The candidate-only frame (D,
+ * card 1958:108619) sells casting an informed vote, while both frames for
+ * someone already in office — officeholder (E, card 1928:99467) and simultaneous
+ * candidate/officeholder (F, card 1928:100987), which are word-for-word
+ * identical — sell transparency about their record. So persona `both` takes the
+ * office copy even though they are also running.
  *
  * `location` fills Figma's "[Location]"; there is no locality on the view, so
  * the caller derives it and a profile that resolves to no place at all keeps the
@@ -217,154 +227,116 @@ function voterCopy(displayName: string, persona: Persona, location: string | nul
 	};
 }
 
-/** In-column light-blue claim prompt (voter- or owner-facing) — a Figma content-well card. */
+/**
+ * The dialog's one line, verbatim from Figma 1901:51851. Exported so it can be
+ * asserted without standing up the Radix dialog, whose click delegation does not
+ * survive JSDOM.
+ *
+ * It asks the reader to nudge someone else. It is deliberately not a pitch to
+ * claim: anyone who opened this dialog has just told us they are not the person.
+ */
+export function notifyDialogTitle(displayName: string): string {
+	return `Ask ${displayName} to complete their profile and contribute to transparency.`;
+}
+
+/**
+ * In-column light-blue notify prompt — the Figma content-well card
+ * (D 1958:108619 / E 1928:99467): a `rounded-3xl` blue-100 panel with centered
+ * 32px heading, 20px body, and one midnight "Send request" button beneath.
+ *
+ * This is the ONLY claim-related card in the content well. The frames put no
+ * owner-facing "are you [Name]?" prompt at the top of the page — the person's
+ * own way in is the claim band below the well (see PersonClaimCTABand) — so do
+ * not reintroduce one here.
+ */
 function ClaimPromptCard({
 	displayName,
 	persona,
 	locationLabel = null,
-	variant,
-	onClaim,
+	onNotify,
 }: {
 	displayName: string;
 	persona: Persona;
 	locationLabel?: string | null;
-	variant: 'voter-card' | 'owner-card';
-	onClaim: VoidFunction;
+	onNotify: VoidFunction;
 }) {
-	const owner = variant === 'owner-card';
-	const voter = voterCopy(displayName, persona, locationLabel);
-	const heading = owner ? `Are you ${displayName}?` : voter.heading;
-	const body = owner
-		? isRunning(persona)
-			? 'Complete your profile now to share why you\u2019re running, your top issues, and how voters can reach you.'
-			: 'Complete your profile now to share your record, your priorities in office, and how constituents can reach you.'
-		: voter.body;
-	const cta = owner ? 'Complete your profile' : 'Send request';
+	const { heading, body } = voterCopy(displayName, persona, locationLabel);
 
 	return (
 		<div
-			className='flex flex-col gap-4 rounded-3xl border border-blue-200 bg-blue-100 p-6'
+			className='flex flex-col items-center gap-6 rounded-3xl bg-blue-100 p-6 text-center text-midnight-900 md:px-10 md:py-12'
 			data-component='ClaimPromptCard'
-			data-variant={variant}
 		>
-			<Text as='h2' styleType='subtitle-1'>
-				{heading}
-			</Text>
-			<Text styleType='body-2'>{body}</Text>
+			<div className='flex flex-col gap-4'>
+				<Text as='h2' styleType='heading-sm'>
+					{heading}
+				</Text>
+				<Text styleType='body-1'>{body}</Text>
+			</div>
 			<Button
 				parent='ClaimProfileModal'
-				styleType='primary'
-				styleSize='md'
+				styleType='secondary'
+				styleSize='lg'
 				className='w-fit'
-				onClick={onClaim}
-				iconRight={owner ? undefined : <IconResolver icon='arrow-up-right' className='h-4 w-4' />}
+				onClick={onNotify}
+				iconRight={<IconResolver icon='arrow-up-right' className='h-4 w-4' />}
 			>
-				{cta}
+				Send request
 			</Button>
 		</div>
 	);
 }
 
-export function ClaimProfileModal({
-	personId,
-	displayName,
-	persona,
-	locationLabel = null,
-	variant = 'banner',
-}: ClaimProfileModalProps) {
+/**
+ * The visitor-facing "ask [Name] to complete their profile" prompt and the
+ * dialog it opens, both from the Figma unclaimed frames.
+ *
+ * Despite the name this is a NOTIFY surface, not a claim one: everything it
+ * submits is a visitor nudging someone else, filed under the `notify` source.
+ * The person's own claim path is entirely in PersonClaimCTABand.
+ */
+export function ClaimProfileModal({ personId, displayName, persona, locationLabel = null }: ClaimProfileModalProps) {
 	const [open, setOpen] = useState(false);
-	const running = isRunning(persona);
-
-	// The owner-facing prompts ("is this you?") pull the person down to the claim
-	// form at the bottom of their own profile rather than opening this dialog, so
-	// there is one place to claim from and the Win/Serve branch happens once, on
-	// submit. If the band is not on the page the dialog is still the fallback.
-	const claimHere = () => {
-		if (!scrollToPersonClaimForm()) setOpen(true);
-	};
-	// The voter-facing prompt is unchanged: it asks a visitor to nudge someone
-	// else, which is the dialog's "Not [Name]?" notify form, not the claim form.
-	const openDialog = () => setOpen(true);
-
-	const headline = `Is this you, ${displayName}?`;
-	const bannerBody = running
-		? 'Claim this profile to share why you\u2019re running, your top issues, and how voters can reach you.'
-		: 'Claim this profile to share your record, your priorities in office, and how constituents can reach you.';
 
 	return (
 		<Dialog.Root open={open} onOpenChange={setOpen}>
-			{variant === 'banner' ? (
-				<ClaimProfileBlock
-					layout='banner'
-					backgroundColor='bright-yellow'
-					headline={headline}
-					body={bannerBody}
-					claimButton={{
-						buttonType: 'button',
-						label: 'Claim your profile',
-						onClick: claimHere,
-						buttonProps: { styleType: 'primary', styleSize: 'md' },
-					}}
-				/>
-			) : (
-				<ClaimPromptCard
-					displayName={displayName}
-					persona={persona}
-					locationLabel={locationLabel}
-					variant={variant}
-					onClaim={variant === 'owner-card' ? claimHere : openDialog}
-				/>
-			)}
+			<ClaimPromptCard
+				displayName={displayName}
+				persona={persona}
+				locationLabel={locationLabel}
+				onNotify={() => setOpen(true)}
+			/>
 
 			<Dialog.Portal>
 				<Dialog.Overlay className='fixed inset-0 z-40 bg-midnight-900/60 backdrop-blur-sm data-[state=open]:animate-in data-[state=open]:fade-in' />
 				<Dialog.Content
-					className='fixed left-1/2 top-1/2 z-50 flex w-[calc(100%-2rem)] max-w-lg -translate-x-1/2 -translate-y-1/2 flex-col gap-6 rounded-2xl bg-white p-6 shadow-xl focus:outline-none sm:p-8'
+					className='fixed left-1/2 top-1/2 z-50 flex w-[calc(100%-2rem)] max-w-[425px] -translate-x-1/2 -translate-y-1/2 flex-col gap-4 rounded-lg border border-neutral-300 bg-white p-6 shadow-lg focus:outline-none'
 					aria-describedby={undefined}
 				>
-					<div className='flex items-start justify-between gap-4'>
-						<Dialog.Title asChild>
-							<Text as='h2' styleType='heading-sm'>
-								Claim your GoodParty.org profile
-							</Text>
-						</Dialog.Title>
-						<Dialog.Close asChild>
-							<Button
-								parent='ClaimProfileModal'
-								styleType='ghost'
-								iconOnly
-								aria-label='Close'
-								iconLeft={<IconResolver icon='x' className='h-5 w-5' />}
-							/>
-						</Dialog.Close>
-					</div>
+					<Dialog.Title asChild>
+						{/*
+						 * Pinned to the frame's 18/28 rather than the `subtitle-2` token,
+						 * which steps up to 20px past 1440. The dialog is a fixed 425px
+						 * panel, so scaling its title with the viewport only costs it a
+						 * third line of wrap.
+						 */}
+						<h2 className='font-secondary pr-6 text-[1.125rem]/[1.75rem] font-semibold text-black'>
+							{notifyDialogTitle(displayName)}
+						</h2>
+					</Dialog.Title>
 
-					<Text styleType='body-2'>
-						If you&apos;re {displayName}, create a free account to verify your identity and take control of
-						this page — add your story, issues, and contact details.
-					</Text>
+					<NotifyForm personId={personId} displayName={displayName} onCancel={() => setOpen(false)} />
 
-					<ButtonLink
-						parent='ClaimProfileModal'
-						href={APP_SIGN_UP_HREF}
-						styleType='primary'
-						styleSize='lg'
-						className='w-full'
-						onClick={() =>
-							trackSignUpClicked({ href: APP_SIGN_UP_HREF, label: 'Claim profile', formId: null })
-						}
-						iconRight={<IconResolver icon='arrow-up-right' className='h-5 w-5' />}
-					>
-						Claim this profile
-					</ButtonLink>
-
-					<div className='flex flex-col gap-4 border-t border-gray-200 pt-6'>
-						<Text styleType='subtitle-2'>Not {displayName}?</Text>
-						<Text styleType='body-2'>
-							Let them know their profile is ready to claim on GoodParty.org.
-						</Text>
-						<NotifyForm personId={personId} displayName={displayName} />
-					</div>
+					<Dialog.Close asChild>
+						<Button
+							parent='ClaimProfileModal'
+							styleType='ghost'
+							iconOnly
+							aria-label='Close'
+							className='absolute right-3 top-3 opacity-70'
+							iconLeft={<IconResolver icon='x' className='h-4 w-4' />}
+						/>
+					</Dialog.Close>
 				</Dialog.Content>
 			</Dialog.Portal>
 		</Dialog.Root>

--- a/src/components/people/ClaimProfileModal.tsx
+++ b/src/components/people/ClaimProfileModal.tsx
@@ -248,6 +248,14 @@ export function notifyDialogTitle(displayName: string): string {
  * owner-facing "are you [Name]?" prompt at the top of the page — the person's
  * own way in is the claim band below the well (see PersonClaimCTABand) — so do
  * not reintroduce one here.
+ *
+ * The heading is `section-heading`, NOT `heading-sm`. Figma names this type
+ * style `heading-lg`, but its value is 32/44 and gp-marketing's `heading-lg` is
+ * 48/60 — the scales do not line up, so tokens have to be matched by value (see
+ * harness/FOLLOWUPS.md). `heading-sm` was the earlier by-name guess: it reaches
+ * 32px only at ≥1440 and carries a 125% line-height, so it rendered 32/40 on
+ * desktop and 24/30 on the mobile artboard, where the frame is still 32/44.
+ * `section-heading` is the flat 32/44 the frames use on both artboards.
  */
 function ClaimPromptCard({
 	displayName,
@@ -267,8 +275,8 @@ function ClaimPromptCard({
 			className='flex flex-col items-center gap-6 rounded-3xl bg-blue-100 p-6 text-center text-midnight-900 md:px-10 md:py-12'
 			data-component='ClaimPromptCard'
 		>
-			<div className='flex flex-col gap-4'>
-				<Text as='h2' styleType='heading-sm'>
+			<div className='flex flex-col gap-3 md:gap-4'>
+				<Text as='h2' styleType='section-heading'>
 					{heading}
 				</Text>
 				<Text styleType='body-1'>{body}</Text>
@@ -277,7 +285,7 @@ function ClaimPromptCard({
 				parent='ClaimProfileModal'
 				styleType='secondary'
 				styleSize='lg'
-				className='w-fit'
+				className='w-full md:w-fit'
 				onClick={onNotify}
 				iconRight={<IconResolver icon='arrow-up-right' className='h-4 w-4' />}
 			>

--- a/src/components/people/PersonClaimCTABand.tsx
+++ b/src/components/people/PersonClaimCTABand.tsx
@@ -23,6 +23,15 @@ const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
  */
 const CLAIM_FORM_ID = 'person-claim-owner';
 
+/**
+ * Verbatim from the Figma band (1922:92593), including its missing final period.
+ * One sentence for everyone: the frames draw the same body on the candidate,
+ * officeholder, and serving-and-running states, so it deliberately does not
+ * branch on `isRunning` the way the routing and the confirmation below do.
+ */
+const CLAIM_BAND_BODY =
+	'Your community deserves accountable leadership. Claim your profile and share your top priorities with residents. Enter your email to get started';
+
 type NotifyValues = { firstname: string; email: string };
 
 export type PersonClaimCTABandProps = {
@@ -105,10 +114,6 @@ export function PersonClaimCTABand({ personId, displayName, isRunning }: PersonC
 		}
 	}
 
-	const body = isRunning
-		? 'Your community deserves accountable leadership. Claim your profile and share why you\u2019re running and your top priorities with residents. Enter your email to get started.'
-		: 'Your community deserves accountable leadership. Claim your profile and share your record and priorities in office with residents. Enter your email to get started.';
-
 	// Both branches speak to the person themselves, not to a visitor — this band is
 	// only ever the subject entering their own address.
 	const successCopy = isRunning
@@ -123,12 +128,12 @@ export function PersonClaimCTABand({ personId, displayName, isRunning }: PersonC
 			data-component='CTABannerBlock'
 		>
 			<Container size='xl'>
-				<div className='flex flex-col items-center gap-6 rounded-2xl bg-blue-100 p-6 text-center text-midnight-900 md:p-12'>
-					<div className='flex max-w-2xl flex-col items-center gap-3 md:gap-4'>
+				<div className='flex flex-col items-center gap-6 rounded-3xl bg-blue-100 p-6 text-center text-midnight-900 lg:px-32 lg:py-40'>
+					<div className='flex flex-col items-center gap-4'>
 						<Text as='h2' styleType='heading-lg'>
 							{`Are you ${displayName}? Complete your profile now.`}
 						</Text>
-						<Text styleType='body-1'>{body}</Text>
+						<Text styleType='body-1'>{CLAIM_BAND_BODY}</Text>
 					</div>
 					{isSuccess ? (
 						<div
@@ -143,17 +148,19 @@ export function PersonClaimCTABand({ personId, displayName, isRunning }: PersonC
 						// `flex flex-col items-center` column: its children do not stretch, so
 						// whichever element is the flex item has to carry `w-full max-w-md` or
 						// the field column collapses to its content width.
-						<div className='w-full max-w-md'>
+						<div className='w-full max-w-[416px]'>
 							<form id={CLAIM_FORM_ID} onSubmit={(e) => void handleSubmit(onSubmit)(e)} noValidate>
 								<div className='flex flex-col gap-4 text-left'>
 									<TextInput
 										label='Name (optional)'
+										placeholder='First name'
 										autoComplete='name'
 										error={errors.firstname?.message}
 										{...register('firstname')}
 									/>
 									<TextInput
 										label='Email address'
+										placeholder='Email address'
 										type='email'
 										required
 										autoComplete='email'
@@ -175,8 +182,8 @@ export function PersonClaimCTABand({ personId, displayName, isRunning }: PersonC
 									<Button
 										parent='PersonClaimCTABand'
 										type='submit'
-										styleType='primary'
-										styleSize='md'
+										styleType='secondary'
+										styleSize='lg'
 										isLoading={isSubmitting}
 										disabled={isSubmitting}
 										className='mx-auto w-fit'

--- a/src/components/people/PersonClaimCTABand.tsx
+++ b/src/components/people/PersonClaimCTABand.tsx
@@ -1,125 +1,46 @@
 'use client';
 
-import { useState } from 'react';
-import { useForm } from 'react-hook-form';
-
-import { APP_SIGN_UP_HREF, trackEvent, trackSignUpClicked } from '~/lib/analytics';
-import { buildClaimRequestBody } from '~/lib/claimRequest';
-import { useDecoratedAppHref } from '~/ui/AttributionProvider';
+import { APP_SIGN_UP_HREF, trackSignUpClicked } from '~/lib/analytics';
 import { Container } from '~/ui/Container';
-import { Button } from '~/ui/Inputs/Button';
-import { TextInput } from '~/ui/Inputs/TextInput';
+import { IconResolver } from '~/ui/IconResolver';
+import { ButtonLink } from '~/ui/Inputs/Button';
 import { Text } from '~/ui/Text';
-import { PERSON_CLAIM_ANCHOR_ID } from './claimFormAnchor';
-
-const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+import { PERSON_CLAIM_ACTION_ID, PERSON_CLAIM_ANCHOR_ID } from './claimFormAnchor';
 
 /**
- * Stable identity for HubSpot's non-HubSpot ("collected") forms tool — see the
- * matching constant in ClaimProfileModal for why this must not be renamed or
- * dropped, and why the `<form>` tag below carries no className. Deliberately
- * different from that one so HubSpot files owner claims separately from visitor
- * nudges; they warrant different follow-up.
+ * GTM resolves the sign-up conversion through this id — `trackSignUpClicked`
+ * pushes it into `window.dataLayer` and the Data Layer Variable is keyed on it.
+ *
+ * It was also HubSpot's key for the collected owner form that used to sit here.
+ * That form is gone (marketing, 2026-08-17: send the person to Win instead of
+ * taking their address), so HubSpot will stop receiving submissions under this
+ * name. The id is kept rather than retired so the clicks that replace those
+ * submissions land on the GTM variable already wired up for this surface.
  */
 const CLAIM_FORM_ID = 'person-claim-owner';
 
-/**
- * Verbatim from the Figma band (1922:92593), including its missing final period.
- * One sentence for everyone: the frames draw the same body on the candidate,
- * officeholder, and serving-and-running states, so it deliberately does not
- * branch on `isRunning` the way the routing and the confirmation below do.
- */
-const CLAIM_BAND_BODY =
-	'Your community deserves accountable leadership. Claim your profile and share your top priorities with residents. Enter your email to get started';
-
-type NotifyValues = { firstname: string; email: string };
-
 export type PersonClaimCTABandProps = {
-	personId: string;
 	displayName: string;
-	/**
-	 * Which product this person belongs to, derived from their persona upstream:
-	 * running (candidate/both) is **Win**, in office only is **Serve**.
-	 *
-	 * It picks the body copy ("share why you're running" vs "your record") and,
-	 * on submit, which branch they take — Win self-serves into sign-up, Serve is
-	 * handed to sales, who send an access link by hand.
-	 */
-	isRunning: boolean;
 };
 
 /**
- * Full-width light-blue claim CTA band for UNCLAIMED empowered person profiles
- * (Figma states D/E/F/H). Mirrors the Figma "Are you [Name]? Complete your
- * profile now." band: centered heading + body over an inline name/email form
- * that posts to the same claim-request endpoint as the claim modal. Rendered in
- * the person `person-cta` section slot (below the content well, above the
- * elections index) in place of the claimed "Join the movement" CTA.
+ * Full-width light-blue claim CTA band for UNCLAIMED empowered CANDIDATE
+ * profiles (Figma states D/F). Mirrors the Figma "Are you [Name]? Complete your
+ * profile now." band, with a button into Win sign-up where the frame draws an
+ * inline name/email form. Rendered in the person `person-cta` section slot
+ * (below the content well, above the elections index) in place of the claimed
+ * "Join the movement" CTA.
  *
- * Carries NO marketing-consent checkbox, unlike the claim modal, which is what
- * the frame specifies (band 1922:92593 has name + email + submit; the modal's
- * dialog 1901:51851 adds the opt-in). The two forms hit one endpoint but are
- * different acts: the modal asks a visitor to opt in while notifying someone
- * else, whereas this band is the person themselves entering their own address to
- * claim their page. The proxy therefore records `marketingConsent: false` for
- * every submission from here — absent an opt-in that is the accurate value, not
- * a dropped field.
+ * Candidate-only by construction: `buildPersonSectionOverrides` no longer shows
+ * any claim surface to the officeholder or past personas, so there is no Serve
+ * branch here. Someone reaching this band is running, and running means Win,
+ * which they can self-serve into.
+ *
+ * The band takes no `personId`: nothing is submitted from here any more, and the
+ * `Sign Up Clicked` event carries `page_path`, which is the profile URL — so the
+ * click is still attributable to the person whose page it came from.
  */
-export function PersonClaimCTABand({ personId, displayName, isRunning }: PersonClaimCTABandProps) {
-	const [isSuccess, setIsSuccess] = useState(false);
-	// Every other sign-up link on the site reaches the app through `Anchor`,
-	// which decorates app.goodparty.org URLs with the captured fbclid/utm params.
-	// This branch navigates programmatically and so has to do it by hand, or a
-	// claim that arrived from an ad would land on sign-up stripped of the
-	// attribution that stitches the two halves of the funnel together.
-	const signUpHref = useDecoratedAppHref(APP_SIGN_UP_HREF) ?? APP_SIGN_UP_HREF;
-	const {
-		register,
-		handleSubmit,
-		setError,
-		formState: { errors, isSubmitting },
-	} = useForm<NotifyValues>({ defaultValues: { firstname: '', email: '' } });
-
-	async function onSubmit(values: NotifyValues) {
-		try {
-			const res = await fetch('/api/people/claim-request', {
-				method: 'POST',
-				headers: { 'Content-Type': 'application/json' },
-				// `owner` is the person claiming their own page, which is not demand
-				// from other people and must never reach candidate_profile_requests.
-				body: buildClaimRequestBody({
-					personId,
-					firstname: values.firstname,
-					email: values.email,
-					source: 'owner',
-				}),
-			});
-			if (!res.ok) throw new Error('Submission failed');
-			trackEvent('Person Profile Claim CTA Submitted', { personId, product: isRunning ? 'win' : 'serve' });
-			setIsSuccess(true);
-
-			// Win only. The lead is stored either way — the redirect happens after a
-			// successful POST so a candidate who abandons sign-up is still a lead and
-			// still counted in the funnel. Serve stops here: sales follows up from
-			// HubSpot and sends the access link by hand.
-			if (isRunning) {
-				// The event carries the bare href, as every other sign-up link on the
-				// site does, so this point is comparable with the rest of the funnel;
-				// the navigation carries the decorated one.
-				trackSignUpClicked({ href: APP_SIGN_UP_HREF, label: 'Claim profile', formId: CLAIM_FORM_ID });
-				window.location.assign(signUpHref);
-			}
-		} catch {
-			setError('root', { message: 'Something went wrong. Please try again.' });
-		}
-	}
-
-	// Both branches speak to the person themselves, not to a visitor — this band is
-	// only ever the subject entering their own address.
-	const successCopy = isRunning
-		? 'Thanks — taking you to GoodParty.org now to create your free account and finish claiming your profile.'
-		: 'Thanks — someone from our team will email you at that address with a link to access your profile.';
-
+export function PersonClaimCTABand({ displayName }: PersonClaimCTABandProps) {
 	return (
 		<article
 			id={PERSON_CLAIM_ANCHOR_ID}
@@ -133,67 +54,32 @@ export function PersonClaimCTABand({ personId, displayName, isRunning }: PersonC
 						<Text as='h2' styleType='heading-lg'>
 							{`Are you ${displayName}? Complete your profile now.`}
 						</Text>
-						<Text styleType='body-1'>{CLAIM_BAND_BODY}</Text>
+						<Text styleType='body-1'>
+							Your community deserves accountable leadership. Claim your profile and share why you&rsquo;re
+							running and your top priorities with residents. Create a free GoodParty.org account to get
+							started.
+						</Text>
 					</div>
-					{isSuccess ? (
-						<div
-							className='w-full max-w-md rounded-md border border-success-200 bg-success-50 px-4 py-3'
-							role='status'
-							aria-live='polite'
-						>
-							<Text styleType='body-2'>{successCopy}</Text>
-						</div>
-					) : (
-						// The sizing sits on the wrapper, not the <form>, because the band is a
-						// `flex flex-col items-center` column: its children do not stretch, so
-						// whichever element is the flex item has to carry `w-full max-w-md` or
-						// the field column collapses to its content width.
-						<div className='w-full max-w-[416px]'>
-							<form id={CLAIM_FORM_ID} onSubmit={(e) => void handleSubmit(onSubmit)(e)} noValidate>
-								<div className='flex flex-col gap-4 text-left'>
-									<TextInput
-										label='Name (optional)'
-										placeholder='First name'
-										autoComplete='name'
-										error={errors.firstname?.message}
-										{...register('firstname')}
-									/>
-									<TextInput
-										label='Email address'
-										placeholder='Email address'
-										type='email'
-										required
-										autoComplete='email'
-										inputMode='email'
-										error={errors.email?.message}
-										{...register('email', {
-											required: 'Email is required',
-											pattern: {
-												value: EMAIL_PATTERN,
-												message: 'Enter a valid email address',
-											},
-										})}
-									/>
-									{errors.root?.message && (
-										<Text styleType='caption' className='text-error-600' role='alert'>
-											{errors.root.message}
-										</Text>
-									)}
-									<Button
-										parent='PersonClaimCTABand'
-										type='submit'
-										styleType='secondary'
-										styleSize='lg'
-										isLoading={isSubmitting}
-										disabled={isSubmitting}
-										className='mx-auto w-fit'
-									>
-										Submit
-									</Button>
-								</div>
-							</form>
-						</div>
-					)}
+					{/*
+					  * `ButtonLink` renders through `Anchor`, which decorates
+					  * app.goodparty.org URLs with the captured fbclid/utm params, so a
+					  * candidate who arrived from an ad lands on sign-up with the
+					  * attribution that stitches the two halves of the funnel together.
+					  * The tracked href is the bare one, as everywhere else on the site,
+					  * so this point stays comparable with the rest of the funnel.
+					  */}
+					<ButtonLink
+						parent='PersonClaimCTABand'
+						id={PERSON_CLAIM_ACTION_ID}
+						href={APP_SIGN_UP_HREF}
+						formId={CLAIM_FORM_ID}
+						styleType='primary'
+						styleSize='md'
+						onClick={() => trackSignUpClicked({ href: APP_SIGN_UP_HREF, label: 'Claim profile', formId: CLAIM_FORM_ID })}
+						iconRight={<IconResolver icon='arrow-up-right' className='h-5 w-5' />}
+					>
+						Claim this profile
+					</ButtonLink>
 				</div>
 			</Container>
 		</article>

--- a/src/components/people/claimFlow.test.tsx
+++ b/src/components/people/claimFlow.test.tsx
@@ -47,6 +47,7 @@ let root: Root;
 let scrollCalls: ScrollCall[];
 let navigations: string[];
 let trackedEvents: { name: string; props?: Record<string, unknown> }[];
+let segmentEvents: { name: string; props?: Record<string, unknown> }[];
 let dataLayer: Record<string, unknown>[];
 let fetchCalls: { url: string; body: Record<string, unknown> }[];
 let fetchOk: boolean;
@@ -69,6 +70,7 @@ beforeEach(() => {
 	scrollCalls = [];
 	navigations = [];
 	trackedEvents = [];
+	segmentEvents = [];
 	dataLayer = [];
 	fetchCalls = [];
 	fetchOk = true;
@@ -98,6 +100,9 @@ beforeEach(() => {
 
 	(window as unknown as { amplitude: unknown }).amplitude = {
 		track: (name: string, props?: Record<string, unknown>) => trackedEvents.push({ name, props }),
+	};
+	(window as unknown as { analytics: unknown }).analytics = {
+		track: (name: string, props?: Record<string, unknown>) => segmentEvents.push({ name, props }),
 	};
 	(window as unknown as { dataLayer: unknown }).dataLayer = dataLayer;
 
@@ -147,6 +152,25 @@ async function click(element: Element) {
 		element.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true, cancelable: true }));
 		await flush();
 	});
+}
+
+/**
+ * Types into a react-hook-form field.
+ *
+ * The value goes through the prototype setter so it bypasses the setter React
+ * installs on the element, which is what makes React's value tracker notice a
+ * change. `input` is what React listens to normally; the focus and `keyup` are
+ * what its Internet Explorer fallback listens to (see the shims in
+ * `beforeEach`). Firing all of them makes this work whichever path React took,
+ * and the tracker means only one change is delivered either way.
+ */
+function setInputValue(input: HTMLInputElement, value: string) {
+	const setter = Object.getOwnPropertyDescriptor(dom.window.HTMLInputElement.prototype, 'value')!.set!;
+	input.focus();
+	setter.call(input, value);
+	input.dispatchEvent(new dom.window.Event('input', { bubbles: true }));
+	input.dispatchEvent(new dom.window.KeyboardEvent('keyup', { bubbles: true }));
+	input.dispatchEvent(new dom.window.Event('change', { bubbles: true }));
 }
 
 const personId = '11111111-1111-4111-8111-111111111111';
@@ -252,5 +276,77 @@ describe('the claim band hands the candidate to Win sign-up', () => {
 		await click(cta);
 
 		expect(fetchCalls).toEqual([]);
+	});
+});
+
+/**
+ * The notify count marketing automates on.
+ *
+ * gp-api also files these into the subject's HubSpot `candidate_profile_requests`,
+ * but only for a subject the civics mart resolves to exactly one HubSpot contact —
+ * a person with none, or with an ambiguous cluster, is skipped without an error
+ * anywhere. Notify is aimed at exactly those thinly-known people, so the CRM
+ * number is a lower bound of unknown tightness and this event is the honest one.
+ *
+ * The form is mounted directly rather than through the dialog, as in
+ * claimFormIds.test.tsx: Radix's click delegation is unreliable under JSDOM and
+ * the submission path is identical either way.
+ */
+describe('a completed notify submission is reported to marketing', () => {
+	const NOTIFY_EVENT = 'Person Profile Notify Submitted';
+	const email = 'visitor@example.com';
+
+	async function submitNotifyForm() {
+		const { NotifyForm } = await import('./ClaimProfileModal');
+		await render(React.createElement(NotifyForm, { personId, displayName }));
+
+		const form = document.querySelector<HTMLFormElement>('form#person-claim-notify')!;
+
+		await act(async () => {
+			setInputValue(form.querySelector<HTMLInputElement>('input[name="email"]')!, email);
+			await flush();
+		});
+		await act(async () => {
+			form.dispatchEvent(new dom.window.Event('submit', { bubbles: true, cancelable: true }));
+			await flush();
+			await flush();
+		});
+	}
+
+	test('fires to Segment with the subject and the page, once gp-api has accepted it', async () => {
+		await submitNotifyForm();
+
+		expect(fetchCalls).toHaveLength(1);
+		expect(segmentEvents).toEqual([
+			{ name: NOTIFY_EVENT, props: { personId, page_path: '/people/example-person' } },
+		]);
+	});
+
+	/**
+	 * Amplitude carried this event before Segment did. Both sinks are kept, and
+	 * kept identical, so a marketing audience and a product funnel built on the
+	 * same name cannot disagree about what a notify is.
+	 */
+	test('fires the same event to Amplitude', async () => {
+		await submitNotifyForm();
+
+		expect(trackedEvents.filter(e => e.name === NOTIFY_EVENT)).toEqual([
+			{ name: NOTIFY_EVENT, props: { personId, page_path: '/people/example-person' } },
+		]);
+	});
+
+	/**
+	 * Firing on click instead of on the response would make the number "people who
+	 * pressed Submit", which is not what a nudge count means and is not something
+	 * an automation can act on.
+	 */
+	test('stays silent when gp-api rejects the submission', async () => {
+		fetchOk = false;
+
+		await submitNotifyForm();
+
+		expect(fetchCalls).toHaveLength(1);
+		expect(segmentEvents).toEqual([]);
+		expect(trackedEvents.filter(e => e.name === NOTIFY_EVENT)).toEqual([]);
 	});
 });

--- a/src/components/people/claimFlow.test.tsx
+++ b/src/components/people/claimFlow.test.tsx
@@ -8,9 +8,12 @@ import { createRoot, type Root } from 'react-dom/client';
  * Covers the claim flow on an unclaimed person profile. Per the Figma frames the
  * page has exactly two claim-related surfaces and they do different jobs: the
  * card at the top of the content well is visitor-facing and only opens the
- * notify dialog, and the band at the bottom is the person's own claim form,
- * which branches on their product — Win (currently running) into sign-up, Serve
- * (in office only) into a "a human will be in touch" confirmation.
+ * notify dialog, and the band at the bottom is the person's own ask.
+ *
+ * That band used to collect a name and email and branch on the person's product
+ * (Win into sign-up, Serve into "a human will be in touch"). Both halves of that
+ * are gone: the band is candidate-only now, so there is no Serve branch, and it
+ * sends people to sign-up instead of taking their address.
  *
  * Like claimFormIds.test.tsx these mount components directly instead of driving
  * the Radix dialog, whose click delegation has proven unreliable under JSDOM,
@@ -86,10 +89,9 @@ beforeEach(() => {
 	// react-dom before its JSDOM exists, so react-dom concludes "no" and falls
 	// back to its Internet Explorer path: change tracking via `attachEvent` /
 	// `detachEvent` and `keyup` rather than `input`. JSDOM has neither method, so
-	// focusing an input throws inside React. These no-ops let that path run;
-	// `setInputValue` below then fires the events both paths listen for, which is
-	// what keeps this file independent of which test file bun happens to load
-	// first.
+	// focusing an input throws inside React — which the notify dialog does on
+	// open. These no-ops let that path run, keeping this file independent of
+	// which test file bun happens to load first.
 	const shim = window.HTMLElement.prototype as unknown as Record<string, unknown>;
 	shim['attachEvent'] = () => {};
 	shim['detachEvent'] = () => {};
@@ -147,50 +149,10 @@ async function click(element: Element) {
 	});
 }
 
-async function submitClaimForm({ name, email }: { name: string; email: string }) {
-	const firstname = document.querySelector<HTMLInputElement>('#person-claim-owner input[name="firstname"]')!;
-	const address = document.querySelector<HTMLInputElement>('#person-claim-owner input[name="email"]')!;
-
-	await act(async () => {
-		setInputValue(firstname, name);
-		setInputValue(address, email);
-		await flush();
-	});
-	await act(async () => {
-		document.querySelector('form#person-claim-owner')!.dispatchEvent(new dom.window.Event('submit', { bubbles: true, cancelable: true }));
-		await flush();
-		await flush();
-	});
-}
-
-/**
- * Types into a react-hook-form field.
- *
- * The value goes through the prototype setter so it bypasses the setter React
- * installs on the element, which is what makes React's value tracker notice a
- * change. `input` is what React listens to normally; the focus and `keyup` are
- * what its Internet Explorer fallback listens to (see the shims in
- * `beforeEach`). Firing all of them makes this work whichever path React took,
- * and the tracker means only one change is delivered either way.
- */
-function setInputValue(input: HTMLInputElement, value: string) {
-	const setter = Object.getOwnPropertyDescriptor(dom.window.HTMLInputElement.prototype, 'value')!.set!;
-	input.focus();
-	setter.call(input, value);
-	input.dispatchEvent(new dom.window.Event('input', { bubbles: true }));
-	input.dispatchEvent(new dom.window.KeyboardEvent('keyup', { bubbles: true }));
-	input.dispatchEvent(new dom.window.Event('change', { bubbles: true }));
-}
-
 const personId = '11111111-1111-4111-8111-111111111111';
 const displayName = 'Example Person';
 
-/** Win: currently running (persona `candidate` or `both`). */
-const winProps = { personId, displayName, isRunning: true };
-/** Serve: in office only (persona `officeholder`). */
-const serveProps = { personId, displayName, isRunning: false };
-
-async function renderProfileClaimSurfaces(isRunning: boolean) {
+async function renderProfileClaimSurfaces() {
 	const [{ ClaimProfileModal }, { PersonClaimCTABand }] = await Promise.all([import('./ClaimProfileModal'), import('./PersonClaimCTABand')]);
 
 	await render(
@@ -200,9 +162,11 @@ async function renderProfileClaimSurfaces(isRunning: boolean) {
 			React.createElement(ClaimProfileModal, {
 				personId,
 				displayName,
-				persona: isRunning ? 'candidate' : 'officeholder',
+				// Only the running personas still see a claim surface, so this is the
+				// pairing the band is ever rendered beside.
+				persona: 'candidate',
 			}),
-			React.createElement(PersonClaimCTABand, { personId, displayName, isRunning }),
+			React.createElement(PersonClaimCTABand, { displayName }),
 		),
 	);
 }
@@ -219,7 +183,7 @@ describe('the top of the content well is notify-only', () => {
 	 * a claim shortcut, is the regression this guards.
 	 */
 	test('the prompt opens the notify dialog rather than the claim form', async () => {
-		await renderProfileClaimSurfaces(true);
+		await renderProfileClaimSurfaces();
 
 		expect(document.querySelectorAll(`[data-component='ClaimPromptCard']`)).toHaveLength(1);
 		expect(document.querySelector('[role="dialog"]')).toBeNull();
@@ -234,7 +198,7 @@ describe('the top of the content well is notify-only', () => {
 	});
 
 	test('the dialog closes without submitting when the visitor cancels', async () => {
-		await renderProfileClaimSurfaces(true);
+		await renderProfileClaimSurfaces();
 		await click(claimPromptButton());
 
 		const cancel = [...document.querySelectorAll('[role="dialog"] button')].find(b => b.textContent?.includes('Cancel'))!;
@@ -245,57 +209,48 @@ describe('the top of the content well is notify-only', () => {
 	});
 });
 
-describe('submitting the claim form branches on the person’s product', () => {
-	test('Win stores the claim request and then routes to sign-up', async () => {
+describe('the claim band hands the candidate to Win sign-up', () => {
+	async function renderBand() {
 		const { PersonClaimCTABand } = await import('./PersonClaimCTABand');
-		await render(React.createElement(PersonClaimCTABand, winProps));
+		await render(React.createElement(PersonClaimCTABand, { displayName }));
+		return document.getElementById('person-claim-signup')!;
+	}
 
-		await submitClaimForm({ name: 'Example', email: 'example@example.org' });
+	test('the call to action is a link to sign-up, not a form', async () => {
+		const cta = await renderBand();
 
-		expect(fetchCalls).toHaveLength(1);
-		expect(fetchCalls[0]?.url).toBe('/api/people/claim-request');
-		expect(fetchCalls[0]?.body).toEqual({ personId, firstname: 'Example', email: 'example@example.org', source: 'owner' });
-		// The lead is stored first, so an abandoned sign-up still leaves a lead.
-		expect(navigations).toEqual(['https://app.goodparty.org/sign-up']);
+		expect(cta.tagName).toBe('A');
+		expect(cta.getAttribute('href')).toBe('https://app.goodparty.org/sign-up');
+		expect(document.querySelector('form')).toBeNull();
 	});
 
-	test('Win fires the sign-up event at the point it navigates', async () => {
-		const { PersonClaimCTABand } = await import('./PersonClaimCTABand');
-		await render(React.createElement(PersonClaimCTABand, winProps));
+	/**
+	 * The GTM Data Layer Variable behind the sign-up conversion is keyed on this
+	 * id. It used to arrive from the band's HubSpot form; the form is gone but the
+	 * key has to survive it, or the conversion stops resolving for this surface.
+	 */
+	test('clicking it reports a sign-up under the surface’s existing form id', async () => {
+		const cta = await renderBand();
 
-		await submitClaimForm({ name: 'Example', email: 'example@example.org' });
+		await click(cta);
 
 		const signUp = trackedEvents.filter(e => e.name === 'Sign Up Clicked');
 		expect(signUp).toHaveLength(1);
-		expect(signUp[0]?.props).toMatchObject({ href: 'https://app.goodparty.org/sign-up' });
+		expect(signUp[0]?.props).toMatchObject({ href: 'https://app.goodparty.org/sign-up', label: 'Claim profile' });
 		expect(dataLayer).toEqual([{ event: 'sign_up_click', formId: 'person-claim-owner' }]);
 	});
 
-	test('Serve stores the claim request and promises a human, not self-serve access', async () => {
-		const { PersonClaimCTABand } = await import('./PersonClaimCTABand');
-		await render(React.createElement(PersonClaimCTABand, serveProps));
+	/**
+	 * Owner-side email capture on this surface is deliberately gone — marketing
+	 * chose the sign-up funnel over the lead. Pinned because a well-meaning
+	 * "restore the lead capture" change would quietly reintroduce a second,
+	 * conflicting owner path and a HubSpot form nobody is watching.
+	 */
+	test('nothing is posted to the claim-request endpoint from the band', async () => {
+		const cta = await renderBand();
 
-		await submitClaimForm({ name: 'Example', email: 'example@example.org' });
+		await click(cta);
 
-		expect(fetchCalls).toHaveLength(1);
-		expect(fetchCalls[0]?.body).toEqual({ personId, firstname: 'Example', email: 'example@example.org', source: 'owner' });
-		expect(navigations).toEqual([]);
-		expect(trackedEvents.filter(e => e.name === 'Sign Up Clicked')).toHaveLength(0);
-
-		const status = document.querySelector('[role="status"]')?.textContent ?? '';
-		expect(status).toContain('someone from our team will email you');
-		expect(status).toContain('link to access your profile');
-	});
-
-	test('a failed submission neither navigates nor claims success', async () => {
-		fetchOk = false;
-		const { PersonClaimCTABand } = await import('./PersonClaimCTABand');
-		await render(React.createElement(PersonClaimCTABand, winProps));
-
-		await submitClaimForm({ name: 'Example', email: 'example@example.org' });
-
-		expect(navigations).toEqual([]);
-		expect(document.querySelector('form#person-claim-owner')).not.toBeNull();
-		expect(document.querySelector('[role="alert"]')?.textContent).toContain('Something went wrong');
+		expect(fetchCalls).toEqual([]);
 	});
 });

--- a/src/components/people/claimFlow.test.tsx
+++ b/src/components/people/claimFlow.test.tsx
@@ -5,11 +5,12 @@ import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 
 /**
- * Covers the claim flow on an unclaimed person profile: the owner-facing prompt
- * at the top of the content well scrolls down to the claim form rather than
- * opening the dialog, and submitting that form branches on the person's product
- * — Win (currently running) into sign-up, Serve (in office only) into a "a human
- * will be in touch" confirmation.
+ * Covers the claim flow on an unclaimed person profile. Per the Figma frames the
+ * page has exactly two claim-related surfaces and they do different jobs: the
+ * card at the top of the content well is visitor-facing and only opens the
+ * notify dialog, and the band at the bottom is the person's own claim form,
+ * which branches on their product — Win (currently running) into sign-up, Serve
+ * (in office only) into a "a human will be in touch" confirmation.
  *
  * Like claimFormIds.test.tsx these mount components directly instead of driving
  * the Radix dialog, whose click delegation has proven unreliable under JSDOM,
@@ -189,7 +190,7 @@ const winProps = { personId, displayName, isRunning: true };
 /** Serve: in office only (persona `officeholder`). */
 const serveProps = { personId, displayName, isRunning: false };
 
-async function renderProfileClaimSurfaces(variant: 'owner-card' | 'voter-card', isRunning: boolean) {
+async function renderProfileClaimSurfaces(isRunning: boolean) {
 	const [{ ClaimProfileModal }, { PersonClaimCTABand }] = await Promise.all([import('./ClaimProfileModal'), import('./PersonClaimCTABand')]);
 
 	await render(
@@ -200,74 +201,47 @@ async function renderProfileClaimSurfaces(variant: 'owner-card' | 'voter-card', 
 				personId,
 				displayName,
 				persona: isRunning ? 'candidate' : 'officeholder',
-				variant,
 			}),
 			React.createElement(PersonClaimCTABand, { personId, displayName, isRunning }),
 		),
 	);
 }
 
-function claimPromptButton(variant: 'owner-card' | 'voter-card') {
-	return document.querySelector(`[data-component='ClaimPromptCard'][data-variant='${variant}'] button`)!;
+function claimPromptButton() {
+	return document.querySelector(`[data-component='ClaimPromptCard'] button`)!;
 }
 
-describe('the top claim prompt pulls the person down to the claim form', () => {
-	test('the owner prompt scrolls to the claim form instead of opening the dialog', async () => {
-		await renderProfileClaimSurfaces('owner-card', true);
-
-		await click(claimPromptButton('owner-card'));
-
-		expect(scrollCalls).toEqual([{ behavior: 'smooth', id: 'person-claim-form' }]);
-		expect(document.querySelector('[role="dialog"]')).toBeNull();
-	});
-
-	test('the owner prompt moves keyboard focus into the claim form', async () => {
-		await renderProfileClaimSurfaces('owner-card', true);
-
-		await click(claimPromptButton('owner-card'));
-
-		const active = document.activeElement;
-		expect(active?.getAttribute('name')).toBe('firstname');
-		expect(active?.closest('form')?.id).toBe('person-claim-owner');
-	});
-
-	test('the scroll is instant when the visitor asks for reduced motion', async () => {
-		(dom.window as unknown as { matchMedia: unknown }).matchMedia = (query: string) => ({ matches: query.includes('reduce'), media: query });
-
-		await renderProfileClaimSurfaces('owner-card', true);
-		await click(claimPromptButton('owner-card'));
-
-		expect(scrollCalls.map(c => c.behavior)).toEqual(['auto']);
-	});
-
+describe('the top of the content well is notify-only', () => {
 	/**
-	 * Reachable rather than theoretical: the code-default template fallback strips
-	 * the CTA banner block the claim band renders into, which would leave the
-	 * prompt on a page with no form to scroll to. The prompt falls back to the
-	 * dialog there, so it is never a button that does nothing.
+	 * The frames put ONE card at the top of the content well and it is
+	 * visitor-facing. An owner-facing "are you [Name]?" prompt was added here
+	 * once and had to be taken back out; a second card, or this one turning into
+	 * a claim shortcut, is the regression this guards.
 	 */
-	test('the scroll reports failure when the claim band is not on the page', async () => {
-		const { scrollToPersonClaimForm } = await import('./claimFormAnchor');
+	test('the prompt opens the notify dialog rather than the claim form', async () => {
+		await renderProfileClaimSurfaces(true);
 
-		expect(scrollToPersonClaimForm()).toBe(false);
-		expect(scrollCalls).toEqual([]);
-	});
-
-	/**
-	 * The counterpart to the owner-prompt test above: this is the entry point the
-	 * notify form is left with, so it has to be shown opening the dialog, not
-	 * merely not scrolling.
-	 */
-	test('the voter prompt still opens the dialog and its notify form', async () => {
-		await renderProfileClaimSurfaces('voter-card', true);
-
+		expect(document.querySelectorAll(`[data-component='ClaimPromptCard']`)).toHaveLength(1);
 		expect(document.querySelector('[role="dialog"]')).toBeNull();
 
-		await click(claimPromptButton('voter-card'));
+		await click(claimPromptButton());
 
 		expect(document.querySelector('[role="dialog"]')).not.toBeNull();
 		expect(document.querySelector('[role="dialog"] form#person-claim-notify')).not.toBeNull();
+		// Nothing up here reaches the person's own claim form.
 		expect(scrollCalls).toEqual([]);
+		expect(document.querySelector('[role="dialog"] form#person-claim-owner')).toBeNull();
+	});
+
+	test('the dialog closes without submitting when the visitor cancels', async () => {
+		await renderProfileClaimSurfaces(true);
+		await click(claimPromptButton());
+
+		const cancel = [...document.querySelectorAll('[role="dialog"] button')].find(b => b.textContent?.includes('Cancel'))!;
+		await click(cancel);
+
+		expect(document.querySelector('[role="dialog"]')).toBeNull();
+		expect(fetchCalls).toEqual([]);
 	});
 });
 

--- a/src/components/people/claimFormAnchor.ts
+++ b/src/components/people/claimFormAnchor.ts
@@ -1,10 +1,15 @@
 /**
  * Anchor on the claim band at the bottom of an unclaimed person profile, so the
- * form can be linked to directly (`/people/<slug>#person-claim-form`).
+ * band can be linked to directly (`/people/<slug>#person-claim-form`). Nothing
+ * on the page scrolls here: the content well is notify-only, and the band is the
+ * single owner-facing ask.
  *
- * Deliberately NOT the `<form id>`. `person-claim-owner` is HubSpot's key for
- * the collected form and is an external contract; keeping the anchor on a
- * wrapper means a future layout change can move it without re-keying the form in
- * HubSpot, and vice versa.
+ * Deliberately NOT an id the band's call to action carries. `person-claim-signup`
+ * keys the GTM conversion and `person-claim-owner` keys HubSpot's collected form,
+ * both external contracts; keeping the anchor on a wrapper means a future layout
+ * change can move it without re-keying anything downstream, and vice versa.
  */
 export const PERSON_CLAIM_ANCHOR_ID = 'person-claim-form';
+
+/** The band's sign-up link — the id the GTM conversion trigger reads. */
+export const PERSON_CLAIM_ACTION_ID = 'person-claim-signup';

--- a/src/components/people/claimFormAnchor.ts
+++ b/src/components/people/claimFormAnchor.ts
@@ -1,46 +1,10 @@
 /**
- * The scroll target for the owner-facing "claim your profile" CTAs, which pull
- * the person down to the claim form at the bottom of their profile instead of
- * opening a dialog.
+ * Anchor on the claim band at the bottom of an unclaimed person profile, so the
+ * form can be linked to directly (`/people/<slug>#person-claim-form`).
  *
  * Deliberately NOT the `<form id>`. `person-claim-owner` is HubSpot's key for
- * the collected form and is an external contract; keeping the scroll target on
- * a wrapper means a future layout change can move the anchor without re-keying
- * the form in HubSpot, and vice versa.
+ * the collected form and is an external contract; keeping the anchor on a
+ * wrapper means a future layout change can move it without re-keying the form in
+ * HubSpot, and vice versa.
  */
 export const PERSON_CLAIM_ANCHOR_ID = 'person-claim-form';
-
-const CLAIM_FIELD_SELECTORS = ['#person-claim-owner input[name="firstname"]', '#person-claim-owner input[name="email"]'];
-
-function prefersReducedMotion(): boolean {
-	if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return false;
-	return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-}
-
-/**
- * Scrolls to the claim form and moves keyboard focus into it, so keyboard and
- * screen-reader users land where sighted users are looking.
- *
- * Returns `false` when the band is not on the page. That is reachable: the
- * code-default template fallback strips the CTA banner block the band renders
- * into, which would leave the claim card on a page with no form. Callers fall
- * back to the dialog rather than leaving the button doing nothing.
- */
-export function scrollToPersonClaimForm(): boolean {
-	if (typeof document === 'undefined') return false;
-
-	const anchor = document.getElementById(PERSON_CLAIM_ANCHOR_ID);
-	if (!anchor) return false;
-
-	const field = CLAIM_FIELD_SELECTORS.reduce<HTMLElement | null>(
-		(found, selector) => found ?? document.querySelector<HTMLElement>(selector),
-		null,
-	);
-
-	// Focus first, with preventScroll, so the browser does not jump instantly and
-	// then animate — and so the smooth scroll below is what the user actually sees.
-	(field ?? anchor).focus({ preventScroll: true });
-
-	anchor.scrollIntoView?.({ behavior: prefersReducedMotion() ? 'auto' : 'smooth', block: 'start' });
-	return true;
-}

--- a/src/components/people/claimFormIds.test.tsx
+++ b/src/components/people/claimFormIds.test.tsx
@@ -85,7 +85,7 @@ async function render(element: React.ReactElement) {
 	});
 }
 
-const bandProps = { personId: 'person-1', displayName: 'Example Person', isRunning: true };
+const bandProps = { displayName: 'Example Person' };
 const notifyProps = { personId: 'person-1', displayName: 'Example Person' };
 
 /**
@@ -112,24 +112,21 @@ function expectNoStylingClasses(form: Element | null) {
 }
 
 describe('claim form HubSpot ids', () => {
-	test('PersonClaimCTABand renders form#person-claim-owner', async () => {
+	/**
+	 * The owner form was retired deliberately (marketing, 2026-08-17): the band
+	 * sends the candidate to Win sign-up instead of collecting their address, so
+	 * HubSpot's `person-claim-owner` collected form stops receiving submissions.
+	 *
+	 * This is the assertion that would fail if someone re-added a form to the band
+	 * without re-deciding that, which matters because a second owner form under a
+	 * new HubSpot name would silently split the history of the old one.
+	 */
+	test('the claim band no longer collects anything for HubSpot', async () => {
 		const { PersonClaimCTABand } = await import('./PersonClaimCTABand');
 
 		await render(React.createElement(PersonClaimCTABand, bandProps));
 
-		const form = document.querySelector('form#person-claim-owner');
-		expect(form).not.toBeNull();
-		// Field names are what HubSpot maps onto contact properties.
-		expect(form?.querySelector('input[name="firstname"]')).not.toBeNull();
-		expect(form?.querySelector('input[name="email"]')).not.toBeNull();
-	});
-
-	test('the band form carries no classes, so HubSpot sees #person-claim-owner alone', async () => {
-		const { PersonClaimCTABand } = await import('./PersonClaimCTABand');
-
-		await render(React.createElement(PersonClaimCTABand, bandProps));
-
-		expectNoStylingClasses(document.querySelector('form#person-claim-owner'));
+		expect(document.querySelector('form')).toBeNull();
 	});
 
 	test('the claim dialog notify form renders form#person-claim-notify', async () => {
@@ -151,14 +148,16 @@ describe('claim form HubSpot ids', () => {
 		expectNoStylingClasses(document.querySelector('form#person-claim-notify'));
 	});
 
-	test('the two ids differ, so HubSpot files owner claims apart from visitor nudges', async () => {
+	test('the notify form is the only one left on an unclaimed profile', async () => {
 		const [{ PersonClaimCTABand }, { NotifyForm }] = await Promise.all([
 			import('./PersonClaimCTABand'),
 			import('./ClaimProfileModal'),
 		]);
 
-		// Both are reachable on an unclaimed empowered profile. Sharing an id would
-		// collapse the two intents into one HubSpot form, besides being invalid markup.
+		// Both surfaces are reachable on an unclaimed candidate profile. The notify
+		// form is fed by OTHER people asking this person to complete their profile
+		// and feeds `candidate_profile_requests`, so it survives the owner form's
+		// removal untouched — different intent, different audience, different table.
 		await render(
 			React.createElement(
 				React.Fragment,
@@ -168,10 +167,7 @@ describe('claim form HubSpot ids', () => {
 			),
 		);
 
-		const ids = [...document.querySelectorAll('form')].map(f => f.id);
-		expect(ids).toContain('person-claim-owner');
-		expect(ids).toContain('person-claim-notify');
-		expect(new Set(ids).size).toBe(ids.length);
+		expect([...document.querySelectorAll('form')].map(f => f.id)).toEqual(['person-claim-notify']);
 	});
 });
 

--- a/src/components/people/claimPromptCopy.test.tsx
+++ b/src/components/people/claimPromptCopy.test.tsx
@@ -235,37 +235,28 @@ describe('the notify dialog matches Figma 1901:51851', () => {
 });
 
 describe('the claim band matches Figma 1922:92593', () => {
-	async function renderBand(isRunning: boolean) {
+	async function renderBand() {
 		const { PersonClaimCTABand } = await import('./PersonClaimCTABand');
-		await render(
-			React.createElement(PersonClaimCTABand, {
-				personId: '11111111-1111-4111-8111-111111111111',
-				displayName,
-				isRunning,
-			}),
-		);
+		await render(React.createElement(PersonClaimCTABand, { displayName }));
 	}
 
+	/**
+	 * The heading is the frame's, verbatim, and it is the page's ONLY "Are you
+	 * [Name]?" — the content well above is notify-only.
+	 *
+	 * The body's last clause is not the frame's. Figma ends "Enter your email to
+	 * get started" because the frame draws an inline form here; marketing replaced
+	 * that form with a link into Win sign-up (2026-08-17), so the sentence had to
+	 * name what the button actually does. The rest is the frame's one body for
+	 * every unclaimed state — it does not branch on running vs in office, and the
+	 * band takes no prop it could branch on.
+	 */
 	test('the band is the page’s only place to claim, and says so in Figma’s words', async () => {
-		await renderBand(true);
+		await renderBand();
 
 		expect(document.querySelector('h2')?.textContent).toBe(`Are you ${displayName}? Complete your profile now.`);
 		expect(document.querySelector('h2 + div')?.textContent).toBe(
-			'Your community deserves accountable leadership. Claim your profile and share your top priorities with residents. Enter your email to get started',
+			'Your community deserves accountable leadership. Claim your profile and share why you\u2019re running and your top priorities with residents. Create a free GoodParty.org account to get started.',
 		);
-	});
-
-	/**
-	 * The frames draw one body for every unclaimed state. It briefly branched on
-	 * running vs in office, which is invented copy — the branch belongs on the
-	 * routing and the confirmation, both of which are below the fold on submit.
-	 */
-	test('the body does not branch on the person’s product', async () => {
-		await renderBand(true);
-		const running = document.querySelector('h2 + div')?.textContent;
-
-		await renderBand(false);
-
-		expect(document.querySelector('h2 + div')?.textContent).toBe(running);
 	});
 });

--- a/src/components/people/claimPromptCopy.test.tsx
+++ b/src/components/people/claimPromptCopy.test.tsx
@@ -5,16 +5,19 @@ import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 
 /**
- * Pins the voter-facing claim prompt card to the Figma unclaimed frames:
- *   D 1958:108619 (candidate only)   E 1928:99467 (elected official only)
- *   F 1928:100987 (serving and running — word-for-word identical to E)
+ * Pins the notify prompt card and its dialog to the Figma unclaimed frames:
+ *   card    D 1958:108619 (candidate only)   E 1928:99467 (elected official only)
+ *           F 1928:100987 (serving and running — word-for-word identical to E)
+ *   dialog  1901:51851
  * Past-election profiles (H 1970:113629) show the voter-guide disclaimer instead
  * of a claim prompt, so no card copy exists for that persona.
  *
- * The copy drifted once already (the shipped card asked "Want to hear from
- * [Name]?" while the frames ask visitors to send a request), which nothing
- * caught because no test read the card's words. The persona split is the part
- * most likely to regress: it is NOT the owner card's running/not-running one.
+ * The copy has drifted twice — first the card asked "Want to hear from [Name]?"
+ * while the frames ask visitors to send a request, then the dialog was rewritten
+ * into a "Claim your GoodParty.org profile" account pitch the frames never had.
+ * Both times nothing caught it because no test read the words. The persona split
+ * is the part most likely to regress next: it splits on holding office, not on
+ * running, so `both` takes the officeholder copy.
  *
  * Like claimFormIds.test.tsx these mount the component directly rather than
  * driving the Radix dialog, whose click delegation has proven unreliable under
@@ -92,7 +95,6 @@ const displayName = 'Example Person';
 
 async function renderPromptCard(options: {
 	persona: 'candidate' | 'officeholder' | 'both';
-	variant?: 'voter-card' | 'owner-card';
 	locationLabel?: string | null;
 }) {
 	const { ClaimProfileModal } = await import('./ClaimProfileModal');
@@ -103,14 +105,13 @@ async function renderPromptCard(options: {
 			displayName,
 			persona: options.persona,
 			locationLabel: options.locationLabel ?? null,
-			variant: options.variant ?? 'voter-card',
 		}),
 	);
 }
 
-function card(variant: 'voter-card' | 'owner-card' = 'voter-card') {
-	const element = document.querySelector(`[data-component='ClaimPromptCard'][data-variant='${variant}']`);
-	if (!element) throw new Error(`expected the ${variant} claim prompt to render`);
+function card() {
+	const element = document.querySelector(`[data-component='ClaimPromptCard']`);
+	if (!element) throw new Error('expected the claim prompt to render');
 	return {
 		heading: element.querySelector('h2')?.textContent ?? '',
 		body: element.querySelector('h2 + div')?.textContent ?? '',
@@ -176,15 +177,95 @@ describe('the voter claim prompt card matches the Figma frames', () => {
 	});
 });
 
-describe('the owner claim prompt card is untouched by the voter copy', () => {
-	/**
-	 * The two cards share a component and sit next to each other in the content
-	 * well, so voter copy leaking into the owner card would be easy to miss.
-	 */
-	test('the owner card keeps its own heading and button', async () => {
-		await renderPromptCard({ persona: 'candidate', variant: 'owner-card', locationLabel: 'Springfield' });
+describe('the notify dialog matches Figma 1901:51851', () => {
+	async function openDialog() {
+		await renderPromptCard({ persona: 'candidate', locationLabel: 'Springfield' });
+		const { NotifyForm } = await import('./ClaimProfileModal');
+		return NotifyForm;
+	}
 
-		expect(card('owner-card').heading).toBe(`Are you ${displayName}?`);
-		expect(card('owner-card').button).toBe('Complete your profile');
+	test('the card is the only claim surface in the content well', async () => {
+		await renderPromptCard({ persona: 'candidate', locationLabel: 'Springfield' });
+
+		expect(document.querySelectorAll(`[data-component='ClaimPromptCard']`)).toHaveLength(1);
+	});
+
+	/**
+	 * The dialog is one sentence asking the visitor to nudge the person. It is
+	 * NOT the "create a free account and take control of this page" pitch that
+	 * replaced it once — that copy sells claiming to a reader who has just told
+	 * us they are somebody else.
+	 */
+	test('the title asks the visitor to nudge the person, not to claim', async () => {
+		const { notifyDialogTitle } = await import('./ClaimProfileModal');
+
+		expect(notifyDialogTitle(displayName)).toBe(
+			`Ask ${displayName} to complete their profile and contribute to transparency.`,
+		);
+	});
+
+	test('the form is name, email, opt-in, Cancel and Submit — nothing else', async () => {
+		const NotifyForm = await openDialog();
+		await render(
+			React.createElement(NotifyForm, {
+				personId: '11111111-1111-4111-8111-111111111111',
+				displayName,
+				onCancel: () => {},
+			}),
+		);
+
+		const labels = [...document.querySelectorAll('label')].map(l => l.textContent?.trim() ?? '');
+		expect(labels[0]).toBe('Name (optional)');
+		expect(labels[1]).toContain('Email address');
+		expect(labels[2]).toContain('Sign up for marketing communications from GoodParty.org');
+
+		const buttons = [...document.querySelectorAll('button')].map(b => b.textContent?.trim());
+		expect(buttons).toEqual(['Cancel', 'Submit']);
+	});
+
+	/** A pre-ticked opt-in is not consent; the frames draw it ticked anyway. */
+	test('the marketing opt-in starts unchecked', async () => {
+		const NotifyForm = await openDialog();
+		await render(
+			React.createElement(NotifyForm, { personId: '11111111-1111-4111-8111-111111111111', displayName }),
+		);
+
+		expect(document.querySelector<HTMLInputElement>('input[type="checkbox"]')?.checked).toBe(false);
+	});
+});
+
+describe('the claim band matches Figma 1922:92593', () => {
+	async function renderBand(isRunning: boolean) {
+		const { PersonClaimCTABand } = await import('./PersonClaimCTABand');
+		await render(
+			React.createElement(PersonClaimCTABand, {
+				personId: '11111111-1111-4111-8111-111111111111',
+				displayName,
+				isRunning,
+			}),
+		);
+	}
+
+	test('the band is the page’s only place to claim, and says so in Figma’s words', async () => {
+		await renderBand(true);
+
+		expect(document.querySelector('h2')?.textContent).toBe(`Are you ${displayName}? Complete your profile now.`);
+		expect(document.querySelector('h2 + div')?.textContent).toBe(
+			'Your community deserves accountable leadership. Claim your profile and share your top priorities with residents. Enter your email to get started',
+		);
+	});
+
+	/**
+	 * The frames draw one body for every unclaimed state. It briefly branched on
+	 * running vs in office, which is invented copy — the branch belongs on the
+	 * routing and the confirmation, both of which are below the fold on submit.
+	 */
+	test('the body does not branch on the person’s product', async () => {
+		await renderBand(true);
+		const running = document.querySelector('h2 + div')?.textContent;
+
+		await renderBand(false);
+
+		expect(document.querySelector('h2 + div')?.textContent).toBe(running);
 	});
 });

--- a/src/components/people/personSectionOverrides.test.ts
+++ b/src/components/people/personSectionOverrides.test.ts
@@ -143,10 +143,15 @@ describe('the claim prompt and the claim form ship together', () => {
 		'x-3412f69c',
 	];
 
-	function claimPromptVariants(slug: string): string[] {
+	/**
+	 * The prompt is the only content card handed a person and a place, so it is
+	 * identified by its props rather than by importing the component — this suite
+	 * runs without a DOM and the component pulls in Radix.
+	 */
+	function claimPrompts(slug: string): { locationLabel?: unknown }[] {
 		return contentCards(slug).flatMap(card => {
-			const variant = (card.content as { props?: { variant?: string } } | undefined)?.props?.variant;
-			return variant ? [variant] : [];
+			const props = (card.content as { props?: Record<string, unknown> } | undefined)?.props;
+			return props && 'personId' in props && 'locationLabel' in props ? [props] : [];
 		});
 	}
 
@@ -158,50 +163,52 @@ describe('the claim prompt and the claim form ship together', () => {
 	}
 
 	/**
-	 * The owner prompt's button scrolls to `#person-claim-form`, and that anchor
-	 * only exists inside PersonClaimCTABand. Both hang off the same `showClaim`
-	 * gate today; this pins the pairing so a future change to either gate cannot
-	 * quietly leave the button scrolling to nothing.
+	 * The prompt asks a visitor to nudge the person; the band is where that
+	 * person actually claims. Both hang off the same `showClaim` gate today, and
+	 * a page carrying one without the other is incoherent either way — a nudge
+	 * leading nowhere, or a claim form on a page that never mentions claiming.
 	 */
-	test('no state renders the owner claim prompt without the claim form below it', () => {
+	test('no state renders the claim prompt without the claim band below it', () => {
 		for (const slug of ALL_STATES) {
-			expect([slug, claimPromptVariants(slug).includes('owner-card')]).toEqual([slug, rendersClaimBand(slug)]);
+			expect([slug, claimPrompts(slug).length > 0]).toEqual([slug, rendersClaimBand(slug)]);
 		}
 	});
 
-	test('the unclaimed states lead with the owner prompt, then the voter prompt', () => {
+	/**
+	 * The frames put exactly ONE card at the top of the content well and it is
+	 * visitor-facing (D 1958:108619, E 1928:99467). An owner-facing "are you
+	 * [Name]?" prompt was added alongside it once and had to be taken back out;
+	 * this is what stops a second one reappearing.
+	 */
+	test('the unclaimed states lead with exactly one claim prompt', () => {
 		for (const slug of ['kim-byrd-b77f912d', 'rob-zotti-d8c578fb', 'tim-ficken-0a951485']) {
-			expect([slug, claimPromptVariants(slug)]).toEqual([slug, ['owner-card', 'voter-card']]);
+			expect([slug, claimPrompts(slug).length]).toEqual([slug, 1]);
 		}
 	});
 
 	// A claimed profile has nothing to claim, and a removed one asked us to stop.
-	test('claimed and removed states show neither prompt', () => {
+	test('claimed and removed states show no prompt', () => {
 		for (const slug of ['allen-slagle-74eee01a', 'x-27255f40', 'x-3412f69c']) {
-			expect([slug, claimPromptVariants(slug)]).toEqual([slug, []]);
+			expect([slug, claimPrompts(slug).length]).toEqual([slug, 0]);
 		}
 	});
 
-	function voterPromptLocation(cards: ReturnType<typeof contentCards>): unknown {
+	function promptLocation(cards: ReturnType<typeof contentCards>): unknown {
 		return cards
-			.map(card => (card.content as { props?: { variant?: string; locationLabel?: unknown } } | undefined)?.props)
-			.find(props => props?.variant === 'voter-card')?.locationLabel;
-	}
-
-	function claimPromptLocation(slug: string): unknown {
-		return voterPromptLocation(contentCards(slug));
+			.map(card => (card.content as { props?: Record<string, unknown> } | undefined)?.props)
+			.find(props => props && 'personId' in props && 'locationLabel' in props)?.['locationLabel'];
 	}
 
 	/**
-	 * The voter prompt for someone in office opens "[Location] deserves greater
+	 * The prompt for someone in office opens "[Location] deserves greater
 	 * transparency" (Figma E 1928:99467, F 1928:100987). Nothing on the view is
 	 * that place — `districtLabel` is a ward, `stateLabel` a two-letter code — so
 	 * it is read back off the breadcrumb, and picking the wrong crumb would name
 	 * the state, or the office, where the frame names the town.
 	 */
-	test('the voter prompt is handed the most specific place in the breadcrumb', () => {
+	test('the prompt is handed the most specific place in the breadcrumb', () => {
 		for (const slug of ['kim-byrd-b77f912d', 'rob-zotti-d8c578fb', 'tim-ficken-0a951485']) {
-			expect([slug, claimPromptLocation(slug)]).toEqual([slug, 'Springfield']);
+			expect([slug, promptLocation(contentCards(slug))]).toEqual([slug, 'Springfield']);
 		}
 	});
 
@@ -228,7 +235,7 @@ describe('the claim prompt and the claim form ship together', () => {
 			}),
 		};
 		const cards = buildPersonSectionOverrides(stateOnly).component_profileContentBlock?.contentCards ?? [];
-		expect(voterPromptLocation(cards)).toBe('Wyoming');
+		expect(promptLocation(cards)).toBe('Wyoming');
 	});
 });
 

--- a/src/components/people/personSectionOverrides.test.ts
+++ b/src/components/people/personSectionOverrides.test.ts
@@ -176,12 +176,16 @@ describe('the claim prompt and the claim form ship together', () => {
 
 	/**
 	 * The frames put exactly ONE card at the top of the content well and it is
-	 * visitor-facing (D 1958:108619, E 1928:99467). An owner-facing "are you
+	 * visitor-facing (D 1958:108619, F 1928:100987). An owner-facing "are you
 	 * [Name]?" prompt was added alongside it once and had to be taken back out;
 	 * this is what stops a second one reappearing.
+	 *
+	 * State E is absent on purpose: an unclaimed officeholder is no longer asked
+	 * to claim anything (see the office-only gating below), so it has no prompt
+	 * to count.
 	 */
 	test('the unclaimed states lead with exactly one claim prompt', () => {
-		for (const slug of ['kim-byrd-b77f912d', 'rob-zotti-d8c578fb', 'tim-ficken-0a951485']) {
+		for (const slug of ['kim-byrd-b77f912d', 'tim-ficken-0a951485']) {
 			expect([slug, claimPrompts(slug).length]).toEqual([slug, 1]);
 		}
 	});
@@ -207,23 +211,26 @@ describe('the claim prompt and the claim form ship together', () => {
 	 * the state, or the office, where the frame names the town.
 	 */
 	test('the prompt is handed the most specific place in the breadcrumb', () => {
-		for (const slug of ['kim-byrd-b77f912d', 'rob-zotti-d8c578fb', 'tim-ficken-0a951485']) {
+		for (const slug of ['kim-byrd-b77f912d', 'tim-ficken-0a951485']) {
 			expect([slug, promptLocation(contentCards(slug))]).toEqual([slug, 'Springfield']);
 		}
 	});
 
 	/**
-	 * The dev fixtures hand every persona a city race, but in production someone
-	 * who only holds office has no candidacy and so no race slug, and their trail
-	 * degrades to `Elections > State > Name`. The card then names the state. That
-	 * is the accepted degradation (see `profileLocationLabel`) — what must not
-	 * happen is the state crumb being skipped for the office, or dropped for the
-	 * generic subject, so this pins the degraded shape rather than assuming the
-	 * fixtures represent it.
+	 * The dev fixtures hand every persona a city race, but in production a
+	 * candidacy can arrive without a slug, leaving no race for the trail to hang
+	 * off, and it degrades to `Elections > State > Name`. The card then names the
+	 * state. That is the accepted degradation (see `profileLocationLabel`) — what
+	 * must not happen is the state crumb being skipped for the office, or dropped
+	 * for the generic subject, so this pins the degraded shape rather than
+	 * assuming the fixtures represent it.
+	 *
+	 * Driven from state F rather than E: the office-only persona no longer renders
+	 * a prompt for the label to reach.
 	 */
-	test('an officeholder with no race falls back to the state, not the office', () => {
-		const view = getDevPersonProfileView('rob-zotti-d8c578fb');
-		if (!view) throw new Error('no dev fixture for rob-zotti-d8c578fb');
+	test('a profile with no race falls back to the state, not the office', () => {
+		const view = getDevPersonProfileView('tim-ficken-0a951485');
+		if (!view) throw new Error('no dev fixture for tim-ficken-0a951485');
 		const stateOnly = {
 			...view,
 			breadcrumb: buildBreadcrumbTrail({
@@ -236,6 +243,142 @@ describe('the claim prompt and the claim form ship together', () => {
 		};
 		const cards = buildPersonSectionOverrides(stateOnly).component_profileContentBlock?.contentCards ?? [];
 		expect(promptLocation(cards)).toBe('Wyoming');
+	});
+});
+
+/**
+ * Marketing removed the claim CTAs from elected-official-only pages (Slack,
+ * 2026-08-17) — someone who only holds office has no self-serve product to be
+ * sent to. The gate reads `persona !== 'officeholder'`, and the persona that is
+ * easy to lose is 'both': `resolvePersona` returns it for someone currently in
+ * office AND running now, and they keep the candidate treatment because they
+ * have a live candidacy to claim into. Nothing else in the file distinguishes
+ * the two, so a future reading of "elected officials" as "anyone in office"
+ * would silently take state F's CTAs with it.
+ */
+describe('claim CTAs are gone from the office-only pages and nowhere else', () => {
+	function claimSurfaces(slug: string): { prompts: number; band: boolean } {
+		const view = getDevPersonProfileView(slug);
+		if (!view) throw new Error(`no dev fixture for ${slug}`);
+		const overrides = buildPersonSectionOverrides(view);
+		const cta = overrides.component_ctaBannerBlock as { render?: unknown } | undefined;
+		return {
+			// Identified the same way `claimPrompts` does it above: the prompt is the
+			// only card handed both a `personId` and a `locationLabel`. This used to
+			// key on a `variant` prop, which went with the owner card — and a filter
+			// on a prop that no longer exists counts zero on every page, which reads
+			// as "the CTAs are gone" no matter what actually rendered.
+			prompts: (overrides.component_profileContentBlock?.contentCards ?? []).filter(card => {
+				const props = (card.content as { props?: Record<string, unknown> } | undefined)?.props;
+				return Boolean(props && 'personId' in props && 'locationLabel' in props);
+			}).length,
+			band: cta?.render !== undefined,
+		};
+	}
+
+	test('state E — an unclaimed officeholder is asked for nothing', () => {
+		expect(getDevPersonProfileView('rob-zotti-d8c578fb')?.persona).toBe('officeholder');
+		expect(claimSurfaces('rob-zotti-d8c578fb')).toEqual({ prompts: 0, band: false });
+	});
+
+	test('state E falls through to no CTA band at all, not the claimed sign-up one', () => {
+		const view = getDevPersonProfileView('rob-zotti-d8c578fb');
+		if (!view) throw new Error('no dev fixture for rob-zotti-d8c578fb');
+		expect(buildPersonSectionOverrides(view).component_ctaBannerBlock).toEqual({ hidden: true });
+	});
+
+	test('states D and F — running, so still asked to claim', () => {
+		expect(getDevPersonProfileView('kim-byrd-b77f912d')?.persona).toBe('candidate');
+		expect(getDevPersonProfileView('tim-ficken-0a951485')?.persona).toBe('both');
+		expect(claimSurfaces('kim-byrd-b77f912d')).toEqual({ prompts: 1, band: true });
+		expect(claimSurfaces('tim-ficken-0a951485')).toEqual({ prompts: 1, band: true });
+	});
+
+	test('state E keeps its civics spine — this removed the ask, not the page', () => {
+		const headings = sectionHeadings('rob-zotti-d8c578fb');
+		expect(headings).toContain('Recent Experience');
+		expect(headings).toContain('District information');
+		expect(headings).toContain('Nearby Officials');
+	});
+});
+
+/**
+ * The hero attribution line. Marketing's spec keyed the pledge copy off CLAIM
+ * status; these pin it to the pledge flag instead, because they are separate
+ * facts (see `pledgeAttribution`). State B is the case that proves it: a claimed
+ * officeholder is `pledged: false` in the shared matrix, because `isPledged`
+ * only ever rolls up from candidacies, so the literal spec would have published
+ * "Has Taken the GoodParty.org Pledge" about them.
+ */
+describe('the hero states the pledge fact, not the claim', () => {
+	const EXPECTED: Array<[string, string, string | undefined]> = [
+		['A', 'allen-slagle-74eee01a', 'pledged'],
+		['B', 'tracy-good-ecff49d3', 'notPledged'],
+		['C', 'susan-overman-ad914b82', 'pledged'],
+		['D', 'kim-byrd-b77f912d', 'notPledged'],
+		['E', 'rob-zotti-d8c578fb', 'notPledged'],
+		['F', 'tim-ficken-0a951485', 'notPledged'],
+		['G', 'bill-fortner-61a42912', 'notPledged'],
+		['H', 'gregory-schreurs-136cadf0', 'notPledged'],
+		['I', 'jeb-hanson-3753676b', 'pledgeIneligible'],
+		['J', 'deb-craft-f88e7434', 'pledgeIneligible'],
+		['K', 'x-27255f40', 'none'],
+		['L', 'x-3412f69c', 'none'],
+	];
+
+	function hero(slug: string) {
+		const view = getDevPersonProfileView(slug);
+		if (!view) throw new Error(`no dev fixture for ${slug}`);
+		return buildPersonSectionOverrides(view).component_profileHero;
+	}
+
+	test('every state resolves to its intended line', () => {
+		for (const [state, slug, attribution] of EXPECTED) {
+			expect([state, hero(slug)?.attribution]).toEqual([state, attribution]);
+		}
+	});
+
+	test('state B — claimed, but the flag says they have not pledged', () => {
+		const view = getDevPersonProfileView('tracy-good-ecff49d3');
+		// Guards the premise. If a fixture change ever makes this person pledged,
+		// the assertion above stops testing the divergence and starts agreeing with
+		// the literal spec by accident.
+		expect([view?.claimed, view?.pledged]).toEqual([true, false]);
+	});
+
+	test('the other divergence — unclaimed, but they did take the pledge', () => {
+		// The bug behind this whole decision: pledged people showing up on
+		// unclaimed pages. No fixture carries the combination (the unclaimed
+		// fixtures leave the spine flag off), so it is composed here rather than
+		// left untested.
+		const view = getDevPersonProfileView('kim-byrd-b77f912d');
+		if (!view) throw new Error('no dev fixture for kim-byrd-b77f912d');
+		const hero = buildPersonSectionOverrides({ ...view, pledged: true }).component_profileHero;
+		expect(hero?.attribution).toBe('pledged');
+		// Still unclaimed, so the page carries no GoodParty.org mark: the line
+		// reports a fact about the person, the mark says whose profile this is.
+		expect(hero?.showBrandMark).toBe(false);
+	});
+
+	test('a major-party page says ineligible even if the spine flags a pledge', () => {
+		// A stale flag from a run under another party must not outrank the party
+		// the page currently reports — the two lines would contradict each other.
+		const view = getDevPersonProfileView('jeb-hanson-3753676b');
+		if (!view) throw new Error('no dev fixture for jeb-hanson-3753676b');
+		expect(buildPersonSectionOverrides({ ...view, pledged: true }).component_profileHero?.attribution).toBe(
+			'pledgeIneligible',
+		);
+	});
+
+	test('the GoodParty.org mark still follows the claim, not the pledge', () => {
+		// Every claimed officeholder is unpledgeable, so keying the mark on the
+		// pledge would strip the branding off a whole persona's claimed profiles.
+		for (const [state, slug] of [['A', 'allen-slagle-74eee01a'], ['B', 'tracy-good-ecff49d3'], ['G', 'bill-fortner-61a42912']] as const) {
+			expect([state, hero(slug)?.showBrandMark]).toEqual([state, true]);
+		}
+		for (const [state, slug] of [['D', 'kim-byrd-b77f912d'], ['I', 'jeb-hanson-3753676b'], ['K', 'x-27255f40']] as const) {
+			expect([state, hero(slug)?.showBrandMark]).toEqual([state, false]);
+		}
 	});
 });
 
@@ -297,7 +440,7 @@ describe('the removal states publish the civics spine and nothing else', () => {
 
 	test('the removal frames carry no card without a heading', () => {
 		// The claim prompts are the only chrome-less `raw` cards in the well, and
-		// `claimPromptVariants` above already pins that they are gone. This catches
+		// `claimPrompts` above already pins that they are gone. This catches
 		// a future raw card (a banner, a notice) being added to every unclaimed
 		// page and silently landing on a page we are meant to have stripped.
 		for (const [state, slug] of REMOVAL_SLUGS) {
@@ -305,14 +448,19 @@ describe('the removal states publish the civics spine and nothing else', () => {
 		}
 	});
 
-	test('the hero is stripped of the photo and never reads as endorsed', () => {
+	test('the hero is stripped of the photo and says nothing about the pledge', () => {
+		// This asserted `notEndorsed` when it was written. The pledge copy replaced
+		// that line, and removal now resolves to no line at all rather than "Has
+		// Not Taken the GoodParty.org Pledge": `pledged` is force-cleared on
+		// removal, so the negative would be a claim we cannot stand behind, made
+		// about the one group who asked us to stop publishing them.
 		for (const [state, slug] of REMOVAL_SLUGS) {
 			const view = getDevPersonProfileView(slug);
 			if (!view) throw new Error(`no dev fixture for ${slug}`);
 			const hero = buildPersonSectionOverrides(view).component_profileHero;
 			expect([state, hero?.profileImageUrl]).toEqual([state, undefined]);
 			expect([state, hero?.isEmpowered]).toEqual([state, false]);
-			expect([state, hero?.attribution]).toEqual([state, 'notEndorsed']);
+			expect([state, hero?.attribution]).toEqual([state, 'none']);
 		}
 	});
 

--- a/src/components/people/personSectionOverrides.test.ts
+++ b/src/components/people/personSectionOverrides.test.ts
@@ -232,6 +232,135 @@ describe('the claim prompt and the claim form ship together', () => {
 	});
 });
 
+/**
+ * The removal states (Figma K 1997:118776 / desktop 1997:118777, L 1997:118282 /
+ * desktop 1997:118283) are the two frames with a legal obligation behind them:
+ * someone asked us to stop publishing their profile, and we kept the crawlable
+ * civics spine on the understanding that everything they or we authored comes
+ * off. Nothing pinned that, so any of it could have been restored by a change
+ * aimed at another state — the authored slot, the hero photo, the pledge badge
+ * and the contact links are all shared code paths.
+ *
+ * These assert on absence, which is exactly what a visual diff is worst at: the
+ * harness scores K/L on a blurred layout metric where a re-appearing avatar or
+ * pledge pill is a rounding error.
+ */
+describe('the removal states publish the civics spine and nothing else', () => {
+	const REMOVAL_SLUGS = [
+		['K', 'x-27255f40'],
+		['L', 'x-3412f69c'],
+	] as const;
+
+	/** Every authored section a claimed page can render, in any persona. */
+	const AUTHORED_HEADINGS = [
+		'Why I\u2019m Running for Office',
+		'Why I Served',
+		'Campaign Issues',
+		'Top Priorities While in Office',
+		'Accomplishments During This Term',
+		'About Me',
+	];
+
+	test('state K — a removed candidate keeps only the public record', () => {
+		expect(sectionHeadings('x-27255f40')).toEqual([
+			'Recent Experience',
+			'Other Candidates for Springfield City Council',
+			'About Springfield City Council',
+			'District information',
+		]);
+	});
+
+	test('state L — a removed officeholder keeps only the public record', () => {
+		expect(sectionHeadings('x-3412f69c')).toEqual([
+			'Recent Experience',
+			'District information',
+			'About Springfield City Council',
+			'Nearby Officials',
+		]);
+	});
+
+	test('neither removal state renders a single authored section', () => {
+		for (const [state, slug] of REMOVAL_SLUGS) {
+			const headings = sectionHeadings(slug);
+			for (const authored of AUTHORED_HEADINGS) {
+				expect([state, authored, headings.includes(authored)]).toEqual([state, authored, false]);
+			}
+		}
+	});
+
+	test('the removal frames carry no card without a heading', () => {
+		// The claim prompts are the only chrome-less `raw` cards in the well, and
+		// `claimPromptVariants` above already pins that they are gone. This catches
+		// a future raw card (a banner, a notice) being added to every unclaimed
+		// page and silently landing on a page we are meant to have stripped.
+		for (const [state, slug] of REMOVAL_SLUGS) {
+			expect([state, contentCards(slug).filter(card => !card.heading)]).toEqual([state, []]);
+		}
+	});
+
+	test('the hero is stripped of the photo and never reads as endorsed', () => {
+		for (const [state, slug] of REMOVAL_SLUGS) {
+			const view = getDevPersonProfileView(slug);
+			if (!view) throw new Error(`no dev fixture for ${slug}`);
+			const hero = buildPersonSectionOverrides(view).component_profileHero;
+			expect([state, hero?.profileImageUrl]).toEqual([state, undefined]);
+			expect([state, hero?.isEmpowered]).toEqual([state, false]);
+			expect([state, hero?.attribution]).toEqual([state, 'notEndorsed']);
+		}
+	});
+
+	test('the pledge badge is suppressed even though the spine still flags it', () => {
+		// Both removal fixtures seed `isPledged: true`. Pledging is a factual civics
+		// flag, so the only reason it does not paint is the removal — making this
+		// the one assertion that would catch removal being dropped from `pledged`.
+		for (const [state, slug] of REMOVAL_SLUGS) {
+			expect([state, getDevPersonProfileView(slug)?.pledged]).toEqual([state, false]);
+		}
+	});
+
+	test('the CTA band is hidden rather than swapped for the generic sign-up', () => {
+		for (const [state, slug] of REMOVAL_SLUGS) {
+			const view = getDevPersonProfileView(slug);
+			if (!view) throw new Error(`no dev fixture for ${slug}`);
+			expect([state, buildPersonSectionOverrides(view).component_ctaBannerBlock]).toEqual([
+				state,
+				{ hidden: true },
+			]);
+		}
+	});
+
+	test('the sidebar keeps the persona facts and drops every way to contact them', () => {
+		// Contact icons, office email/phone and the mailing address all hang off
+		// `view.links` / `view.officeAddress`, which removal empties. The office
+		// address in particular is a home-adjacent detail on a page the subject
+		// asked us to take down.
+		for (const [state, slug] of REMOVAL_SLUGS) {
+			const view = getDevPersonProfileView(slug);
+			if (!view) throw new Error(`no dev fixture for ${slug}`);
+			const sidebar = buildPersonSectionOverrides(view).component_profileContentBlock?.sidebar;
+			expect([state, sidebar?.contactIcons ?? []]).toEqual([state, []]);
+			expect([state, sidebar?.officeContacts ?? []]).toEqual([state, []]);
+			expect([state, sidebar?.officeAddress ?? []]).toEqual([state, []]);
+			// Party is public record and stays — losing it would be over-stripping.
+			expect([state, Boolean(sidebar?.politicalAffiliation)]).toEqual([state, true]);
+		}
+	});
+
+	test('K shows its election date; L, who is not running, does not', () => {
+		// The Figma removal frames are one generic template that shows both rows on
+		// both states (logged in harness/FOLLOWUPS.md as a reference artifact), so
+		// the harness cannot arbitrate this. Persona correctness is pinned here.
+		const rowLabels = (slug: string) => {
+			const view = getDevPersonProfileView(slug);
+			if (!view) throw new Error(`no dev fixture for ${slug}`);
+			const sidebar = buildPersonSectionOverrides(view).component_profileContentBlock?.sidebar;
+			return (sidebar?.topInfos ?? []).map(info => info.label);
+		};
+		expect(rowLabels('x-27255f40')).toEqual(['Election Date']);
+		expect(rowLabels('x-3412f69c')).toEqual([]);
+	});
+});
+
 describe('card grouping sets the Figma heading levels', () => {
 	/** Headings per white card: the first is the 32/44 one, the rest are 24/32. */
 	function headingsByCard(slug: string): string[][] {

--- a/src/components/people/personSectionOverrides.tsx
+++ b/src/components/people/personSectionOverrides.tsx
@@ -656,6 +656,34 @@ function profileLocationLabel(view: PersonProfileView): string | null {
 }
 
 /**
+ * Which pledge statement the hero makes about this person.
+ *
+ * Marketing specified these three lines keyed off CLAIM status ("has taken" for
+ * claimed, "has not" for unclaimed). Claiming and pledging are separate facts
+ * here: `pledged` is the ETL-maintained spine flag `Person.isPledged`, rolled up
+ * from candidacies, and nothing in the claim path writes it. A claimed
+ * officeholder cannot carry it at all — they have no candidacy for it to roll up
+ * from, which is why state B in the shared matrix is `claimed` and `pledged:
+ * false` — and a pledged candidate whose page nobody has claimed carries it
+ * while reading as unclaimed. Keying the sentence to the claim would therefore
+ * publish "Has Taken the GoodParty.org Pledge" about named people who have not,
+ * so each line is keyed to the fact it asserts instead.
+ *
+ * Party wins over the pledge flag: a Democrat or Republican is not eligible to
+ * take the pledge, so their status is ineligibility rather than a choice, and a
+ * stale `isPledged` from a past run under another party must not override that.
+ *
+ * Removal (K/L) says nothing at all. `pledged` is force-cleared for removed
+ * profiles, so "Has Not Taken…" there would be a line we know may be false,
+ * asserted about the one group who asked us to stop publishing them.
+ */
+function pledgeAttribution(view: PersonProfileView): 'pledged' | 'notPledged' | 'pledgeIneligible' | 'none' {
+	if (view.removed) return 'none';
+	if (view.majorParty) return 'pledgeIneligible';
+	return view.pledged ? 'pledged' : 'notPledged';
+}
+
+/**
  * Maps a resolved PersonProfileView onto the `personProfile` template's section
  * overrides (keyed by section `_type`/`_key`). Per-state gating (empowerment,
  * removal, claim/pledge/CTA visibility) is expressed by suppressing sections —
@@ -664,12 +692,24 @@ function profileLocationLabel(view: PersonProfileView): string | null {
 export function buildPersonSectionOverrides(view: PersonProfileView): SectionOverrides {
 	// Past-election profiles (G claimed, H unclaimed) lead with the past-election
 	// disclaimer, NOT the claim CTA — so exclude persona 'past' from the claim gate.
+	//
 	// `unpublished` is excluded too: the profile is already claimed, it just isn't
 	// live, so "Are you …? Claim your profile" addresses someone who owns it and
 	// the voter-facing prompt asks the reader to nudge a person who already
 	// decided. This is the only difference from the equivalent `absent` page.
+	//
+	// 'officeholder' is excluded too (marketing, 2026-08-17): someone who only
+	// holds office has no self-serve product to be sent to, so their claim
+	// prompts asked for an email that sales then had to action by hand. Note this
+	// is the officeholder persona ONLY — 'both' (serving AND running) keeps the
+	// candidate treatment, because they have a live candidacy and Win to claim
+	// into. State E therefore loses its claim surfaces entirely; D/F keep theirs.
 	const showClaim =
-		view.empowered && !view.claimed && !view.unpublished && view.persona !== 'past';
+		view.empowered &&
+		!view.claimed &&
+		!view.unpublished &&
+		view.persona !== 'past' &&
+		view.persona !== 'officeholder';
 	// The pledge explainer is claimed content across every persona (Figma A/B/C/G
 	// all show it once claimed). Unclaimed empowered pages lead with the claim
 	// prompt instead, so it stays hidden there.
@@ -677,9 +717,9 @@ export function buildPersonSectionOverrides(view: PersonProfileView): SectionOve
 
 	// The person-profile CTA band sits below the content well (Figma order):
 	//  - claimed (A/B/C/G)   → generic centered "Join the movement" sign-up CTA
-	//  - unclaimed empowered (D/E/F/H) → full-width interactive claim CTA band
-	//    ("Are you …? Complete your profile now." + inline name/email form)
-	//  - major-party (I/J) + removed (K/L) → no CTA band
+	//  - unclaimed empowered candidates (D/F) → full-width claim CTA band
+	//    ("Are you …? Complete your profile now." + a button into Win sign-up)
+	//  - officeholder-only (E), past (H), major-party (I/J), removed (K/L) → none
 	const ctaOverride: SectionOverrides['component_ctaBannerBlock'] = view.claimed
 		? {
 				align: 'center',
@@ -699,15 +739,7 @@ export function buildPersonSectionOverrides(view: PersonProfileView): SectionOve
 				// center, which is the misalignment marketing reported.
 			}
 		: showClaim
-			? {
-					render: (
-						<PersonClaimCTABand
-							personId={view.personId}
-							displayName={view.displayName}
-							isRunning={view.persona === 'candidate' || view.persona === 'both'}
-						/>
-					),
-				}
+			? { render: <PersonClaimCTABand displayName={view.displayName} /> }
 			: { hidden: true };
 
 	// The Figma content well is one column of cards. For unclaimed empowered pages
@@ -768,11 +800,13 @@ export function buildPersonSectionOverrides(view: PersonProfileView): SectionOve
 			profileImageUrl: view.avatarUrl ?? undefined,
 			isEmpowered: view.empowered,
 			tags: personaTags(view.persona),
-			// The GoodParty attribution line + on-photo logo gate on CLAIMED (endorsed):
-			// only claimed pages (A/B/C/G) show "Empowered by GoodParty.org" with the
-			// logo. Every unclaimed page — independent (D/E/F/H), major-party (I/J), and
-			// removed (K/L) — shows the neutral "Not Endorsed by GoodParty.org" line.
-			attribution: view.claimed ? 'empowered' : 'notEndorsed',
+			// The line states the person's pledge status (see `pledgeAttribution`).
+			// The GoodParty mark stays on CLAIMED, which is what it has always meant
+			// here — it marks the page as a GoodParty.org profile rather than making
+			// a claim about the pledge, and moving it onto `pledged` would strip it
+			// from every claimed officeholder.
+			attribution: pledgeAttribution(view),
+			showBrandMark: view.claimed,
 		},
 		component_claimProfileBlock: {
 			// The standalone full-width claim banner is always suppressed now: the

--- a/src/components/people/personSectionOverrides.tsx
+++ b/src/components/people/personSectionOverrides.tsx
@@ -664,7 +664,12 @@ function profileLocationLabel(view: PersonProfileView): string | null {
 export function buildPersonSectionOverrides(view: PersonProfileView): SectionOverrides {
 	// Past-election profiles (G claimed, H unclaimed) lead with the past-election
 	// disclaimer, NOT the claim CTA — so exclude persona 'past' from the claim gate.
-	const showClaim = view.empowered && !view.claimed && view.persona !== 'past';
+	// `unpublished` is excluded too: the profile is already claimed, it just isn't
+	// live, so "Are you …? Claim your profile" addresses someone who owns it and
+	// the voter-facing prompt asks the reader to nudge a person who already
+	// decided. This is the only difference from the equivalent `absent` page.
+	const showClaim =
+		view.empowered && !view.claimed && !view.unpublished && view.persona !== 'past';
 	// The pledge explainer is claimed content across every persona (Figma A/B/C/G
 	// all show it once claimed). Unclaimed empowered pages lead with the claim
 	// prompt instead, so it stays hidden there.
@@ -728,9 +733,12 @@ export function buildPersonSectionOverrides(view: PersonProfileView): SectionOve
 	// Authored slot: claimed pages show real owner content; unclaimed but
 	// empowered pages (Figma D/E/F/H) show muted placeholder prompt cards in the
 	// same slot; major-party (I/J) and removed (K/L) pages show neither.
+	// Unpublished pages are excluded as well — every placeholder ends in "once
+	// they claim their profile", so leaving them in would restate the claim
+	// prompt the block above just suppressed.
 	const authoredSections = view.claimed
 		? buildAuthoredSections(view)
-		: view.empowered
+		: view.empowered && !view.unpublished
 			? buildAuthoredPlaceholderSections(view)
 			: {};
 	const contentCards: ProfileContentCardProps[] = [

--- a/src/components/people/personSectionOverrides.tsx
+++ b/src/components/people/personSectionOverrides.tsx
@@ -711,14 +711,15 @@ export function buildPersonSectionOverrides(view: PersonProfileView): SectionOve
 			: { hidden: true };
 
 	// The Figma content well is one column of cards. For unclaimed empowered pages
-	// two claim cards lead the column: the person-facing "Are you …?" prompt,
-	// whose button scrolls down to the claim form in the band below the well, then
-	// the voter-facing "ask them to complete their profile" prompt, whose button
-	// opens the notify dialog.
-	// Between them and the civics cards: authored cards (empowerment-gated) then
-	// the civics-spine cards (Recent Experience → Other candidates → Nearby
-	// officials → About position → District map) that render on every state.
-	const claimCard = (variant: 'voter-card' | 'owner-card'): ProfileContentCardProps => ({
+	// exactly ONE card leads the column (frames D 1958:108619 / E 1928:99467): the
+	// visitor-facing "ask them to complete their profile" prompt, whose button
+	// opens the notify dialog. The frames put no owner-facing claim prompt up
+	// here — the person's own way in is the claim band below the well — so do not
+	// add a second card.
+	// Below it: authored cards (empowerment-gated) then the civics-spine cards
+	// (Recent Experience → Other candidates → Nearby officials → About position →
+	// District map) that render on every state.
+	const claimCard = (): ProfileContentCardProps => ({
 		raw: true,
 		content: (
 			<ClaimProfileModal
@@ -726,7 +727,6 @@ export function buildPersonSectionOverrides(view: PersonProfileView): SectionOve
 				displayName={view.displayName}
 				persona={view.persona}
 				locationLabel={profileLocationLabel(view)}
-				variant={variant}
 			/>
 		),
 	});
@@ -743,7 +743,7 @@ export function buildPersonSectionOverrides(view: PersonProfileView): SectionOve
 			: {};
 	const contentCards: ProfileContentCardProps[] = [
 		...(view.persona === 'past' ? [pastElectionDisclaimer(view)] : []),
-		...(showClaim ? [claimCard('owner-card'), claimCard('voter-card')] : []),
+		...(showClaim ? [claimCard()] : []),
 		...orderedSectionCards(view, { ...authoredSections, ...buildCivicSections(view) }),
 	];
 	const sidebar = buildSidebar(view);

--- a/src/components/people/pledgeAttributionCopy.test.tsx
+++ b/src/components/people/pledgeAttributionCopy.test.tsx
@@ -1,0 +1,167 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { JSDOM } from 'jsdom';
+import * as React from 'react';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+/**
+ * Pins the three hero attribution lines word for word (marketing, 2026-08-17,
+ * approved by Emily and Jack):
+ *   pledged          → "Has Taken the GoodParty.org Pledge"
+ *   notPledged       → "Has Not Taken the GoodParty.org Pledge"
+ *   pledgeIneligible → "Ineligible for the GoodParty.org Pledge Due to Partisan Affiliation"
+ *
+ * These are statements about named real people, so the wording is not ours to
+ * tidy: "Has Not Taken" is not "Has not taken the pledge", and the partisan line
+ * names the reason rather than implying a choice. `personSectionOverrides.test`
+ * pins which state gets which line; this pins what those lines say, which
+ * nothing else reads.
+ *
+ * Also pins that the /candidate framing ("Empowered by GoodParty.org") is
+ * untouched — it shares this component and was not part of the request.
+ *
+ * Mounts the component directly, like the other DOM tests in this folder.
+ */
+
+const DOM_GLOBALS = [
+	'Node',
+	'NodeFilter',
+	'Element',
+	'HTMLElement',
+	'HTMLAnchorElement',
+	'DocumentFragment',
+	'DOMRect',
+	'Event',
+	'CustomEvent',
+	'MouseEvent',
+	'KeyboardEvent',
+	'FocusEvent',
+	'MutationObserver',
+] as const;
+
+let dom: JSDOM;
+let root: Root | null = null;
+
+beforeEach(() => {
+	dom = new JSDOM('<!DOCTYPE html><html><body><div id="root"></div></body></html>', {
+		url: 'http://localhost/people/example-person',
+		pretendToBeVisual: true,
+	});
+	const { window } = dom;
+
+	globalThis.window = window as unknown as Window & typeof globalThis;
+	globalThis.document = window.document;
+	globalThis.navigator = window.navigator;
+	globalThis.getComputedStyle = window.getComputedStyle.bind(window);
+
+	for (const name of DOM_GLOBALS) {
+		(globalThis as Record<string, unknown>)[name] = (window as unknown as Record<string, unknown>)[name];
+	}
+
+	(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterEach(async () => {
+	await unmount();
+	dom.window.close();
+});
+
+/** Every case renders more than once, and React allows one root per container. */
+async function unmount() {
+	const current = root;
+	root = null;
+	if (!current) return;
+	await act(async () => {
+		current.unmount();
+	});
+}
+
+async function renderHero(props: Record<string, unknown>) {
+	const { ProfileHero } = await import('~/ui/ProfileHero');
+
+	await unmount();
+	await act(async () => {
+		root = createRoot(document.getElementById('root')!);
+		root.render(
+			React.createElement(ProfileHero, {
+				candidateName: 'Example Person',
+				office: 'City Council',
+				...props,
+			} as never),
+		);
+		await new Promise<void>(resolve => {
+			dom.window.setTimeout(resolve, 0);
+		});
+	});
+}
+
+/**
+ * The attribution line is whichever text sits under the office line — read off
+ * the rendered hero rather than a test id, so a refactor that drops the line
+ * fails here instead of passing against a selector nothing renders.
+ */
+function attributionText(): string {
+	const hero = document.querySelector("[data-component='ProfileHero']");
+	if (!hero) throw new Error('expected the hero to render');
+	const line = [...hero.querySelectorAll('span, p')]
+		.map(node => node.textContent?.trim() ?? '')
+		.find(text => text.includes('GoodParty.org'));
+	return line ?? '';
+}
+
+/**
+ * The GoodParty.org logo, by the viewBox of its artwork — the hero also renders
+ * an anonymous-avatar svg when there is no headshot, so a bare `svg` count would
+ * never reach zero.
+ */
+function markCount(): number {
+	return document.querySelectorAll("[data-component='ProfileHero'] svg[viewBox='35 42 137 116']").length;
+}
+
+describe('the hero pledge lines say exactly what marketing approved', () => {
+	test('a person who has taken the pledge', async () => {
+		await renderHero({ attribution: 'pledged', showBrandMark: true });
+
+		expect(attributionText()).toBe('Has Taken the GoodParty.org Pledge');
+	});
+
+	test('a person who has not', async () => {
+		await renderHero({ attribution: 'notPledged', showBrandMark: false });
+
+		expect(attributionText()).toBe('Has Not Taken the GoodParty.org Pledge');
+	});
+
+	test('a major-party affiliate, who cannot', async () => {
+		await renderHero({ attribution: 'pledgeIneligible', showBrandMark: false });
+
+		expect(attributionText()).toBe('Ineligible for the GoodParty.org Pledge Due to Partisan Affiliation');
+	});
+
+	test('a removed profile says nothing about the pledge either way', async () => {
+		await renderHero({ attribution: 'none', showBrandMark: false });
+
+		expect(attributionText()).toBe('');
+	});
+
+	test('the /candidate pages keep the empowerment line they always had', async () => {
+		await renderHero({ isEmpowered: true });
+
+		expect(attributionText()).toBe('Empowered by GoodParty.org');
+	});
+});
+
+describe('the GoodParty.org mark is independent of the line', () => {
+	test('a claimed profile carries the mark even when the line is negative', async () => {
+		await renderHero({ attribution: 'notPledged', showBrandMark: true });
+
+		expect(attributionText()).toBe('Has Not Taken the GoodParty.org Pledge');
+		expect(markCount()).toBeGreaterThan(0);
+	});
+
+	test('an unclaimed profile carries none, however affirmative the line', async () => {
+		await renderHero({ attribution: 'pledged', showBrandMark: false });
+
+		expect(attributionText()).toBe('Has Taken the GoodParty.org Pledge');
+		expect(markCount()).toBe(0);
+	});
+});

--- a/src/components/people/unpublishedProfileSections.test.tsx
+++ b/src/components/people/unpublishedProfileSections.test.tsx
@@ -1,0 +1,120 @@
+/**
+ * Pins the one behaviour that separates an unpublished profile from an
+ * unclaimed one: no claim affordances.
+ *
+ * The bug this guards was invisible from the API layer — gp-api 404'd for both
+ * "never claimed" and "unpublished", so a person who deliberately hid their own
+ * profile got "Are you [Name]?" on their own page, plus a card asking voters to
+ * pester them into finishing it. Asserting on `view.unpublished` alone would not
+ * have caught it, because the flag is only worth anything if the section builder
+ * reads it. So these assertions read the composed section overrides.
+ *
+ * Structure is compared against the `absent` view of the SAME fixture rather
+ * than a hand-written list of expected cards: the point is that unpublished
+ * differs from unclaimed in exactly one respect, and a literal list would go
+ * stale the next time the civics spine gains a card.
+ */
+import { describe, expect, test } from 'bun:test';
+import { isValidElement, type ReactElement, type ReactNode } from 'react';
+import { buildPersonSectionOverrides } from './personSectionOverrides';
+import {
+	composeView,
+	type PersonProfileView,
+} from '~/lib/peopleProfile';
+import {
+	PERSON_ID,
+	UNPUBLISHED_FIXTURES,
+	viewForFixture,
+	type StateFixture,
+} from '~/testing/peopleProfileFixtures';
+
+/** The same spine with no overlay at all — a person nobody has claimed. */
+function absentView(fixture: StateFixture): PersonProfileView {
+	return composeView(PERSON_ID, fixture.person, null, {});
+}
+
+/**
+ * Every string rendered inside a section, including deep inside the claim
+ * prompt components, so a claim CTA cannot hide behind a nested element.
+ */
+function collectText(node: ReactNode): string[] {
+	if (node == null || typeof node === 'boolean') return [];
+	if (typeof node === 'string' || typeof node === 'number') return [String(node)];
+	if (Array.isArray(node)) return node.flatMap(child => collectText(child as ReactNode));
+	if (isValidElement(node)) {
+		const el = node as ReactElement<Record<string, unknown>>;
+		const props = el.props ?? {};
+		// Component elements are not rendered here, so their copy lives in props
+		// (displayName, variant, heading, …) rather than in children.
+		return Object.entries(props).flatMap(([key, value]) =>
+			key === 'children' || typeof value !== 'string' ? collectText(value as ReactNode) : [value],
+		);
+	}
+	return [];
+}
+
+function cardShapes(view: PersonProfileView): string[] {
+	const overrides = buildPersonSectionOverrides(view);
+	return (overrides.component_profileContentBlock?.contentCards ?? []).map(
+		card => card.heading ?? (card.raw ? 'raw' : (card.cardType ?? 'untitled')),
+	);
+}
+
+function claimPromptVariants(view: PersonProfileView): string[] {
+	const overrides = buildPersonSectionOverrides(view);
+	return (overrides.component_profileContentBlock?.contentCards ?? [])
+		.flatMap(card => collectText(card.content))
+		.filter(text => text === 'owner-card' || text === 'voter-card');
+}
+
+describe('an unpublished profile suppresses every claim affordance', () => {
+	for (const fixture of UNPUBLISHED_FIXTURES) {
+		describe(fixture.description, () => {
+			const view = viewForFixture(fixture);
+
+			test('renders no owner or voter claim prompt card', () => {
+				expect(claimPromptVariants(view)).toEqual([]);
+			});
+
+			test('hides the CTA band instead of offering the claim form', () => {
+				expect(buildPersonSectionOverrides(view).component_ctaBannerBlock).toEqual({ hidden: true });
+			});
+
+			test('drops the "once they claim their profile" placeholder cards', () => {
+				const text = cardShapes(view).join(' ');
+				expect(text).not.toContain('Why');
+				expect(text).not.toContain('About');
+			});
+
+			test('keeps the hero neutral rather than claiming endorsement', () => {
+				const hero = buildPersonSectionOverrides(view).component_profileHero;
+				expect(hero?.attribution).toBe('notEndorsed');
+			});
+		});
+	}
+});
+
+describe('an unpublished profile is otherwise the unclaimed page', () => {
+	for (const fixture of UNPUBLISHED_FIXTURES) {
+		test(`${fixture.description} keeps its civics spine`, () => {
+			const unpublished = cardShapes(viewForFixture(fixture));
+			const absent = cardShapes(absentView(fixture));
+
+			// The civics spine is the public record, which the person unpublishing
+			// their profile does not retract — unlike a removal (K/L), which does.
+			expect(unpublished).toContain('Recent Experience');
+			// Nothing is invented: unpublished only ever drops cards.
+			expect(absent).toEqual(expect.arrayContaining(unpublished));
+
+			// Claim prompts and their authored placeholders only exist on the
+			// empowered branch, so that is the only branch where the column shrinks.
+			// The major-party fixture is here to prove the suppression is keyed on
+			// `unpublished` and not silently riding on `empowered`.
+			if (fixture.expected.empowered) {
+				expect(unpublished.length).toBeLessThan(absent.length);
+			} else {
+				expect(unpublished).toEqual(absent);
+			}
+		});
+	}
+});

--- a/src/components/people/unpublishedProfileSections.test.tsx
+++ b/src/components/people/unpublishedProfileSections.test.tsx
@@ -15,7 +15,6 @@
  * stale the next time the civics spine gains a card.
  */
 import { describe, expect, test } from 'bun:test';
-import { isValidElement, type ReactElement, type ReactNode } from 'react';
 import { buildPersonSectionOverrides } from './personSectionOverrides';
 import {
 	composeView,
@@ -33,26 +32,6 @@ function absentView(fixture: StateFixture): PersonProfileView {
 	return composeView(PERSON_ID, fixture.person, null, {});
 }
 
-/**
- * Every string rendered inside a section, including deep inside the claim
- * prompt components, so a claim CTA cannot hide behind a nested element.
- */
-function collectText(node: ReactNode): string[] {
-	if (node == null || typeof node === 'boolean') return [];
-	if (typeof node === 'string' || typeof node === 'number') return [String(node)];
-	if (Array.isArray(node)) return node.flatMap(child => collectText(child as ReactNode));
-	if (isValidElement(node)) {
-		const el = node as ReactElement<Record<string, unknown>>;
-		const props = el.props ?? {};
-		// Component elements are not rendered here, so their copy lives in props
-		// (displayName, variant, heading, …) rather than in children.
-		return Object.entries(props).flatMap(([key, value]) =>
-			key === 'children' || typeof value !== 'string' ? collectText(value as ReactNode) : [value],
-		);
-	}
-	return [];
-}
-
 function cardShapes(view: PersonProfileView): string[] {
 	const overrides = buildPersonSectionOverrides(view);
 	return (overrides.component_profileContentBlock?.contentCards ?? []).map(
@@ -60,11 +39,21 @@ function cardShapes(view: PersonProfileView): string[] {
 	);
 }
 
-function claimPromptVariants(view: PersonProfileView): string[] {
+/**
+ * The claim prompt is the only card handed both a `personId` and a
+ * `locationLabel`, which is how personSectionOverrides.test.ts finds it too.
+ *
+ * Do NOT go back to matching prop text for a `variant`: that prop existed only
+ * to tell the owner and visitor cards apart, and it went with the owner card. A
+ * text match against a prop that no longer exists makes the assertion below pass
+ * no matter what renders.
+ */
+function claimPrompts(view: PersonProfileView): unknown[] {
 	const overrides = buildPersonSectionOverrides(view);
-	return (overrides.component_profileContentBlock?.contentCards ?? [])
-		.flatMap(card => collectText(card.content))
-		.filter(text => text === 'owner-card' || text === 'voter-card');
+	return (overrides.component_profileContentBlock?.contentCards ?? []).flatMap(card => {
+		const props = (card.content as { props?: Record<string, unknown> } | undefined)?.props;
+		return props && 'personId' in props && 'locationLabel' in props ? [props] : [];
+	});
 }
 
 describe('an unpublished profile suppresses every claim affordance', () => {
@@ -72,8 +61,17 @@ describe('an unpublished profile suppresses every claim affordance', () => {
 		describe(fixture.description, () => {
 			const view = viewForFixture(fixture);
 
-			test('renders no owner or voter claim prompt card', () => {
-				expect(claimPromptVariants(view)).toEqual([]);
+			test('renders no claim prompt card', () => {
+				expect(claimPrompts(view)).toEqual([]);
+			});
+
+			// Proves the assertion above is doing work: the same person, merely
+			// unclaimed rather than unpublished, gets the prompt — unless the spine
+			// was never empowered to begin with (a major-party page has no claim
+			// surfaces in either state).
+			test('the equivalent unclaimed profile gets one whenever it is empowered', () => {
+				const absent = absentView(fixture);
+				expect(claimPrompts(absent).length).toBe(absent.empowered ? 1 : 0);
 			});
 
 			test('hides the CTA band instead of offering the claim form', () => {
@@ -88,7 +86,13 @@ describe('an unpublished profile suppresses every claim affordance', () => {
 
 			test('keeps the hero neutral rather than claiming endorsement', () => {
 				const hero = buildPersonSectionOverrides(view).component_profileHero;
-				expect(hero?.attribution).toBe('notEndorsed');
+				// This asserted the 'notEndorsed' line, which the pledge copy replaced.
+				// What has to hold is unchanged: unpublishing must not promote the
+				// page, so the hero reads exactly as the equivalent unclaimed one — and
+				// the GoodParty.org mark, which follows the claim, stays off.
+				const absent = buildPersonSectionOverrides(absentView(fixture)).component_profileHero;
+				expect(hero?.attribution).toBe(absent?.attribution);
+				expect(hero?.showBrandMark).toBe(false);
 			});
 		});
 	}

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -6,6 +6,20 @@ export function trackEvent(eventName: string, eventProperties?: Record<string, u
 	window.amplitude?.track(eventName, eventProperties);
 }
 
+/**
+ * The Segment sink, which is a different destination set from {@link trackEvent}'s
+ * Amplitude — Segment is what marketing builds automation on, because its HubSpot
+ * destination lands events on the CRM side without anyone shipping code.
+ *
+ * The snippet in `~/ui/Segment` is the stub queue, so `analytics.track` exists and
+ * buffers from the moment the inline script runs; a call made before analytics.js
+ * finishes downloading is replayed, not dropped.
+ */
+export function trackSegmentEvent(eventName: string, eventProperties?: Record<string, unknown>): void {
+	if (typeof window === 'undefined') return;
+	window.analytics?.track(eventName, eventProperties);
+}
+
 /** Click-to-call MOFU CTA (component_clickToCallBlock). */
 export function trackClickToCallCtaViewed(props: { page_path: string | null }): void {
 	trackEvent('Click to Call CTA Viewed', { page_path: props.page_path });
@@ -17,6 +31,38 @@ export function trackClickToCallCtaClicked(props: { page_path: string | null }):
 
 export function trackClickToCallPhoneSubmitted(props: { page_path: string | null }): void {
 	trackEvent('Click to Call Phone Submitted', { page_path: props.page_path });
+}
+
+/**
+ * A completed notify submission on an unclaimed /people profile: a visitor has
+ * asked us to nudge `personId` to finish their profile, and gp-api has accepted
+ * the lead. Call it on success, never on click — the point of the number is
+ * completed asks.
+ *
+ * It goes to Segment as well as Amplitude because the CRM-side count marketing
+ * would otherwise automate on, the HubSpot contact property
+ * `candidate_profile_requests`, is only a lower bound. gp-api writes it solely
+ * when the SUBJECT resolves to exactly one HubSpot contact in the civics person
+ * mart (`mart_civics.people.hs_contact_id`, which the mart nulls for a person
+ * whose identity cluster carries zero or several contacts), and it deliberately
+ * mints nothing for a person the CRM has never seen — see
+ * `CrmPersonProfilesService.syncClaimRequestCount` in gp-api. Notify exists for
+ * the people we hold the least data on, so the population that write skips is
+ * the population the number is meant to describe, and it skips them without an
+ * error anywhere: the call is detached from the request and swallows its own
+ * failures. Segment sees every completed submission whatever the CRM knows.
+ *
+ * `page_path` is passed explicitly, as in {@link trackSignUpClicked}. Nothing in
+ * this module attaches it, and Segment's snippet puts the path in event
+ * *context* rather than in properties, so a property-keyed audience would not
+ * find it otherwise.
+ */
+export function trackPersonProfileNotifySubmitted(props: { personId: string }): void {
+	const pagePath = typeof window !== 'undefined' ? window.location.pathname : null;
+	const properties = { personId: props.personId, page_path: pagePath ?? null };
+
+	trackEvent('Person Profile Notify Submitted', properties);
+	trackSegmentEvent('Person Profile Notify Submitted', properties);
 }
 
 /**

--- a/src/lib/electionsApi.ts
+++ b/src/lib/electionsApi.ts
@@ -379,23 +379,29 @@ export async function getVoterDensityForDistrict(
 /**
  * Result of resolving a person's product overlay (gp-api). The distinction
  * matters for the render gate:
- *  - `live`   → an owner has claimed + published a profile; enrich the page.
- *  - `absent` → no published overlay (never claimed, or unpublished draft); the
- *               page still renders as an unclaimed, programmatic-SEO profile
- *               from the election-api spine, with claim CTAs.
- *  - `gone`   → the owner deleted their profile; suppress the page entirely.
+ *  - `live`        → an owner has claimed + published a profile; enrich the page.
+ *  - `absent`      → nobody has claimed this person; the page still renders as an
+ *                    unclaimed, programmatic-SEO profile from the election-api
+ *                    spine, with claim CTAs.
+ *  - `unpublished` → someone owns a profile here but it is not live. Renders the
+ *                    same spine page as `absent`, minus every claim CTA — they
+ *                    already claimed it, so asking them to claim it is wrong, and
+ *                    asking voters to nudge them to finish it is worse.
+ *  - `gone`        → the owner deleted their profile; suppress the page entirely.
  */
 export type PublicPersonProfileResult =
 	| { status: 'live'; profile: PublicPersonProfile }
 	| { status: 'absent' }
+	| { status: 'unpublished' }
 	| { status: 'gone' }
 	| { status: 'removed' };
 
 /**
  * The product-owned overlay for a person's public profile (gp-api). gp-api
- * returns 200 (live), 404 (never created / unpublished), or 410 (deleted). We
- * map those to the render-gate outcomes above; any transient/5xx failure falls
- * back to `absent` so the spine page still renders instead of 404-ing.
+ * returns 200 (live, removed, or unpublished), 404 (never created), or 410
+ * (deleted). We map those to the render-gate outcomes above; any transient/5xx
+ * failure falls back to `absent` so the spine page still renders instead of
+ * 404-ing.
  */
 export async function getPublicPersonProfileStatus(
 	personId: string,
@@ -410,6 +416,9 @@ export async function getPublicPersonProfileStatus(
 				// Privacy takedown: gp-api answers 200 with { removed: true } and no
 				// authored content. Render the minimal "removal requested" states.
 				if (profile.removed === true) return { status: 'removed' };
+				// Checked after `removed` because a takedown outranks the owner's own
+				// publish state, and gp-api only ever sends one of the two markers.
+				if (profile.unpublished === true) return { status: 'unpublished' };
 				return { status: 'live', profile };
 			}
 			if (res.status === 410) return { status: 'gone' };

--- a/src/lib/electionsHelpers.test.ts
+++ b/src/lib/electionsHelpers.test.ts
@@ -16,6 +16,7 @@ import {
 	formatSidebarLinkLabel,
 	formatTermLength,
 	linkHrefAlreadyPresent,
+	mapCandidacyToCard,
 	normalizeCandidateLookupName,
 	normalizeLinkHrefForCompare,
 	prependClaimedWebsiteIfNew,
@@ -1485,5 +1486,29 @@ describe('redirectCityPlaceToFourLevelUrl', () => {
 		};
 
 		await redirectCityPlaceToFourLevelUrl(place, 'OK', 'ok/binger');
+	});
+});
+
+describe('mapCandidacyToCard', () => {
+	test('re-cases unformatted spine names, so the election listings match the profiles', () => {
+		expect(mapCandidacyToCard({ id: 'c1', firstName: 'chris', lastName: 'lewis', slug: 'chris-lewis' }, 0).name).toBe(
+			'Chris Lewis',
+		);
+	});
+
+	test('returns an already-formatted name untouched', () => {
+		expect(mapCandidacyToCard({ id: 'c2', firstName: 'Ian', lastName: 'McDonald', slug: 'ian-mcdonald' }, 0).name).toBe(
+			'Ian McDonald',
+		);
+	});
+
+	test('casing stays out of the slug fallback href, which has to keep matching live URLs', () => {
+		expect(mapCandidacyToCard({ id: 'c3', firstName: 'chris', lastName: 'lewis', raceId: 'r1' }, 0).href).toBe(
+			'/profile?slug=chris-lewis&raceId=r1',
+		);
+	});
+
+	test('falls back to a placeholder when the row carries no name', () => {
+		expect(mapCandidacyToCard({ id: 'c4' }, 0).name).toBe('Candidate');
 	});
 });

--- a/src/lib/electionsHelpers.ts
+++ b/src/lib/electionsHelpers.ts
@@ -7,6 +7,7 @@ import type { FactsCardProps } from '~/ui/FactsCard';
 
 import { permanentRedirect } from 'next/navigation';
 import { isCityOrTownMtfcc, looksLikeCountySlugSegment, looksLikeDistrictSlug, resolveCountySlugForPlace } from '~/lib/electionsApi';
+import { formatPersonName } from '~/lib/personName';
 
 const COUNTY_EQUIV_SUFFIX_RE =
 	/\s+(County|Parish|City and Borough|City and County|Borough|Census Area|Municipality)$/i;
@@ -114,7 +115,10 @@ export function mapCandidacyToCard(
 	candidacy: CandidacyItem,
 	index: number,
 ): { _key: string; name: string; partyAffiliation: string; avatar?: string; href: string } {
-	const name = [candidacy.firstName, candidacy.lastName].filter(Boolean).join(' ') || 'Candidate';
+	// These cards read the same unformatted spine rows the people profiles do, so
+	// they need the same display-time casing. The slug in `href` below stays raw:
+	// it is lowercased by construction and must keep matching existing URLs.
+	const name = formatPersonName([candidacy.firstName, candidacy.lastName].filter(Boolean).join(' ')) ?? 'Candidate';
 	return {
 		_key: candidacy.id ?? `c-${index}`,
 		name,

--- a/src/lib/peopleProfile.states.test.ts
+++ b/src/lib/peopleProfile.states.test.ts
@@ -11,7 +11,8 @@
  * so the Storybook stories render the exact same data.
  */
 import { afterEach, describe, expect, test } from 'bun:test';
-import { loadPersonProfile } from './peopleProfile';
+import type { PersonItem } from '~/types/people';
+import { isIndexableProfile, loadPersonProfile } from './peopleProfile';
 import {
 	assertNoPii,
 	buildPeopleFetchMock,
@@ -19,6 +20,7 @@ import {
 	PERSON_ID,
 	STATE_FIXTURES,
 	UNPUBLISHED_FIXTURES,
+	viewForFixture,
 } from '~/testing/peopleProfileFixtures';
 
 const originalFetch = globalThis.fetch;
@@ -70,6 +72,66 @@ describe('public profile — removal SEO signal', () => {
 			// flag that drives it matches the spec for every state.
 			expect(fixture.expected.removed).toBe(fixture.expected.noindex);
 		}
+	});
+});
+
+/**
+ * The fixture spine minus every field a real unclaimed record routinely lacks:
+ * the BallotReady bio and headshot, and the social/website columns the link rail
+ * is built from. What survives is the civics spine alone — an office term
+ * and/or a candidacy — which is the shape the contentless-profile suppression
+ * has to reason about. The enriched fixtures pass the thinness test on their
+ * bio and photo, so asserting on them unstripped would prove nothing about the
+ * design state itself.
+ */
+function bareCivicsSpine(person: PersonItem): PersonItem {
+	return {
+		...person,
+		bioText: null,
+		headshotUrl: null,
+		websiteUrl: null,
+		linkedinUrl: null,
+		facebookUrl: null,
+		twitterUrl: null,
+		instagramUrl: null,
+	};
+}
+
+/**
+ * The indexing directive for all twelve Figma states plus the two unpublished
+ * overlays, asserted against the same hand-written `expected.noindex` column the
+ * rest of the matrix is specified by.
+ *
+ * This exists because suppressing contentless profiles is a rule that can only
+ * fail in one direction that matters: quietly withholding a legitimate design
+ * state. Every claimed state (A–C, G) is safe by construction — isThinProfile
+ * short-circuits on `claimed` — so the risk is concentrated in the unclaimed
+ * ones, and the past-election states in particular, where a concluded race no
+ * longer makes someone a current candidate. Stripping each fixture to its
+ * civics spine first is what makes the assertion mean "the state is
+ * indexable", rather than "this fixture happened to carry a headshot".
+ */
+describe('public profile — indexing directive across the 12 states', () => {
+	for (const fixture of [...STATE_FIXTURES, ...UNPUBLISHED_FIXTURES]) {
+		test(`state ${fixture.state} — ${fixture.description}`, () => {
+			const view = viewForFixture({ ...fixture, person: bareCivicsSpine(fixture.person) });
+
+			expect(isIndexableProfile(view)).toBe(!fixture.expected.noindex);
+		});
+	}
+
+	// The counterweight: with the civics spine gone too, there is nothing left to
+	// tell the page apart, and that — not the design state — is what suppression
+	// keys on. Without this the matrix above would also pass if isThinProfile
+	// were `() => false`.
+	test('the same spine with no office and no candidacy is the shape that is withheld', () => {
+		const bare = fixtureForState('D');
+		const view = viewForFixture({
+			...bare,
+			person: { ...bareCivicsSpine(bare.person), Candidacies: [], OfficeHolders: [] },
+		});
+
+		expect(isIndexableProfile(view)).toBe(false);
 	});
 });
 

--- a/src/lib/peopleProfile.states.test.ts
+++ b/src/lib/peopleProfile.states.test.ts
@@ -18,6 +18,7 @@ import {
 	fixtureForState,
 	PERSON_ID,
 	STATE_FIXTURES,
+	UNPUBLISHED_FIXTURES,
 } from '~/testing/peopleProfileFixtures';
 
 const originalFetch = globalThis.fetch;
@@ -43,6 +44,7 @@ describe('public profile — 12-state data-flow matrix', () => {
 			expect(view.majorParty).toBe(e.majorParty);
 			expect(view.empowered).toBe(e.empowered);
 			expect(view.removed).toBe(e.removed);
+			expect(view.unpublished).toBe(e.unpublished);
 			expect(view.pledged).toBe(e.pledged);
 
 			// Content gating (what actually paints).
@@ -67,6 +69,48 @@ describe('public profile — removal SEO signal', () => {
 			// noindex is applied in the page metadata from view.removed; assert the
 			// flag that drives it matches the spec for every state.
 			expect(fixture.expected.removed).toBe(fixture.expected.noindex);
+		}
+	});
+});
+
+describe('public profile — unpublished overlay', () => {
+	for (const fixture of UNPUBLISHED_FIXTURES) {
+		test(`${fixture.description} resolves like its ${fixture.state} counterpart`, async () => {
+			globalThis.fetch = buildPeopleFetchMock(fixture) as unknown as typeof fetch;
+
+			const view = await loadPersonProfile(PERSON_ID);
+			expect(view).not.toBeNull();
+			if (!view) return;
+
+			const e = fixture.expected;
+			// Layout-driving axes are untouched: an unpublished profile still renders
+			// the unclaimed spine page, so anything that changes here is a regression
+			// in blast radius, not a fix.
+			expect(view.state).toBe(fixture.state);
+			expect(view.claimed).toBe(false);
+			expect(view.empowered).toBe(e.empowered);
+			expect(view.removed).toBe(false);
+			expect(view.unpublished).toBe(true);
+
+			// The spine survives — unlike removal (K/L), this is not a takedown.
+			expect(view.avatarUrl).not.toBeNull();
+			expect(view.bio).not.toBeNull();
+			expect(view.recentExperience.length).toBeGreaterThan(0);
+
+			// Nothing the owner drafted may leak through the marker.
+			expect(view.issues).toEqual([]);
+			expect(view.whyRunning).toBeNull();
+			expect(view.accomplishments).toEqual([]);
+			expect(assertNoPii(view)).toEqual([]);
+		});
+	}
+
+	test('stays indexable — the spine page predates the person signing up', () => {
+		// Deliberately unlike removal: only the CTAs were wrong, so the SEO signal
+		// is left alone. Pinned so a future "unpublished means hide it" reading
+		// cannot quietly deindex a legitimate programmatic-SEO page.
+		for (const fixture of UNPUBLISHED_FIXTURES) {
+			expect(fixture.expected.noindex).toBe(false);
 		}
 	});
 });

--- a/src/lib/peopleProfile.test.ts
+++ b/src/lib/peopleProfile.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test';
 import type { PersonItem, PersonOfficeHolder, PublicPersonProfile } from '~/types/people';
 import {
 	buildBreadcrumbTrail,
+	buildNearbyOfficialCards,
 	buildPersonSlug,
 	buildPersonSlugFromBase,
 	composeView,
@@ -452,6 +453,36 @@ describe('composeView claim + overlay precedence', () => {
 	});
 });
 
+describe('composeView display name casing', () => {
+	test('cases an unformatted spine name without disturbing the canonical slug', () => {
+		const view = composeView(PID, makePerson({ slug: 'chris-lewis', fullName: 'chris lewis' }), null);
+		expect(view.displayName).toBe('Chris Lewis');
+		expect(view.initials).toBe('CL');
+		expect(view.canonicalSlug).toBe('chris-lewis-11111111');
+	});
+
+	test('composes first/last when the spine has no fullName', () => {
+		const view = composeView(PID, makePerson({ firstName: 'ed', lastName: 'johnson' }), null);
+		expect(view.displayName).toBe('Ed Johnson');
+	});
+
+	test('leaves an already-formatted spine name alone', () => {
+		const view = composeView(PID, makePerson({ fullName: 'Blaine K. Bowman' }), null);
+		expect(view.displayName).toBe('Blaine K. Bowman');
+	});
+
+	// An owner who types their name in lowercase means it; only the spine's
+	// lowercase is the unformatted-data signature.
+	test('never re-cases an owner-authored displayName', () => {
+		const view = composeView(
+			PID,
+			makePerson({ fullName: 'bell hooks' }),
+			makeOverlay({ displayName: 'bell hooks' }),
+		);
+		expect(view.displayName).toBe('bell hooks');
+	});
+});
+
 describe('composeView issues, links, labels', () => {
 	test('keeps only visible issues that have a title, preserving order', () => {
 		const view = composeView(
@@ -705,5 +736,43 @@ describe('buildBreadcrumbTrail', () => {
 		expect(labels[1]).toBe('California');
 		expect(labels).toContain('Mayor');
 		expect(labels[labels.length - 1]).toBe('Jane Doe');
+	});
+});
+
+describe('buildNearbyOfficialCards', () => {
+	const OTHER = '22222222-2222-2222-2222-222222222222';
+	const personsById = (person: PersonItem) => new Map([[OTHER.toLowerCase(), person]]);
+
+	test('takes the spine fullName, re-cased', () => {
+		const cards = buildNearbyOfficialCards(
+			[makeOffice({ personId: OTHER, officeTitle: 'city council member' })],
+			personsById(makePerson({ id: OTHER, fullName: 'chris lewis' })),
+			PID,
+		);
+		expect(cards.map((c) => c.name)).toEqual(['Chris Lewis']);
+	});
+
+	test('falls through to first + last when fullName is absent', () => {
+		const cards = buildNearbyOfficialCards(
+			[makeOffice({ personId: OTHER })],
+			personsById(makePerson({ id: OTHER, firstName: 'chris', lastName: 'lewis' })),
+			PID,
+		);
+		expect(cards.map((c) => c.name)).toEqual(['Chris Lewis']);
+	});
+
+	// Rows with no linked person still render a card, labelled by the office. The
+	// title comes from the same spine as the names and arrives uncased too.
+	test('falls through to the office title, cased', () => {
+		const cards = buildNearbyOfficialCards([makeOffice({ officeTitle: 'city council member' })], new Map(), PID);
+		expect(cards.map((c) => c.name)).toEqual(['City Council Member']);
+	});
+
+	test('skips a row with no name and no office title', () => {
+		expect(buildNearbyOfficialCards([makeOffice({})], new Map(), PID)).toEqual([]);
+	});
+
+	test('excludes the subject of the profile', () => {
+		expect(buildNearbyOfficialCards([makeOffice({ personId: PID, officeTitle: 'mayor' })], new Map(), PID)).toEqual([]);
 	});
 });

--- a/src/lib/peopleProfile.test.ts
+++ b/src/lib/peopleProfile.test.ts
@@ -7,6 +7,7 @@ import {
 	buildPersonSlugFromBase,
 	composeView,
 	extractPersonId,
+	isThinProfile,
 	resolveProfileState,
 	type PersonPersona,
 } from './peopleProfile';
@@ -55,6 +56,7 @@ function makePerson(p: Partial<PersonItem> = {}): PersonItem {
 		linkedinUrl: null,
 		facebookUrl: null,
 		twitterUrl: null,
+		instagramUrl: null,
 		state: null,
 		...p,
 	};
@@ -480,6 +482,188 @@ describe('composeView display name casing', () => {
 			makeOverlay({ displayName: 'bell hooks' }),
 		);
 		expect(view.displayName).toBe('bell hooks');
+	});
+});
+
+describe('isThinProfile', () => {
+	// The shape behind the 1,792 GSC flagged: a name, a state, and nothing else.
+	const thinPerson = makePerson({ fullName: 'chris lewis', state: 'VA' });
+
+	test('an unclaimed profile with no office and no content is thin', () => {
+		const view = composeView(PID, thinPerson, null);
+		expect(view.roleTitle).toBe('Candidate');
+		expect(isThinProfile(view)).toBe(true);
+	});
+
+	test('a candidacy that names a position is enough to differentiate', () => {
+		const view = composeView(
+			PID,
+			makePerson({ fullName: 'chris lewis', Candidacies: [{ id: 'c1', positionName: 'Mayor' }] }),
+			null,
+		);
+		expect(isThinProfile(view)).toBe(false);
+	});
+
+	test('an office term is enough to differentiate', () => {
+		const view = composeView(
+			PID,
+			makePerson({
+				fullName: 'chris lewis',
+				OfficeHolders: [makeOffice({ isCurrent: true, officeTitle: 'City Council' })],
+			}),
+			null,
+		);
+		expect(isThinProfile(view)).toBe(false);
+	});
+
+	test('a candidacy with a null position name does not differentiate', () => {
+		const view = composeView(
+			PID,
+			makePerson({ fullName: 'chris lewis', Candidacies: [{ id: 'c1', positionName: null }] }),
+			null,
+		);
+		expect(isThinProfile(view)).toBe(true);
+	});
+
+	// The dbt mart wraps the BallotReady office columns in nullif(x, '') because
+	// "the S3 feed uses '' (not null) for absent values" — but only some of them.
+	// m_election_api__office_holder.sql does it for office_title and skips
+	// position_name, so '' is a value this feed genuinely sends, and under
+	// `officeName ?? positionId` that '' is the answer: the positionId behind it
+	// is never consulted and a profile whose race resolved gets withheld.
+	test('an empty-string position name does not mask a resolved position', () => {
+		const view = composeView(
+			PID,
+			makePerson({ fullName: 'chris lewis', Candidacies: [{ id: 'c1', positionName: '' }] }),
+			null,
+			{ positionId: 'pos-1' },
+		);
+
+		expect(view.officeName).toBe('');
+		expect(isThinProfile(view)).toBe(false);
+	});
+
+	// Same feed, same reason, one field over: m_election_api__person.sql nullif()s
+	// the social URLs beside it but not bio_text, so a blank bio has to read as
+	// the absence it is rather than as content that keeps the page in the index.
+	test('a whitespace-only spine bio is not content', () => {
+		const view = composeView(PID, makePerson({ fullName: 'chris lewis', bioText: '   ' }), null);
+
+		expect(isThinProfile(view)).toBe(true);
+	});
+
+	/**
+	 * The sitemap builder derives the same signal from the candidacy and
+	 * officeholder sweeps, so it drops any URL those feeds name no office for. If
+	 * this predicate could withhold a page those feeds DO name, the sitemap would
+	 * advertise a URL that renders noindex — trading the current GSC report for
+	 * "Submitted URL marked noindex". These pin the link that prevents it, which
+	 * is `recentExperience` rather than `officeName`: the sweeps see every row,
+	 * while the view names only the row primaryCandidacy/pickCurrentOffice chose.
+	 */
+	describe('anything the civics feeds name keeps the page indexable', () => {
+		test('a named candidacy the view did not choose', () => {
+			const view = composeView(
+				PID,
+				makePerson({
+					fullName: 'chris lewis',
+					// primaryCandidacy prefers a slugged row, so it picks the unnamed
+					// one; the sitemap's sweep sees both.
+					Candidacies: [
+						{ id: 'c1', slug: 'unnamed-race', positionName: null },
+						{ id: 'c2', positionName: 'Mayor' },
+					],
+				}),
+				null,
+			);
+
+			expect(view.officeName).toBeNull();
+			expect(isThinProfile(view)).toBe(false);
+		});
+
+		// #227 stopped a concluded race from making someone a current candidate,
+		// which is a persona change only — the race still names the seat. Worth
+		// pinning because a page whose only civics row is in the past is exactly
+		// the shape that looks discardable, and it is a legitimate voter-guide
+		// page carrying a real office, an election date and a disclaimer.
+		test('a concluded race that still names the seat', () => {
+			const view = composeView(
+				PID,
+				makePerson({
+					fullName: 'chris lewis',
+					Candidacies: [
+						{ id: 'c1', positionName: 'Mayor', Race: { electionDate: '2020-11-03' } },
+					],
+				}),
+				null,
+			);
+
+			expect(view.persona).toBe('candidate');
+			expect(isThinProfile(view)).toBe(false);
+		});
+
+		test('an office term the view could not title', () => {
+			const view = composeView(
+				PID,
+				makePerson({ fullName: 'chris lewis', OfficeHolders: [makeOffice({ isCurrent: true })] }),
+				null,
+			);
+
+			expect(view.officeName).toBeNull();
+			expect(isThinProfile(view)).toBe(false);
+		});
+	});
+
+	describe('any single signal keeps the page indexable', () => {
+		test('a spine bio', () => {
+			expect(isThinProfile(composeView(PID, makePerson({ ...thinPerson, bioText: 'A bio.' }), null))).toBe(false);
+		});
+
+		test('a headshot', () => {
+			expect(
+				isThinProfile(composeView(PID, makePerson({ ...thinPerson, headshotUrl: 'p.png' }), null)),
+			).toBe(false);
+		});
+
+		test('an outbound link', () => {
+			expect(
+				isThinProfile(
+					composeView(PID, makePerson({ ...thinPerson, websiteUrl: 'https://x.example' }), null),
+				),
+			).toBe(false);
+		});
+
+		// Instagram is the one link in election-api's `urls[]` block that
+		// buildLinks did not fall back to the spine for, so a person whose only
+		// public link was an Instagram reached this predicate looking contentless.
+		// Asserting the link too, not just the verdict: the verdict alone would
+		// still pass if the URL were counted but never rendered.
+		test('an Instagram on the spine, which the link rail used to drop', () => {
+			const view = composeView(
+				PID,
+				makePerson({ ...thinPerson, instagramUrl: 'https://instagram.com/chris' }),
+				null,
+			);
+
+			expect(view.links.map((l) => l.kind)).toEqual(['instagram']);
+			expect(isThinProfile(view)).toBe(false);
+		});
+	});
+
+	// An owner asked for this page; the claimed population is far too small to
+	// drive clustering, so it is never withheld from the index.
+	test('a claimed profile is never thin, even with nothing else on it', () => {
+		const view = composeView(PID, thinPerson, makeOverlay({}));
+		expect(view.claimed).toBe(true);
+		expect(isThinProfile(view)).toBe(false);
+	});
+
+	// Removal already sets noindex on its own; both rules agreeing here means the
+	// K/L pages cannot be re-indexed by one rule while the other suppresses them.
+	test('a removed profile stripped back to the bare spine is thin', () => {
+		const view = composeView(PID, thinPerson, makeOverlay({ bioOverride: 'gone' }), { removed: true });
+		expect(view.removed).toBe(true);
+		expect(isThinProfile(view)).toBe(true);
 	});
 });
 

--- a/src/lib/peopleProfile.ts
+++ b/src/lib/peopleProfile.ts
@@ -16,6 +16,7 @@ import {
 	getStateName,
 } from '~/lib/electionsHelpers';
 import { classifyPartyFrom, isMajorParty, type PartyClass } from '~/lib/party';
+import { formatPersonName } from '~/lib/personName';
 import type { CandidacyItem } from '~/types/elections';
 import type {
 	PersonAccomplishment,
@@ -518,7 +519,7 @@ const PARTY_LABELS: Record<PartyClass, string> = {
 };
 
 function nameOf(first?: string | null, last?: string | null, fallback = ''): string {
-	return [first, last].filter(Boolean).join(' ') || fallback;
+	return formatPersonName([first, last].filter(Boolean).join(' ')) ?? fallback;
 }
 
 /** Maps candidacies sharing a position into "Other Candidates" cards, excluding the subject. */
@@ -564,8 +565,14 @@ export function buildNearbyOfficialCards(
 		const pid = oh.personId ?? null;
 		if (pid && pid.toLowerCase() === excludePersonId.toLowerCase()) continue;
 		const person = pid ? personsById.get(pid.toLowerCase()) : undefined;
+		// The office-title fallback needs the same casing pass: it comes from the
+		// same spine and arrives all-lowercase ("city council member") on the rows
+		// that have no linked person. `formatPersonName` is reused rather than
+		// duplicated because the guard is what matters here — only an entirely
+		// lowercase value is touched — not the person-specific prefix rules.
 		const name =
-			person?.fullName ?? nameOf(person?.firstName, person?.lastName, oh.officeTitle ?? '');
+			formatPersonName(person?.fullName) ??
+			nameOf(person?.firstName, person?.lastName, formatPersonName(oh.officeTitle) ?? '');
 		if (!name) continue;
 		// Dedupe by personId when present, else by name — otherwise null-id rows
 		// with the same office title yield duplicate cards (and colliding React
@@ -700,7 +707,10 @@ export function composeView(
 	const removed = extras.removed ?? false;
 	const claimed = overlay !== null && !removed;
 	const composedName = [person?.firstName, person?.lastName].filter(Boolean).join(' ');
-	const nameFromPerson = person?.fullName ?? (composedName || null);
+	// Casing is applied to the spine name only. The overlay's displayName is
+	// owner-authored, where an all-lowercase value is a deliberate style choice
+	// (bell hooks) rather than the unformatted-data signature it is upstream.
+	const nameFromPerson = formatPersonName(person?.fullName ?? (composedName || null));
 	const displayName = overlay?.displayName ?? nameFromPerson ?? 'Public Official';
 	const office = pickCurrentOffice(person);
 	const persona = resolvePersona(person, office);
@@ -1023,7 +1033,8 @@ export async function loadPersonProfile(personId: string): Promise<PersonProfile
 	const stateCode = office?.state ?? person?.state ?? candidacy?.state ?? null;
 
 	const composedName = [person?.firstName, person?.lastName].filter(Boolean).join(' ');
-	const displayName = overlay?.displayName ?? person?.fullName ?? (composedName || 'Public Official');
+	const displayName =
+		overlay?.displayName ?? formatPersonName(person?.fullName ?? composedName) ?? 'Public Official';
 
 	// The interlink sections are independent; fetch in parallel. Each degrades to
 	// empty on any miss so the core profile always renders.

--- a/src/lib/peopleProfile.ts
+++ b/src/lib/peopleProfile.ts
@@ -190,6 +190,13 @@ export interface PersonProfileView {
 	majorParty: boolean;
 	/** True when the person requested removal (states K/L). */
 	removed: boolean;
+	/**
+	 * True when someone owns a profile here that is not live. Orthogonal to the
+	 * Figma state letter — the page keeps its normal unclaimed layout and spine
+	 * content — but every "claim this profile" affordance is suppressed, because
+	 * the person it would address has already claimed it.
+	 */
+	unpublished: boolean;
 	/** True when the page uses the empowerment/pledge/claim framing. */
 	empowered: boolean;
 	/** True when the person has taken the GoodParty pledge (renders a badge). */
@@ -665,6 +672,7 @@ export function buildBreadcrumbTrail(params: {
 
 export interface ComposeExtras {
 	removed?: boolean;
+	unpublished?: boolean;
 	positionId?: string | null;
 	electionDate?: string | null;
 	positionDescription?: string | null;
@@ -705,6 +713,10 @@ export function composeView(
 	extras: ComposeExtras = {},
 ): PersonProfileView {
 	const removed = extras.removed ?? false;
+	// Deliberately not folded into `claimed` or the state letter: an unpublished
+	// page is still the unclaimed spine layout, so it keeps the person's public
+	// record. Only the claim affordances differ.
+	const unpublished = extras.unpublished ?? false;
 	const claimed = overlay !== null && !removed;
 	const composedName = [person?.firstName, person?.lastName].filter(Boolean).join(' ');
 	// Casing is applied to the spine name only. The overlay's displayName is
@@ -762,6 +774,7 @@ export function composeView(
 		partyClass,
 		majorParty,
 		removed,
+		unpublished,
 		empowered,
 		// Pledge is a factual spine flag; suppress it on removed (K/L) pages along
 		// with the rest of the authored/empowerment framing.
@@ -999,6 +1012,7 @@ export async function loadPersonProfile(personId: string): Promise<PersonProfile
 	if (overlayResult.status === 'gone') return null;
 
 	const removed = overlayResult.status === 'removed';
+	const unpublished = overlayResult.status === 'unpublished';
 	const overlay = overlayResult.status === 'live' ? overlayResult.profile : null;
 
 	// Unclaimed and no removal: only render if the data team has a canonical
@@ -1048,6 +1062,7 @@ export async function loadPersonProfile(personId: string): Promise<PersonProfile
 
 	return composeView(personId, person, overlay, {
 		removed,
+		unpublished,
 		positionId,
 		electionDate,
 		positionDescription,

--- a/src/lib/peopleProfile.ts
+++ b/src/lib/peopleProfile.ts
@@ -240,6 +240,82 @@ export interface PersonProfileView {
 	updatedAt: string;
 }
 
+/**
+ * Whether a spine string carries an actual value.
+ *
+ * Shared with the sitemap builder so both halves of the indexing decision
+ * normalize the civics feed the same way. The feed has three spellings for
+ * "absent" — null, '' and whitespace — because the BallotReady S3 export writes
+ * '' rather than null and the dbt mart only nullif()s some of the columns it
+ * lands (see isThinProfile). Anything that tests one of these fields for
+ * presence has to collapse all three or the two rules drift apart.
+ */
+export function hasText(value: string | null | undefined): boolean {
+	return Boolean(value?.trim());
+}
+
+/**
+ * Whether the profile carries anything that tells it apart from the rest of the
+ * unclaimed corpus.
+ *
+ * A profile with no resolved office, no authored content, no photo and no links
+ * renders a name and a state inside ~114KB of site chrome, and nothing else.
+ * Sampling the URLs Google flagged put 200 of 200 in that shape and within 817
+ * bytes of each other (0.7%), while profiles that do resolve an office spread
+ * across 78% of their size — so the flagged pages are not merely similar, they
+ * are the same document with the name swapped. That is what makes Google
+ * cluster them and elect its own canonical; the canonical tag itself is correct
+ * and self-referential, so nothing about it is worth changing.
+ *
+ * The test is deliberately generous — any single signal is enough to keep the
+ * page indexable — and it is recomputed from the view on every render, so a
+ * page returns to the index on its own once the data team backfills its office.
+ * There is no list to maintain and nothing to re-index by hand.
+ */
+export function isThinProfile(view: PersonProfileView): boolean {
+	// An owner who claimed and published asked for this page to exist; the
+	// population is small enough that indexing it can never drive clustering.
+	if (view.claimed) return false;
+	// Every signal goes through `hasText`, and the alternatives are `||` rather
+	// than `??`, because the upstream feed spells "absent" three ways. The dbt
+	// mart wraps some BallotReady columns in nullif(x, '') and not others —
+	// m_election_api__office_holder.sql does it for office_title but not for
+	// position_name, and m_election_api__person.sql does it for neither bio_text
+	// nor headshot_url — so '' arrives as a value. Under `??` that '' is the
+	// answer: `officeName ?? positionId` returns '' and never consults the
+	// positionId, so a profile with a resolved race would be suppressed.
+	const hasOffice = hasText(view.officeName) || hasText(view.positionId);
+	const hasAuthoredContent =
+		hasText(view.bio) ||
+		hasText(view.whyRunning) ||
+		view.issues.length > 0 ||
+		view.accomplishments.length > 0;
+	const hasIdentity = hasText(view.avatarUrl) || view.links.length > 0;
+	// Load-bearing beyond its own line: this is what makes the sitemap's
+	// projection of this rule safe. buildRecentExperience emits a row for every
+	// office term and every named candidacy — the same two feeds the sitemap
+	// sweeps — so anything the sitemap counts as an office lands here even when
+	// `hasOffice` above misses it (the sitemap sees every row; the view's
+	// officeName is only the one `pickCurrentOffice`/`primaryCandidacy` chose).
+	// Narrowing this to, say, current terms only would silently reopen the
+	// "sitemap advertises a page that renders noindex" direction.
+	const hasPublicRecord = view.recentExperience.length > 0;
+	return !hasOffice && !hasAuthoredContent && !hasIdentity && !hasPublicRecord;
+}
+
+/**
+ * Whether the page asks to be indexed.
+ *
+ * Two unrelated reasons to say no — a privacy removal (Figma K/L) keeps a
+ * crawlable URL it should not advertise, and a contentless profile is a
+ * near-duplicate of every other one — resolved into the single directive
+ * `generateMetadata` emits. It lives here rather than inline at the call site so
+ * the 12-state matrix asserts the expression that actually ships.
+ */
+export function isIndexableProfile(view: PersonProfileView): boolean {
+	return !view.removed && !isThinProfile(view);
+}
+
 function pickCurrentOffice(person: PersonItem | null): PersonOfficeHolder | null {
 	const offices = person?.OfficeHolders ?? [];
 	if (offices.length === 0) return null;
@@ -443,7 +519,15 @@ function buildLinks(
 	const email = overlay?.publicEmail ?? office?.officeEmail ?? null;
 	// Owner's public line wins; their office-line override precedes the spine's.
 	const phone = overlay?.publicPhone ?? overlay?.officePhone ?? office?.officePhone ?? null;
-	const instagram = overlay?.instagramUrl ?? null;
+	// Instagram reads the spine like its four siblings below. It was the one
+	// public link in election-api's `urls[]` block the spine fallback skipped, so
+	// an unclaimed person whose only public link was an Instagram rendered no
+	// link rail at all — and, since isThinProfile reads `links` as the identity
+	// signal, was withheld from the index for having no content while we held a
+	// URL that no other profile in the corpus shares.
+	const instagram = overlay?.instagramUrl ?? person?.instagramUrl ?? null;
+	// No spine fallback: TikTok is owner-authored only. BallotReady's urls[] has
+	// no tiktok type, so there is no spine column to read.
 	const tiktok = overlay?.tiktokUrl ?? null;
 	const facebook = overlay?.facebookUrl ?? person?.facebookUrl ?? null;
 	const twitter = overlay?.twitterUrl ?? person?.twitterUrl ?? null;

--- a/src/lib/personName.test.ts
+++ b/src/lib/personName.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, test } from 'bun:test';
+import { formatPersonName } from './personName';
+
+describe('formatPersonName', () => {
+	test('cases the unformatted rows that produced "chris lewis — Candidate"', () => {
+		expect(formatPersonName('chris lewis')).toBe('Chris Lewis');
+		expect(formatPersonName('george leo moniz')).toBe('George Leo Moniz');
+	});
+
+	// The guard that makes this transform safe to apply corpus-wide: anything
+	// already carrying an uppercase letter is evidence of a formatted source.
+	describe('passes already-formatted names through untouched', () => {
+		for (const name of [
+			'McDonald',
+			'Ian McDonald',
+			"O'Brien",
+			"Siobhan O'Brien",
+			'DeAngelo',
+			'Chris DeAngelo',
+			'van der Berg',
+			'Pieter van der Berg',
+			'Blaine K. Bowman',
+			'Smith-Jones',
+			'Mary Smith-Jones',
+			'Martin Luther King Jr.',
+			'Henry Ford III',
+			'LaToya Cantrell',
+			'MacArthur',
+			'Rebecca Reid',
+			'Allen Earl Slagle',
+		]) {
+			test(name, () => {
+				expect(formatPersonName(name)).toBe(name);
+			});
+		}
+	});
+
+	describe('applies name conventions when the source is entirely lowercase', () => {
+		const cases: [string, string][] = [
+			['ian mcdonald', 'Ian McDonald'],
+			['mcgee', 'McGee'],
+			['mccoy', 'McCoy'],
+			["siobhan o'brien", "Siobhan O'Brien"],
+			["chris d'angelo", "Chris D'Angelo"],
+			// The curly apostrophe (U+2019) that CMS round-trips and spreadsheet
+			// exports substitute for the ASCII one has to case identically, and the
+			// variant that arrived has to survive: rewriting it to ASCII would edit a
+			// name we were only asked to re-case.
+			['siobhan o\u2019brien', 'Siobhan O\u2019Brien'],
+			['chris d\u2019angelo', 'Chris D\u2019Angelo'],
+			['mary smith-jones', 'Mary Smith-Jones'],
+			['anne-marie o\'neill-burke', "Anne-Marie O'Neill-Burke"],
+			['henry ford iii', 'Henry Ford III'],
+			['walter carter iv', 'Walter Carter IV'],
+			['blaine k. bowman', 'Blaine K. Bowman'],
+		];
+		for (const [input, expected] of cases) {
+			test(`${input} → ${expected}`, () => {
+				expect(formatPersonName(input)).toBe(expected);
+			});
+		}
+	});
+
+	// The Roman-numeral rule fires on the final token only: several of those
+	// words are ordinary names elsewhere in a full name.
+	describe('does not uppercase a numeral-word outside suffix position', () => {
+		const cases: [string, string][] = [
+			['vi nguyen', 'Vi Nguyen'],
+			['ix santos', 'Ix Santos'],
+			['x jones', 'X Jones'],
+			['henry vi ford', 'Henry Vi Ford'],
+		];
+		for (const [input, expected] of cases) {
+			test(`${input} → ${expected}`, () => {
+				expect(formatPersonName(input)).toBe(expected);
+			});
+		}
+
+		test('a single-token name is the whole name, not a suffix', () => {
+			expect(formatPersonName('vi')).toBe('Vi');
+			expect(formatPersonName('iv')).toBe('Iv');
+		});
+
+		test('a real generational suffix is still uppercased', () => {
+			expect(formatPersonName('henry ford iii')).toBe('Henry Ford III');
+			expect(formatPersonName('walter carter iv.')).toBe('Walter Carter IV.');
+		});
+	});
+
+	// Documented losses. An all-lowercase source has already destroyed the
+	// distinction, so these assert the deliberate choice rather than a fix.
+	describe('does not guess where lowercase input is genuinely ambiguous', () => {
+		test('Mac is left as an ordinary word start, because Mackenzie is not MacKenzie', () => {
+			expect(formatPersonName('macdonald')).toBe('Macdonald');
+			expect(formatPersonName('sarah mackenzie')).toBe('Sarah Mackenzie');
+		});
+
+		test('DeAngelo is not reconstructed, because Deangelo is also a real name', () => {
+			expect(formatPersonName('chris deangelo')).toBe('Chris Deangelo');
+		});
+
+		test('a trailing numeral-word is read as a suffix, which is the commoner case', () => {
+			expect(formatPersonName('nguyen vi')).toBe('Nguyen VI');
+		});
+
+		test('particles are capitalized, matching US civic records over Dutch convention', () => {
+			expect(formatPersonName('pieter van der berg')).toBe('Pieter Van Der Berg');
+			expect(formatPersonName('juan de la cruz')).toBe('Juan De La Cruz');
+		});
+	});
+
+	describe('edge cases', () => {
+		test('normalizes the stray whitespace these rows also carry', () => {
+			expect(formatPersonName('  chris   lewis  ')).toBe('Chris Lewis');
+		});
+
+		test('trims but does not re-case a formatted name', () => {
+			expect(formatPersonName('  Blaine K. Bowman ')).toBe('Blaine K. Bowman');
+		});
+
+		test('null-ish and blank input yield null, so callers keep their fallback', () => {
+			expect(formatPersonName(null)).toBeNull();
+			expect(formatPersonName(undefined)).toBeNull();
+			expect(formatPersonName('')).toBeNull();
+			expect(formatPersonName('   ')).toBeNull();
+		});
+
+		test('a name with no cased letters at all is left alone', () => {
+			expect(formatPersonName('小明')).toBe('小明');
+		});
+
+		test('is idempotent', () => {
+			for (const input of ['chris lewis', 'ian mcdonald', "siobhan o'brien", 'henry ford iii']) {
+				const once = formatPersonName(input);
+				expect(formatPersonName(once)).toBe(once);
+			}
+		});
+	});
+});

--- a/src/lib/personName.ts
+++ b/src/lib/personName.ts
@@ -1,0 +1,123 @@
+// Display casing for names sourced from the civics spine. A large share of
+// election-api's Person rows carry an unformatted, entirely-lowercase name
+// ("chris lewis"), which reaches the page title, the hero and the JSON-LD
+// verbatim. The real fix is upstream normalization; this is the display-time
+// guard that keeps an unformatted row from rendering as one.
+
+/**
+ * Only an ENTIRELY lowercase string is re-cased. Any uppercase character is
+ * taken as evidence the source was already formatted, and the value is returned
+ * byte-for-byte.
+ *
+ * This guard is the whole safety argument. Title-casing is lossy — it cannot
+ * distinguish `McDonald` from `Mcdonald`, `DeAngelo` from `Deangelo`, or
+ * `van der Berg` from `Van Der Berg` — so applying it to a correctly-cased name
+ * destroys information that upstream got right. Restricting it to the one input
+ * shape that is unambiguously unformatted means a correct name can never be
+ * made incorrect; the worst case is that an unformatted name stays unformatted.
+ */
+function isUnformatted(name: string): boolean {
+	return /[a-z]/.test(name) && name === name.toLowerCase();
+}
+
+/**
+ * Suffix tokens that are Roman numerals rather than words. Restricted to the
+ * range that actually occurs in personal names — beyond `X` the numerals start
+ * colliding with real surnames (`Li`, `Mi`, `Di` are not numerals, and a longer
+ * list would eventually swallow one).
+ *
+ * Applied to the FINAL token only. Several entries are also ordinary names in
+ * their own right — `Vi` is a common Vietnamese given name and `Ix` a surname —
+ * so matching position-blindly turned `vi nguyen` into `VI Nguyen`. A trailing
+ * numeral is overwhelmingly a generational suffix; a leading or middle one is
+ * overwhelmingly a name.
+ *
+ * The residual case this cannot reach is a person whose LAST token is one of
+ * these words (`nguyen vi` still yields `Nguyen VI`). Nothing in an
+ * all-lowercase string separates that from a dropped-period `Nguyen VI`, and
+ * the suffix reading is the commoner one in this corpus.
+ */
+const ROMAN_SUFFIXES = new Set(['ii', 'iii', 'iv', 'vi', 'vii', 'viii', 'ix', 'x']);
+
+/**
+ * `Mc` is capitalized on the following letter (`mcdonald` → `McDonald`) because
+ * the prefix is essentially always patronymic in English-language name data.
+ *
+ * `Mac` deliberately gets no such rule: it is a genuine prefix in `MacArthur`
+ * but an ordinary word-start in `Mackenzie`, `Mackey` and `Macias`, and nothing
+ * in an all-lowercase string distinguishes them. Guessing would corrupt more
+ * names than it repaired, so `macdonald` becomes `Macdonald`.
+ */
+const MC_PREFIX_RE = /^mc([a-z]{2,})$/;
+
+/**
+ * Elided prefixes that capitalize the letter after the apostrophe
+ * (`o'brien` → `O'Brien`, `d'angelo` → `D'Angelo`).
+ *
+ * Only these two, and only in the leading position: an interior apostrophe is
+ * usually a possessive or a contraction inside a transliteration, where
+ * capitalizing the next letter would be wrong.
+ *
+ * Both the ASCII apostrophe and the curly right single quotation mark (U+2019)
+ * are matched, and whichever one arrived is echoed back: CMS round-trips and
+ * spreadsheet exports routinely substitute the curly form, and matching only
+ * ASCII would drop those names through to the plain path as `O’brien`.
+ */
+const ELIDED_PREFIX_RE = /^([od])([\u2019'])([a-z].*)$/;
+
+function capitalizeFirst(word: string): string {
+	return word.charAt(0).toUpperCase() + word.slice(1);
+}
+
+/**
+ * Cases one whitespace-delimited token, recursing through hyphens so each half
+ * of a compound surname is capitalized (`smith-jones` → `Smith-Jones`).
+ */
+function formatToken(token: string, isSuffix = false): string {
+	if (!token) return token;
+	if (isSuffix && ROMAN_SUFFIXES.has(token.replace(/\./g, ''))) return token.toUpperCase();
+	// Neither half of a compound surname is in suffix position, so the numeral
+	// rule stays off for both.
+	if (token.includes('-')) return token.split('-').map(part => formatToken(part)).join('-');
+
+	const [, elidedPrefix, elidedApostrophe, elidedRest] = ELIDED_PREFIX_RE.exec(token) ?? [];
+	if (elidedPrefix && elidedApostrophe && elidedRest) {
+		return `${elidedPrefix.toUpperCase()}${elidedApostrophe}${capitalizeFirst(elidedRest)}`;
+	}
+
+	const [, mcRest] = MC_PREFIX_RE.exec(token) ?? [];
+	if (mcRest) return `Mc${capitalizeFirst(mcRest)}`;
+
+	return capitalizeFirst(token);
+}
+
+/**
+ * Formats a display name for rendering, re-casing only unformatted input.
+ *
+ * Nobiliary particles (`van`, `de`, `del`, `di`, …) are capitalized like any
+ * other token rather than being kept lowercase. From an all-lowercase string
+ * there is no way to tell a Dutch tussenvoegsel, which convention lowercases,
+ * from a Hispanic compound surname, which US civic records overwhelmingly
+ * render capitalized — and the latter is far more common in this corpus. A
+ * source that sends `van der Berg` already cased keeps it, via the guard above.
+ *
+ * Whitespace is normalized because the same rows that arrive uncased also
+ * arrive with doubled and trailing spaces.
+ *
+ * There is deliberately no `string → string` overload: blank and
+ * whitespace-only input returns null, so promising a string for every string
+ * would hand callers a compile-time guarantee the implementation breaks.
+ */
+export function formatPersonName(name: null | undefined): null;
+export function formatPersonName(name: string | null | undefined): string | null;
+export function formatPersonName(name: string | null | undefined): string | null {
+	if (name == null) return null;
+	const trimmed = name.trim().replace(/\s+/g, ' ');
+	if (!trimmed) return null;
+	if (!isUnformatted(trimmed)) return trimmed;
+	const tokens = trimmed.split(' ');
+	// A lone token is the whole name, never a generational suffix — a row
+	// carrying only a first name would otherwise render `vi` as `VI`.
+	const lastIndex = tokens.length > 1 ? tokens.length - 1 : -1;
+	return tokens.map((token, i) => formatToken(token, i === lastIndex)).join(' ');
+}

--- a/src/lib/sitemap-entries.test.ts
+++ b/src/lib/sitemap-entries.test.ts
@@ -59,14 +59,37 @@ describe('fetchPeopleSitemapEntries', () => {
 	type MockPerson = { id: string; slug: string; state: string | null };
 
 	/**
+	 * A row on the candidacy / officeholder feeds. The bare-string form is a row
+	 * that names an office, which is the ordinary case; the object form exists to
+	 * model the rows that carry a personId and nothing else — the shape behind
+	 * the flagged near-duplicate pages.
+	 */
+	type MockLink = string | { personId: string; positionName?: string | null; officeTitle?: string | null };
+
+	function linkRow(link: MockLink): {
+		personId: string;
+		positionName: string | null;
+		officeTitle: string | null;
+	} {
+		if (typeof link === 'string') {
+			return { personId: link, positionName: 'Mayor', officeTitle: null };
+		}
+		return {
+			personId: link.personId,
+			positionName: link.positionName ?? null,
+			officeTitle: link.officeTitle ?? null,
+		};
+	}
+
+	/**
 	 * Stands in for the four upstream feeds the band reads. `state: null` models
 	 * the ~8% of the real table that no `?state=` sweep can reach, which is the
 	 * whole reason the candidacy/officeholder union exists.
 	 */
 	function mockUpstream(opts: {
 		persons: MockPerson[];
-		candidacies?: Record<string, string[]>;
-		officeholders?: Record<string, string[]>;
+		candidacies?: Record<string, MockLink[]>;
+		officeholders?: Record<string, MockLink[]>;
 		published?: { personId: string; updatedAt?: string }[];
 		unlisted?: { personId: string }[];
 		unlistedStatus?: number;
@@ -108,11 +131,11 @@ describe('fetchPeopleSitemapEntries', () => {
 			}
 			if (url.pathname.endsWith('/v1/candidacies')) {
 				const state = url.searchParams.get('state') ?? '';
-				return json((opts.candidacies?.[state] ?? []).map((personId) => ({ personId })));
+				return json((opts.candidacies?.[state] ?? []).map(linkRow));
 			}
 			if (url.pathname.endsWith('/v1/officeholders')) {
 				const state = url.searchParams.get('state') ?? '';
-				return json((opts.officeholders?.[state] ?? []).map((personId) => ({ personId })));
+				return json((opts.officeholders?.[state] ?? []).map(linkRow));
 			}
 			return json([]);
 		}) as typeof fetch;
@@ -133,7 +156,10 @@ describe('fetchPeopleSitemapEntries', () => {
 	// programmatic page is the destination now, so it has to be listed even
 	// though gp-api knows nothing about it.
 	test('lists people who have never been claimed', async () => {
-		mockUpstream({ persons: [{ id: aliceId, slug: 'alice-smith', state: 'WY' }] });
+		mockUpstream({
+			persons: [{ id: aliceId, slug: 'alice-smith', state: 'WY' }],
+			candidacies: { WY: [aliceId] },
+		});
 
 		const entries = await fetchPeopleSitemapEntries(base, 'a');
 
@@ -147,7 +173,7 @@ describe('fetchPeopleSitemapEntries', () => {
 				{ id: bobId, slug: 'bob-jones', state: null },
 				{ id: carolId, slug: 'carol-diaz', state: null },
 			],
-			candidacies: { WY: [bobId] },
+			candidacies: { WY: [aliceId, bobId] },
 			officeholders: { MT: [carolId] },
 		});
 
@@ -211,6 +237,7 @@ describe('fetchPeopleSitemapEntries', () => {
 				{ id: aliceId, slug: 'alice-smith', state: 'WY' },
 				{ id: bobId, slug: 'bob-jones', state: 'WY' },
 			],
+			candidacies: { WY: [aliceId, bobId] },
 			unlisted: [{ personId: bobId }],
 		});
 
@@ -226,6 +253,7 @@ describe('fetchPeopleSitemapEntries', () => {
 	test('matches unlisted ids case-insensitively, since the id is a uuid from another service', async () => {
 		mockUpstream({
 			persons: [{ id: aliceId, slug: 'alice-smith', state: 'WY' }],
+			candidacies: { WY: [aliceId] },
 			unlisted: [{ personId: aliceId.toUpperCase() }],
 		});
 
@@ -238,6 +266,7 @@ describe('fetchPeopleSitemapEntries', () => {
 				{ id: aliceId, slug: 'alice-smith', state: 'WY' },
 				{ id: bobId, slug: 'bob-jones', state: 'WY' },
 			],
+			candidacies: { WY: [bobId] },
 			published: [{ personId: aliceId, updatedAt: '2026-01-15T00:00:00.000Z' }],
 		});
 
@@ -277,7 +306,10 @@ describe('fetchPeopleSitemapEntries', () => {
 		expect(await fetchPeopleSitemapEntries(base, 'a')).toEqual([]);
 
 		clearPeopleSitemapCache();
-		mockUpstream({ persons: [{ id: aliceId, slug: 'alice-smith', state: 'WY' }] });
+		mockUpstream({
+			persons: [{ id: aliceId, slug: 'alice-smith', state: 'WY' }],
+			candidacies: { WY: [aliceId] },
+		});
 
 		expect((await fetchPeopleSitemapEntries(base, 'a')).map((e) => e.url)).toEqual([
 			`${base}/people/alice-smith-aaaaaaaa`,
@@ -317,7 +349,109 @@ describe('fetchPeopleSitemapEntries', () => {
 		});
 		await expect(fetchPeopleSitemapEntries(base, 'a')).rejects.toThrow();
 
+		mockUpstream({
+			persons: [{ id: aliceId, slug: 'alice-smith', state: 'WY' }],
+			candidacies: { WY: [aliceId] },
+		});
+
+		expect((await fetchPeopleSitemapEntries(base, 'a')).map((e) => e.url)).toEqual([
+			`${base}/people/alice-smith-aaaaaaaa`,
+		]);
+	});
+
+	// The GSC "Duplicate, Google chose different canonical than user" cohort: the
+	// page renders noindex because it has nothing on it, so advertising it would
+	// only swap that report for "Submitted URL marked noindex".
+	test('omits a person whose civics feeds name no office', async () => {
+		mockUpstream({
+			persons: [
+				{ id: aliceId, slug: 'alice-smith', state: 'WY' },
+				{ id: bobId, slug: 'bob-jones', state: 'WY' },
+			],
+			candidacies: { WY: [aliceId, { personId: bobId, positionName: null }] },
+		});
+
+		const [aShard, bShard] = await Promise.all([
+			fetchPeopleSitemapEntries(base, 'a'),
+			fetchPeopleSitemapEntries(base, 'b'),
+		]);
+
+		expect(aShard.map((e) => e.url)).toEqual([`${base}/people/alice-smith-aaaaaaaa`]);
+		expect(bShard).toEqual([]);
+	});
+
+	// A person reachable only by the state sweep has no candidacy or officeholder
+	// row at all, so there is no office to render and nothing to index.
+	test('omits a person who appears on no civics feed at all', async () => {
 		mockUpstream({ persons: [{ id: aliceId, slug: 'alice-smith', state: 'WY' }] });
+
+		expect(await fetchPeopleSitemapEntries(base, 'a')).toEqual([]);
+	});
+
+	test('an officeholder row that carries only officeTitle still counts as an office', async () => {
+		mockUpstream({
+			persons: [{ id: aliceId, slug: 'alice-smith', state: 'WY' }],
+			officeholders: { WY: [{ personId: aliceId, officeTitle: 'City Council' }] },
+		});
+
+		expect((await fetchPeopleSitemapEntries(base, 'a')).map((e) => e.url)).toEqual([
+			`${base}/people/alice-smith-aaaaaaaa`,
+		]);
+	});
+
+	// Blank-but-present is the same absence as null. It is not a hypothetical:
+	// the dbt mart wraps office_title in nullif(x, '') because "the S3 feed uses
+	// '' (not null) for absent values", and leaves position_name alone. Both
+	// sides of the decision route these through the same `hasText`, so the
+	// renderer reads a blank the same way.
+	for (const blank of ['', '   ']) {
+		test(`treats a ${blank === '' ? 'empty' : 'whitespace-only'} position name as no office`, async () => {
+			mockUpstream({
+				persons: [{ id: aliceId, slug: 'alice-smith', state: 'WY' }],
+				candidacies: { WY: [{ personId: aliceId, positionName: blank }] },
+			});
+
+			expect(await fetchPeopleSitemapEntries(base, 'a')).toEqual([]);
+		});
+	}
+
+	/**
+	 * Pins the two column projections, because a name election-api does not know
+	 * is not a soft failure: its query schemas are `.strict()` and validate
+	 * `columns` against an allow-list built from the Prisma scalar-field enum, so
+	 * a typo is a 400, and `fetchElectionJsonOrThrow` turns that into a failed
+	 * shard rather than a partial sitemap. Asserting the request here is what
+	 * makes the projection reviewable against those schemas without a token.
+	 */
+	test('projects only the columns the thinness signal needs', async () => {
+		const urls = mockUpstream({
+			persons: [{ id: aliceId, slug: 'alice-smith', state: 'WY' }],
+			candidacies: { WY: [aliceId] },
+		});
+		await fetchPeopleSitemapEntries(base, 'a');
+
+		const columnsFor = (path: string): Set<string> =>
+			new Set(
+				urls
+					.filter((u) => new URL(u).pathname.endsWith(path))
+					.map((u) => new URL(u).searchParams.get('columns') ?? ''),
+			);
+
+		expect(columnsFor('/v1/candidacies')).toEqual(new Set(['personId,positionName']));
+		expect(columnsFor('/v1/officeholders')).toEqual(
+			new Set(['personId,positionName,officeTitle']),
+		);
+		expect(columnsFor('/v1/persons')).toEqual(new Set(['id,slug']));
+	});
+
+	// The one case where the sitemap must not apply the office test: an owner who
+	// claimed and published gets an indexable page regardless of the spine, so
+	// dropping it here would hide the only pages with authored content.
+	test('keeps a claimed person who has no office on any feed', async () => {
+		mockUpstream({
+			persons: [{ id: aliceId, slug: 'alice-smith', state: 'WY' }],
+			published: [{ personId: aliceId, updatedAt: '2026-01-15T00:00:00.000Z' }],
+		});
 
 		expect((await fetchPeopleSitemapEntries(base, 'a')).map((e) => e.url)).toEqual([
 			`${base}/people/alice-smith-aaaaaaaa`,

--- a/src/lib/sitemap-entries.ts
+++ b/src/lib/sitemap-entries.ts
@@ -11,7 +11,7 @@ import {
 	resolveElectionPositionFromRaceSlug,
 	stripCountySuffix as stripCountySuffixFromHelpers,
 } from '~/lib/electionsHelpers';
-import { buildPersonSlugFromBase } from '~/lib/peopleProfile';
+import { buildPersonSlugFromBase, hasText } from '~/lib/peopleProfile';
 import { FAQ_BASE_PATH, getFaqSitemapEntries } from '~/lib/faqSlugs';
 import { fetchElectionApiJsonCached } from '~/lib/electionApiFetch';
 import { allFaqsQuery } from '~/sanity/groq';
@@ -651,12 +651,17 @@ export async function fetchStateElectionSitemapEntries(
 
 type PeopleSitemapPerson = { id?: string; slug?: string | null };
 
-type PeopleSitemapData = {
+type PersonEnumeration = {
+	persons: PeopleSitemapPerson[];
+	/** personIds the civics feeds give a named office or race — see fetchAllPersons. */
+	personIdsWithOffice: Set<string>;
+};
+
+type PeopleSitemapData = PersonEnumeration & {
 	/** personId → updatedAt, for the published subset only; also marks "claimed". */
 	updatedByPersonId: Map<string, string | undefined>;
 	/** personIds whose page must never be advertised — see the loader for why. */
 	unlistedPersonIds: Set<string>;
-	persons: PeopleSitemapPerson[];
 };
 
 /**
@@ -678,6 +683,13 @@ const PERSON_ID_BATCH = 150;
  * live page renders.
  */
 const ENUMERATION_CONCURRENCY = 8;
+
+/** Projected row from the candidacy / officeholder sweeps in fetchAllPersons. */
+type LinkedFeedRow = {
+	personId?: string;
+	positionName?: string | null;
+	officeTitle?: string | null;
+};
 
 async function mapWithConcurrency<T, R>(
 	items: readonly T[],
@@ -713,8 +725,15 @@ async function mapWithConcurrency<T, R>(
  *
  * If election-api ever grows a cursor or a dedicated enumeration feed, this
  * whole dance collapses into a single paged read.
+ *
+ * The candidacy and officeholder sweeps double as the thinness signal. They are
+ * already walked for the union above, and they are the same two feeds the
+ * profile renderer resolves an office from, so asking them for the position
+ * name alongside the personId answers "does this person's page have anything on
+ * it" for the whole corpus at the cost of one extra projected column — rather
+ * than 216k profile loads.
  */
-async function fetchAllPersons(): Promise<PeopleSitemapPerson[]> {
+async function fetchAllPersons(): Promise<PersonEnumeration> {
 	const tags = [PEOPLE_SITEMAP_CACHE_TAG];
 	const states = [...US_STATE_CODES];
 	const byId = new Map<string, PeopleSitemapPerson>();
@@ -732,25 +751,38 @@ async function fetchAllPersons(): Promise<PeopleSitemapPerson[]> {
 		}
 	}
 
-	const linkedFeeds: { path: string; state: string }[] = states.flatMap((state) => [
-		{ path: 'v1/candidacies', state },
-		{ path: 'v1/officeholders', state },
-	]);
+	// Columns differ per feed because the two models name the office differently:
+	// a candidacy carries only positionName, an office term can carry either that
+	// or officeTitle (the renderer reads both, so the sitemap has to as well).
+	//
+	// Both projections are checked against election-api at origin/main: each
+	// endpoint's Zod schema takes a param literally named `columns` and validates
+	// it against an allow-list built from the Prisma scalar-field enum, so a name
+	// this service does not have is a 400 rather than a silently ignored filter —
+	// and `personId`, `positionName` and `officeTitle` are all scalars on those
+	// two models (candidacies.schema.ts, officeHolders.schema.ts). The schemas
+	// are `.strict()`, which is why the param is `columns` here and the
+	// `placeColumns`/`raceColumns` used elsewhere in this file would 400.
+	const linkedFeeds: { path: string; state: string; columns: string }[] = states.flatMap(
+		(state) => [
+			{ path: 'v1/candidacies', state, columns: 'personId,positionName' },
+			{ path: 'v1/officeholders', state, columns: 'personId,positionName,officeTitle' },
+		],
+	);
 	const linked = await mapWithConcurrency(
 		linkedFeeds,
 		ENUMERATION_CONCURRENCY,
-		async ({ path, state }) =>
-			fetchElectionJsonOrThrow<{ personId?: string }>(
-				path,
-				{ state, columns: 'personId' },
-				tags,
-			),
+		async ({ path, state, columns }) =>
+			fetchElectionJsonOrThrow<LinkedFeedRow>(path, { state, columns }, tags),
 	);
 	const unseen = new Set<string>();
+	const personIdsWithOffice = new Set<string>();
 	for (const rows of linked) {
 		for (const row of rows) {
 			const id = row.personId?.toLowerCase();
-			if (id && !byId.has(id)) unseen.add(id);
+			if (!id) continue;
+			if (hasText(row.positionName) || hasText(row.officeTitle)) personIdsWithOffice.add(id);
+			if (!byId.has(id)) unseen.add(id);
 		}
 	}
 
@@ -770,7 +802,7 @@ async function fetchAllPersons(): Promise<PeopleSitemapPerson[]> {
 		}
 	}
 
-	return [...byId.values()];
+	return { persons: [...byId.values()], personIdsWithOffice };
 }
 
 let cachedPeopleSitemapData: Promise<PeopleSitemapData> | null = null;
@@ -793,7 +825,7 @@ export function clearPeopleSitemapCache(): void {
 async function getCachedPeopleSitemapData(): Promise<PeopleSitemapData> {
 	if (!cachedPeopleSitemapData) {
 		const load = (async (): Promise<PeopleSitemapData> => {
-			const [published, unlisted, persons] = await Promise.all([
+			const [published, unlisted, enumeration] = await Promise.all([
 				fetchGpApiJsonOrThrow<{ personId?: string; updatedAt?: string }>(
 					'v1/public-person-profiles/published',
 					[PEOPLE_SITEMAP_CACHE_TAG],
@@ -819,7 +851,7 @@ async function getCachedPeopleSitemapData(): Promise<PeopleSitemapData> {
 				if (row.personId) unlistedPersonIds.add(row.personId.toLowerCase());
 			}
 
-			return { updatedByPersonId, unlistedPersonIds, persons };
+			return { updatedByPersonId, unlistedPersonIds, ...enumeration };
 		})();
 		cachedPeopleSitemapData = load;
 		// Settle via two-arg `then`, not `finally`: the upstream reads throw now, and
@@ -855,19 +887,52 @@ async function getCachedPeopleSitemapData(): Promise<PeopleSitemapData> {
  * crawlers at someone who asked to be left alone, and an owner-deleted profile
  * has no page to reach at all — gp-api answers 410 and the route 404s.
  *
+ * People whose civics feeds name no office are dropped for the same reason at
+ * one remove: their page renders `noindex` (see isThinProfile) because it has
+ * no content to tell it apart from every other one, and a sitemap that keeps
+ * advertising them would simply trade "Duplicate, Google chose different
+ * canonical" for "Submitted URL marked noindex".
+ *
+ * That test is a projection of the renderer's, not a copy of it — the sitemap
+ * sees offices and claims but not photos, links or bios. The asymmetry runs one
+ * way only, and it is worth being precise about why, because the argument is
+ * not "an office implies an office".
+ *
+ * Harmful direction (advertise a URL that renders `noindex`) — impossible. This
+ * band lists a person only when gp-api says they published, which makes the
+ * view `claimed` and short-circuits isThinProfile, or when some row on the
+ * candidacy/officeholder sweeps named an office. In that second case the
+ * renderer's escape hatch is `recentExperience`, not `officeName`:
+ * buildRecentExperience emits a row for every office term and every candidacy
+ * carrying a positionName, which is exactly the set these sweeps see, so
+ * `hasPublicRecord` holds even when the one candidacy `primaryCandidacy` picked
+ * happens to be the unnamed one. peopleProfile.test.ts pins that link.
+ *
+ * Benign direction (drop a URL the renderer would index) — real, and accepted.
+ * A person can be dropped here and indexed there in three shapes: an office
+ * term with dates but no title at all (the sweeps see no name; the renderer
+ * still lists a dated "Public office" row), a photo/bio/link with no office,
+ * and a civics row whose own `state` column is null so no `?state=` sweep
+ * reaches it. The cost is the sitemap entry, not the indexing: the page still
+ * renders `index` and is still linked from the profile and election interlinks,
+ * so a crawler finds it anyway. The reverse would put us straight into
+ * "Submitted URL marked noindex", which is the report we are trying to leave.
+ *
  * Upstream fetches are shared across shards via getCachedPeopleSitemapData.
  */
 export async function fetchPeopleSitemapEntries(
 	baseUrl: string,
 	shard?: string,
 ): Promise<MetadataRoute.Sitemap> {
-	const { updatedByPersonId, unlistedPersonIds, persons } = await getCachedPeopleSitemapData();
+	const { updatedByPersonId, unlistedPersonIds, persons, personIdsWithOffice } =
+		await getCachedPeopleSitemapData();
 
 	const entries: MetadataRoute.Sitemap = [];
 	for (const p of persons) {
 		if (!p.id || !p.slug) continue;
 		const personId = p.id.toLowerCase();
 		if (unlistedPersonIds.has(personId)) continue;
+		if (!updatedByPersonId.has(personId) && !personIdsWithOffice.has(personId)) continue;
 		// When a shard is requested, only emit people whose slug falls in it. The
 		// canonical URL appends the 8-hex id suffix but shares the base's first
 		// char, so sharding on the base is equivalent.

--- a/src/testing/peopleProfileFixtures.ts
+++ b/src/testing/peopleProfileFixtures.ts
@@ -30,7 +30,8 @@ export type OverlayFixture =
 	| { status: 'live'; profile: PublicPersonProfile }
 	| { status: 'absent' }
 	| { status: 'gone' }
-	| { status: 'removed' };
+	| { status: 'removed' }
+	| { status: 'unpublished' };
 
 export interface StateFixture {
 	state: ProfileState;
@@ -47,6 +48,12 @@ export interface ExpectedFacts {
 	majorParty: boolean;
 	empowered: boolean;
 	removed: boolean;
+	/**
+	 * The owner has a profile that is not live. Orthogonal to the state letter —
+	 * it suppresses claim affordances without changing the layout — so it is
+	 * false across all twelve Figma states and only set by UNPUBLISHED_FIXTURES.
+	 */
+	unpublished: boolean;
 	pledged: boolean;
 	hasAvatar: boolean;
 	hasBio: boolean;
@@ -186,6 +193,7 @@ const claimedFacts = (persona: PersonPersona, pledged: boolean): ExpectedFacts =
 	majorParty: false,
 	empowered: true,
 	removed: false,
+	unpublished: false,
 	pledged,
 	hasAvatar: true,
 	hasBio: true,
@@ -202,6 +210,7 @@ const unclaimedIndepFacts = (persona: PersonPersona): ExpectedFacts => ({
 	majorParty: false,
 	empowered: true,
 	removed: false,
+	unpublished: false,
 	pledged: false,
 	hasAvatar: true, // spine headshot
 	hasBio: true, // spine bioText
@@ -215,6 +224,7 @@ const unclaimedMajorFacts = (persona: PersonPersona): ExpectedFacts => ({
 	majorParty: true,
 	empowered: false,
 	removed: false,
+	unpublished: false,
 	pledged: false,
 	hasAvatar: true,
 	hasBio: true,
@@ -231,6 +241,7 @@ const removedFacts = (persona: PersonPersona, majorParty: boolean): ExpectedFact
 	majorParty,
 	empowered: false,
 	removed: true,
+	unpublished: false,
 	pledged: false, // suppressed on removal even though the spine flag is set
 	hasAvatar: false, // stripped
 	hasBio: false, // stripped
@@ -345,6 +356,37 @@ export const STATE_FIXTURES: StateFixture[] = [
 	},
 ];
 
+// ----- unpublished overlays (not Figma states) -------------------------------
+
+/**
+ * An owner exists but their profile is not live, so gp-api answers 200
+ * `{ unpublished: true }` instead of the 404 it used to send. This is NOT a
+ * thirteenth Figma state: the page renders its normal unclaimed layout and full
+ * civics spine, so these reuse the same fixtures as D and I. The only thing
+ * that changes is that every claim affordance is suppressed, which the state
+ * letter cannot express — hence a separate list rather than a matrix row.
+ *
+ * Both an empowered (D) and a major-party (I) base are covered because the
+ * claim prompts only exist on the empowered branch; without the I case a
+ * regression that gated on `empowered` alone would look fixed.
+ */
+export const UNPUBLISHED_FIXTURES: StateFixture[] = [
+	{
+		state: 'D',
+		description: 'Unpublished profile — independent candidate spine',
+		person: spine({ Candidacies: [candidacy()] }),
+		overlay: { status: 'unpublished' },
+		expected: { ...unclaimedIndepFacts('candidate'), unpublished: true },
+	},
+	{
+		state: 'I',
+		description: 'Unpublished profile — major-party candidate spine',
+		person: spine({ Candidacies: [candidacy({ party: 'Republican' })] }),
+		overlay: { status: 'unpublished' },
+		expected: { ...unclaimedMajorFacts('candidate'), unpublished: true },
+	},
+];
+
 export function fixtureForState(state: ProfileState): StateFixture {
 	const found = STATE_FIXTURES.find((f) => f.state === state);
 	if (!found) throw new Error(`No fixture for state ${state}`);
@@ -358,10 +400,16 @@ export function fixtureForState(state: ProfileState): StateFixture {
  * integration matrix asserts on.
  */
 export function viewFor(state: ProfileState): PersonProfileView {
-	const fixture = fixtureForState(state);
+	return viewForFixture(fixtureForState(state));
+}
+
+/** `viewFor` for fixtures that are not a Figma state (see UNPUBLISHED_FIXTURES). */
+export function viewForFixture(fixture: StateFixture): PersonProfileView {
 	const overlay = fixture.overlay.status === 'live' ? fixture.overlay.profile : null;
-	const removed = fixture.overlay.status === 'removed';
-	return composeView(PERSON_ID, fixture.person, overlay, { removed });
+	return composeView(PERSON_ID, fixture.person, overlay, {
+		removed: fixture.overlay.status === 'removed',
+		unpublished: fixture.overlay.status === 'unpublished',
+	});
 }
 
 // ----- fetch mock ------------------------------------------------------------
@@ -400,6 +448,8 @@ export function buildPeopleFetchMock(
 					return jsonResponse({}, 404) as unknown as Response;
 				case 'removed':
 					return jsonResponse({ personId: PERSON_ID, removed: true }) as unknown as Response;
+				case 'unpublished':
+					return jsonResponse({ personId: PERSON_ID, unpublished: true }) as unknown as Response;
 				case 'live':
 					return jsonResponse(fixture.overlay.profile) as unknown as Response;
 			}

--- a/src/testing/peopleProfileFixtures.ts
+++ b/src/testing/peopleProfileFixtures.ts
@@ -131,6 +131,7 @@ function spine(over: Partial<PersonItem> = {}): PersonItem {
 		linkedinUrl: null,
 		facebookUrl: null,
 		twitterUrl: null,
+		instagramUrl: null,
 		state: 'CA',
 		isPledged: false,
 		...over,

--- a/src/types/people.ts
+++ b/src/types/people.ts
@@ -69,6 +69,7 @@ export interface PersonItem {
 	linkedinUrl: string | null;
 	facebookUrl: string | null;
 	twitterUrl: string | null;
+	instagramUrl: string | null;
 	state: string | null;
 	/** Took the GoodParty pledge (ETL-sourced, read-only). */
 	isPledged?: boolean;

--- a/src/types/people.ts
+++ b/src/types/people.ts
@@ -129,6 +129,12 @@ export interface PublicPersonProfile {
 	personId: string;
 	/** Privacy takedown flag from gp-api. When true, render the minimal K/L states. */
 	removed?: boolean;
+	/**
+	 * The person owns a profile that is not live (draft, or deliberately
+	 * unpublished). gp-api sends this instead of a 404 so we can tell them apart
+	 * from someone who never claimed; every authored field is null either way.
+	 */
+	unpublished?: boolean;
 	displayName: string | null;
 	roleTitleOverride: string | null;
 	bioOverride: string | null;

--- a/src/types/segment.d.ts
+++ b/src/types/segment.d.ts
@@ -1,0 +1,19 @@
+declare global {
+	interface Window {
+		/**
+		 * Segment's analytics.js, installed by the inline snippet in `~/ui/Segment`.
+		 * Optional because that snippet runs `afterInteractive`, so anything firing
+		 * during hydration can still find it absent.
+		 *
+		 * Only the methods this app calls are declared. The snippet exposes the full
+		 * analytics.js surface; widen this as call sites need it rather than
+		 * importing Segment's types, which would pull the SDK into the bundle for a
+		 * script we load from their CDN.
+		 */
+		analytics?: {
+			track(eventName: string, eventProperties?: Record<string, unknown>): void;
+		};
+	}
+}
+
+export {};

--- a/src/ui/ProfileHero.tsx
+++ b/src/ui/ProfileHero.tsx
@@ -63,7 +63,7 @@ const styles = tv({
 		attributionIcon: 'w-[37px] h-[28px]',
 		// Figma "Empowered by GoodParty.org": Outfit SemiBold 20/28.
 		attributionText: 'font-primary text-[1.25rem] font-semibold leading-7',
-		notEndorsed: 'text-sm',
+		attributionMuted: 'text-sm',
 	},
 	variants: {
 		backgroundColor: {
@@ -83,7 +83,7 @@ const styles = tv({
 				office: 'text-white',
 				attribution: 'text-white',
 				tag: 'border-gray-300 text-[color:#0a0a0a]',
-				notEndorsed: 'text-gray-400',
+				attributionMuted: 'text-gray-400',
 			},
 			cream: {
 				base: 'text-midnight-900',
@@ -92,7 +92,7 @@ const styles = tv({
 				office: 'text-midnight-900',
 				attribution: 'text-midnight-900',
 				tag: 'bg-white border-gray-300 text-[color:#0a0a0a]',
-				notEndorsed: 'text-gray-500',
+				attributionMuted: 'text-gray-500',
 			},
 		},
 	},
@@ -122,13 +122,41 @@ export type ProfileHeroProps = {
 	 * Attribution row under the office line. When omitted it falls back to
 	 * `isEmpowered` (empowered → "Empowered by GoodParty.org", otherwise none).
 	 */
-	attribution?: 'empowered' | 'notEndorsed' | 'none';
+	attribution?: AttributionMode;
+	/**
+	 * GoodParty.org mark — the logo on the portrait and the one beside the
+	 * attribution line. Separate from `attribution` because the mark says the
+	 * profile is a GoodParty.org one while the line states a fact about the
+	 * person; on /people those are different inputs (claim vs pledge) and tying
+	 * the mark to the pledge would strip the branding from every claimed
+	 * officeholder, who cannot carry the flag at all. Defaults to the empowerment
+	 * framing, which is what the /candidate pages mean by it.
+	 */
+	showBrandMark?: boolean;
 };
+
+type AttributionMode = 'empowered' | 'pledged' | 'notPledged' | 'pledgeIneligible' | 'none';
+
+const ATTRIBUTION_COPY: Record<Exclude<AttributionMode, 'none'>, string> = {
+	empowered: 'Empowered by GoodParty.org',
+	pledged: 'Has Taken the GoodParty.org Pledge',
+	notPledged: 'Has Not Taken the GoodParty.org Pledge',
+	pledgeIneligible: 'Ineligible for the GoodParty.org Pledge Due to Partisan Affiliation',
+};
+
+/**
+ * Which lines get the Figma 20/28 semibold treatment (with the mark) rather than
+ * the grey disclaimer line. Polarity, not source: a line that says the person
+ * did something with us reads as an affirmation, and one that says they did not
+ * is a footnote — putting "Has Not Taken the GoodParty.org Pledge" in the
+ * affirmative style beside the logo would read as a badge.
+ */
+const AFFIRMATIVE_ATTRIBUTIONS: ReadonlySet<AttributionMode> = new Set<AttributionMode>(['empowered', 'pledged']);
 
 export function ProfileHero(props: ProfileHeroProps) {
 	const backgroundColor = props.backgroundColor ?? 'midnight';
 	const resolvedBackgroundColor = backgroundColor === 'white' ? 'cream' : backgroundColor;
-	const { base, backgroundWrapper, band, belowBand, container, imageWrapper, image, badge, content, tagRow, tag, tagText, nameOffice, officeLines, heading, office, officeLink, attribution, attributionIcon, attributionText, notEndorsed } = styles({ backgroundColor: resolvedBackgroundColor });
+	const { base, backgroundWrapper, band, belowBand, container, imageWrapper, image, badge, content, tagRow, tag, tagText, nameOffice, officeLines, heading, office, officeLink, attribution, attributionIcon, attributionText, attributionMuted } = styles({ backgroundColor: resolvedBackgroundColor });
 
 	const renderOfficeLine = (label: string, href?: string) => (
 		<Text key={label} as="p" styleType="subtitle-1" className={office()}>
@@ -143,7 +171,9 @@ export function ProfileHero(props: ProfileHeroProps) {
 	);
 
 	// `attribution` wins when provided; otherwise fall back to legacy `isEmpowered`.
-	const attributionMode = props.attribution ?? (props.isEmpowered ? 'empowered' : 'none');
+	const attributionMode: AttributionMode = props.attribution ?? (props.isEmpowered ? 'empowered' : 'none');
+	const showBrandMark = props.showBrandMark ?? attributionMode === 'empowered';
+	const isAffirmative = AFFIRMATIVE_ATTRIBUTIONS.has(attributionMode);
 	const tags = props.tags?.filter(Boolean) ?? [];
 
 	// Per Figma the persona pill is colour-coded by label: an in-office "Incumbent"
@@ -185,9 +215,7 @@ export function ProfileHero(props: ProfileHeroProps) {
 								</div>
 							)}
 						</div>
-						{attributionMode === 'empowered' && (
-							<Logo className={badge()} />
-						)}
+						{showBrandMark && <Logo className={badge()} />}
 					</div>
 					<div className={content()}>
 						{tags.length > 0 && (
@@ -208,17 +236,17 @@ export function ProfileHero(props: ProfileHeroProps) {
 								{props.secondaryOffice && renderOfficeLine(props.secondaryOffice, props.secondaryOfficeHref)}
 							</div>
 						</div>
-						{attributionMode === 'empowered' && (
-							<div className={attribution()}>
-								<Logo className={attributionIcon()} />
-								<span className={attributionText()}>Empowered by GoodParty.org</span>
-							</div>
-						)}
-						{attributionMode === 'notEndorsed' && (
-							<Text as="span" styleType="body-2" className={notEndorsed()}>
-								Not Endorsed by GoodParty.org
-							</Text>
-						)}
+						{attributionMode !== 'none' &&
+							(isAffirmative ? (
+								<div className={attribution()}>
+									{showBrandMark && <Logo className={attributionIcon()} />}
+									<span className={attributionText()}>{ATTRIBUTION_COPY[attributionMode]}</span>
+								</div>
+							) : (
+								<Text as="span" styleType="body-2" className={attributionMuted()}>
+									{ATTRIBUTION_COPY[attributionMode]}
+								</Text>
+							))}
 					</div>
 				</div>
 			</Container>


### PR DESCRIPTION
Release of `develop` to production. Eight PRs, all reviewed and approved, all green on `develop`.

## What ships

**Claim surfaces rebuilt to the Figma frames**
- #234 — the owner-facing "Are you [Name]?" card is gone from the top of the content well. That ask now lives only in the band below the well; the content well carries a single visitor-facing notify card.
- #239 — the band sends the person into Win sign-up instead of collecting their address (marketing, 2026-08-17), and officeholder-only profiles lose their claim surfaces entirely, since someone who only holds office has no self-serve product to be sent to.
- #241 — unpublished profiles no longer ask anyone to claim a page that is already owned.
- #242 — the claim card's heading matches the frame by value (32/44 on both artboards) rather than by token name.

**Copy**
- #239 — pledge attribution replaces the old endorsement line. Three cases: partisan ineligibility wins, then pledged, then not pledged.
- #240 — spine names that arrive uncased are cased at display time.

**Indexing and SEO**
- #236 — profiles with no resolved office and no differentiating content render `noindex, follow` and drop out of the sitemap, answering the "Duplicate, Google chose different canonical than user" report. Pages return to the index on their own as office data backfills.

**Instrumentation**
- #243 — completed notify submissions report to Segment, giving marketing a signal to build automation on.

**Test coverage**
- #238 — the removal states (Figma K/L) are pinned so they cannot drift.

## Known follow-up

The pledge lines key off `Person.isPledged`, which the data platform currently rolls up from candidacies only — it does not yet include Serve-side elected-office pledges or the verbal/email pledge signals. Until that lands, an elected official who pledged through Serve reads "Has Not Taken the GoodParty.org Pledge". The data fix is in flight and this copy ships as specified.

## Verification

`develop` is green (Verify: success). Full suite passing; all 12 profile states spot-checked on the develop deployment, with claim surfaces appearing only on unclaimed candidate states (D/F), suppressed on officeholder (E), past (H) and major-party (I/J), and K/L serving `noindex`.

Made with [Cursor](https://cursor.com)