### PR TITLE
Say who has taken the pledge on the related-person cards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,12 @@ bower_components
 build/Release
 
 # Dependency directories
+# Both spellings: the trailing slash matches only a real directory, and the
+# worktree workflow this repo uses often symlinks node_modules at a sibling
+# checkout instead of installing into each one. A symlink is a blob, so the
+# slashed form does not cover it and `git add -A` will happily commit a path
+# that is dangling on every other machine.
+node_modules
 node_modules/
 jspm_packages/
 

--- a/src/components/people/personSectionOverrides.tsx
+++ b/src/components/people/personSectionOverrides.tsx
@@ -14,7 +14,7 @@ import { IconResolver } from '~/ui/IconResolver';
 import { cn } from '~/ui/_lib/utils';
 import { Text } from '~/ui/Text';
 import { ButtonLink } from '~/ui/Inputs/Button';
-import { CandidatesCard } from '~/ui/CandidatesCard';
+import { CandidatesCard, type CardAttributionMode } from '~/ui/CandidatesCard';
 import { VoterDensityMapCard } from './VoterDensityMapCard';
 import { ClaimProfileModal } from './ClaimProfileModal';
 import { PersonClaimCTABand } from './PersonClaimCTABand';
@@ -598,6 +598,28 @@ function buildSidebar(view: PersonProfileView): ElectionsSidebarProps | undefine
 	};
 }
 
+/**
+ * Which pledge statement a related-person card makes — the hero's
+ * {@link pledgeAttribution}, narrowed to the affirmative.
+ *
+ * A card says someone HAS pledged, or says nothing. It never carries "Has Not
+ * Taken…" or "Ineligible…", which the hero does carry, because the ETL has never
+ * written `Person.is_pledged`: 0 of 69,385 sampled production rows are true (see
+ * `docs/person-spine-pledge-and-claim-linkage-handoff.md`), and 40 sampled live
+ * profiles on 2026-08-20 rendered "Has Taken…" zero times. The negative line is
+ * therefore a statement we cannot stand behind, and a profile carries six of
+ * these cards — publishing it here would multiply by six a claim the hero is
+ * already under pressure for. An affirmative-only rule cannot be false when it
+ * renders, and it lights up on its own the day the backfill lands.
+ *
+ * When it does land and marketing wants the other two lines here, this function
+ * returns them and `CardAttributionMode` widens to admit them. Nothing else
+ * moves: the flag is already on the card, and the copy is already shared.
+ */
+function relatedCardAttribution(card: RelatedPersonCard): CardAttributionMode {
+	return card.isPledged ? 'pledged' : 'none';
+}
+
 /** Maps interlink cards to CandidatesBlock cards, dropping any without a link. */
 function toCandidateCards(cards: RelatedPersonCard[]): CandidateCard[] {
 	return cards
@@ -607,7 +629,12 @@ function toCandidateCards(cards: RelatedPersonCard[]): CandidateCard[] {
 			name: c.name,
 			partyAffiliation: c.subtitle ?? '',
 			href: c.href!,
+			// The mark and the yellow frame follow this; the line follows the pledge.
+			// They are different facts — one says whose candidate this is, the other
+			// asserts something the person did — and on /people they come from
+			// different sources, so the card must not tie them together.
 			isGoodPartyCandidate: c.isEmpowered,
+			attribution: relatedCardAttribution(c),
 			...(c.avatarUrl ? { avatar: c.avatarUrl } : {}),
 		}));
 }

--- a/src/components/people/relatedCardPledgeAttribution.test.tsx
+++ b/src/components/people/relatedCardPledgeAttribution.test.tsx
@@ -1,0 +1,243 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { JSDOM } from 'jsdom';
+import * as React from 'react';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+/**
+ * Pins what the related-person cards on a person profile say about the people on
+ * them: the pledge, when the spine affirms it, and otherwise nothing.
+ *
+ * They used to read "Empowered by GoodParty.org" — word for word the line the
+ * hero carried until marketing replaced it with the three pledge lines
+ * (2026-08-17, approved by Emily and Jack; see `pledgeAttributionCopy.test.tsx`).
+ * The hero was rewritten and these were missed.
+ *
+ * Only the affirmative line comes across. The negative and ineligible lines the
+ * hero renders are pinned OUT here, deliberately — `relatedCardAttribution`
+ * carries the reasoning and the production evidence.
+ *
+ * Drives the real `buildPersonSectionOverrides` output rather than hand-built
+ * props, because the mapping is the thing that was missing, and mounts the
+ * section's own content node like the other DOM tests in this folder.
+ */
+
+const DOM_GLOBALS = [
+	'Node',
+	'NodeFilter',
+	'Element',
+	'HTMLElement',
+	'HTMLAnchorElement',
+	'DocumentFragment',
+	'DOMRect',
+	'Event',
+	'CustomEvent',
+	'MouseEvent',
+	'KeyboardEvent',
+	'FocusEvent',
+	'MutationObserver',
+] as const;
+
+const PLEDGED = 'Has Taken the GoodParty.org Pledge';
+const NOT_PLEDGED = 'Has Not Taken the GoodParty.org Pledge';
+const INELIGIBLE = 'Ineligible for the GoodParty.org Pledge Due to Partisan Affiliation';
+const EMPOWERED = 'Empowered by GoodParty.org';
+
+let dom: JSDOM;
+let root: Root | null = null;
+
+beforeEach(() => {
+	dom = new JSDOM('<!DOCTYPE html><html><body><div id="root"></div></body></html>', {
+		url: 'http://localhost/people/example-person',
+		pretendToBeVisual: true,
+	});
+	const { window } = dom;
+
+	globalThis.window = window as unknown as Window & typeof globalThis;
+	globalThis.document = window.document;
+	globalThis.navigator = window.navigator;
+	globalThis.getComputedStyle = window.getComputedStyle.bind(window);
+
+	for (const name of DOM_GLOBALS) {
+		(globalThis as Record<string, unknown>)[name] = (window as unknown as Record<string, unknown>)[name];
+	}
+
+	(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterEach(async () => {
+	await unmount();
+	dom.window.close();
+});
+
+/** Every case renders more than once, and React allows one root per container. */
+async function unmount() {
+	const current = root;
+	root = null;
+	if (!current) return;
+	await act(async () => {
+		current.unmount();
+	});
+}
+
+async function render(element: React.ReactElement) {
+	await unmount();
+	await act(async () => {
+		root = createRoot(document.getElementById('root')!);
+		root.render(element);
+		await new Promise<void>(resolve => {
+			dom.window.setTimeout(resolve, 0);
+		});
+	});
+}
+
+type Rail = 'otherCandidates' | 'nearbyOfficials';
+
+const RAIL_HEADING: Record<Rail, string> = {
+	otherCandidates: 'Other Candidates',
+	nearbyOfficials: 'Nearby Officials',
+};
+
+/**
+ * Renders one rail of a dev fixture profile and hands back the source cards, so
+ * every case can state its premise against the data rather than hoping the
+ * fixture still seeds what the assertion needs.
+ */
+async function renderRail(slug: string, rail: Rail) {
+	const { getDevPersonProfileView } = await import('~/lib/devPeopleProfileFixtures');
+	const { buildPersonSectionOverrides } = await import('./personSectionOverrides');
+
+	const view = getDevPersonProfileView(slug);
+	if (!view) throw new Error(`no dev fixture for ${slug}`);
+	const source = view[rail];
+	const cards = buildPersonSectionOverrides(view).component_profileContentBlock?.contentCards ?? [];
+	const section = cards.find(card => card.heading?.startsWith(RAIL_HEADING[rail]));
+	if (!section) throw new Error(`no "${RAIL_HEADING[rail]}…" section on ${slug}`);
+
+	await render(<>{section.content}</>);
+	return { source };
+}
+
+function cards(): Element[] {
+	return [...document.querySelectorAll("[data-component='CandidatesCard']")];
+}
+
+/** Cards carrying the GoodParty treatment, by the yellow frame the variant paints. */
+function goodPartyCards(): Element[] {
+	return cards().filter(card => card.className.includes('border-bright-yellow-600'));
+}
+
+/** The GoodParty.org mark, by the viewBox of its artwork. */
+function markCount(scope: ParentNode = document): number {
+	return scope.querySelectorAll("svg[viewBox='35 42 137 116']").length;
+}
+
+function countOf(text: string): number {
+	return cards().filter(card => card.textContent?.includes(text)).length;
+}
+
+describe('a related-person card states the pledge when the spine affirms it', () => {
+	for (const [slug, rail] of [
+		['allen-slagle-74eee01a', 'otherCandidates'],
+		['tracy-good-ecff49d3', 'nearbyOfficials'],
+	] as const) {
+		test(`${RAIL_HEADING[rail]} names every pledged person, and only those`, async () => {
+			const { source } = await renderRail(slug, rail);
+
+			// The premise, stated against the data: without it the equality below
+			// could hold at 0 === 0 and the case would pass having tested nothing.
+			const pledged = source.filter(card => card.isPledged);
+			expect(pledged.length).toBeGreaterThan(0);
+			expect(pledged.length).toBeLessThan(source.length);
+
+			expect(countOf(PLEDGED)).toBe(pledged.length);
+			for (const card of pledged) {
+				const rendered = cards().find(node => node.textContent?.includes(card.name));
+				expect(rendered?.textContent).toContain(PLEDGED);
+			}
+		});
+
+		test(`${RAIL_HEADING[rail]} makes no other claim about anyone`, async () => {
+			const { source } = await renderRail(slug, rail);
+
+			expect(cards().length).toBeGreaterThan(0);
+			// The negative line is false for anyone who pledged through Serve or by
+			// hand, and the ETL has never written the flag it would be keyed to, so
+			// it would be published about every person on the rail. The ineligible
+			// line belongs to the profile the card links to, not to a summary of it.
+			expect(document.body.textContent).not.toContain(NOT_PLEDGED);
+			expect(document.body.textContent).not.toContain(INELIGIBLE);
+			// The retired wording, which is what was missed in the first place.
+			expect(document.body.textContent).not.toContain(EMPOWERED);
+			expect(source.some(card => card.isEmpowered)).toBe(true);
+		});
+	}
+
+	// The line follows the pledge and the frame follows empowerment. They are
+	// different facts from different sources, and the fixtures seed them on
+	// different cycles precisely so a card that ties them together fails here.
+	test('the pledge line does not ride on the GoodParty badge', async () => {
+		const { source } = await renderRail('allen-slagle-74eee01a', 'otherCandidates');
+
+		const pledgedNotEmpowered = source.filter(card => card.isPledged && !card.isEmpowered);
+		const empoweredNotPledged = source.filter(card => card.isEmpowered && !card.isPledged);
+		expect(pledgedNotEmpowered.length).toBeGreaterThan(0);
+		expect(empoweredNotPledged.length).toBeGreaterThan(0);
+
+		for (const card of pledgedNotEmpowered) {
+			const node = cards().find(el => el.textContent?.includes(card.name));
+			expect(node?.textContent).toContain(PLEDGED);
+			expect(node?.className).not.toContain('border-bright-yellow-600');
+		}
+		for (const card of empoweredNotPledged) {
+			const node = cards().find(el => el.textContent?.includes(card.name));
+			expect(node?.textContent).not.toContain(PLEDGED);
+			expect(node?.className).toContain('border-bright-yellow-600');
+		}
+	});
+
+	// Branding, not an assertion — a change that dropped the whole GoodParty
+	// treatment must not pass as a copy fix.
+	test('the badge and the yellow frame survive', async () => {
+		await renderRail('allen-slagle-74eee01a', 'otherCandidates');
+
+		const branded = goodPartyCards();
+		expect(branded.length).toBeGreaterThan(0);
+		for (const card of branded) {
+			expect(markCount(card)).toBe(1);
+		}
+	});
+});
+
+describe('the shared card is unchanged off /people', () => {
+	// The Sanity claim block's example card and /candidate/[...slug] still mean
+	// "Empowered by GoodParty.org" by the badge; marketing scoped the pledge copy
+	// to the person profiles. An edit that keyed the shared component to the
+	// pledge instead of adding to it fails here.
+	test('a GoodParty candidate still reads as empowered by default', async () => {
+		const { CandidatesCard } = await import('~/ui/CandidatesCard');
+
+		await render(
+			<CandidatesCard name='Example Person' partyAffiliation='Independent' href='/people/example-person' isGoodPartyCandidate />,
+		);
+
+		expect(document.body.textContent).toContain(EMPOWERED);
+	});
+
+	test('the pledge is the more specific fact when a card is both', async () => {
+		const { CandidatesCard } = await import('~/ui/CandidatesCard');
+
+		await render(
+			<CandidatesCard
+				name='Example Person'
+				partyAffiliation='Independent'
+				href='/people/example-person'
+				isGoodPartyCandidate
+				attribution='pledged'
+			/>,
+		);
+
+		expect(document.body.textContent).toContain(PLEDGED);
+		expect(document.body.textContent).not.toContain(EMPOWERED);
+	});
+});

--- a/src/lib/devPeopleProfileFixtures.ts
+++ b/src/lib/devPeopleProfileFixtures.ts
@@ -182,12 +182,18 @@ function relatedCards(prefix: string, count: number, empoweredEvery = 3): Relate
 	return Array.from({ length: count }, (_, i) => {
 		const subtitle = PARTIES[i % PARTIES.length]!;
 		const isMajorParty = subtitle === 'Republican' || subtitle === 'Democrat';
+		// Pledged is seeded on a different cycle from empowered, and the two overlap
+		// on neither the first nor every card. Production cannot show this at all —
+		// the ETL has never written `is_pledged` — so the fixtures are the only place
+		// the pledge line renders, and they have to prove it does not ride on the
+		// badge: a card can be pledged without being empowered and vice versa.
 		return {
 			personId: `${prefix}-${i}`,
 			name: NAMES[i % NAMES.length]!,
 			subtitle,
 			href: `/people/${prefix}-${i}`,
 			isEmpowered: !isMajorParty && i % empoweredEvery === 0,
+			isPledged: !isMajorParty && i % 4 === 2,
 			avatarUrl: null,
 		};
 	});

--- a/src/lib/peopleProfile.test.ts
+++ b/src/lib/peopleProfile.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, test } from 'bun:test';
+import type { CandidacyItem } from '~/types/elections';
 import type { PersonItem, PersonOfficeHolder, PublicPersonProfile } from '~/types/people';
 import {
 	buildBreadcrumbTrail,
 	buildNearbyOfficialCards,
+	buildOtherCandidateCards,
 	buildPersonSlug,
 	buildPersonSlugFromBase,
 	composeView,
@@ -958,5 +960,87 @@ describe('buildNearbyOfficialCards', () => {
 
 	test('excludes the subject of the profile', () => {
 		expect(buildNearbyOfficialCards([makeOffice({ personId: PID, officeTitle: 'mayor' })], new Map(), PID)).toEqual([]);
+	});
+
+	// The pledge flag was already in memory here — `loadNearbyOfficials` resolves
+	// the same persons for their names — and the builder simply never read it.
+	test('carries the spine pledge flag through', () => {
+		const cards = buildNearbyOfficialCards(
+			[makeOffice({ personId: OTHER, officeTitle: 'mayor' })],
+			personsById(makePerson({ id: OTHER, fullName: 'chris lewis', isPledged: true })),
+			PID,
+		);
+		expect(cards.map((c) => c.isPledged)).toEqual([true]);
+	});
+
+	test('is not pledged when the spine says nothing', () => {
+		const cards = buildNearbyOfficialCards(
+			[makeOffice({ personId: OTHER, officeTitle: 'mayor' })],
+			personsById(makePerson({ id: OTHER, fullName: 'chris lewis' })),
+			PID,
+		);
+		expect(cards.map((c) => c.isPledged)).toEqual([false]);
+	});
+
+	// A row with no linked person still renders a card, labelled by its office.
+	// There is no one to have pledged, so it must not claim anyone did.
+	test('is not pledged when there is no person to look up', () => {
+		const cards = buildNearbyOfficialCards([makeOffice({ officeTitle: 'city council member' })], new Map(), PID);
+		expect(cards.map((c) => c.isPledged)).toEqual([false]);
+	});
+
+	// Same precedence as the hero: party decides eligibility, so a stale flag from
+	// a past run under another party cannot make the card contradict the profile
+	// it links to.
+	test('a major-party official is not pledged even when the flag says so', () => {
+		const cards = buildNearbyOfficialCards(
+			[makeOffice({ personId: OTHER, officeTitle: 'mayor', partyNames: ['Democratic'] })],
+			personsById(makePerson({ id: OTHER, fullName: 'chris lewis', isPledged: true })),
+			PID,
+		);
+		expect(cards.map((c) => c.isPledged)).toEqual([false]);
+	});
+});
+
+describe('buildOtherCandidateCards', () => {
+	const OTHER = '33333333-3333-3333-3333-333333333333';
+	const candidacy = (c: Partial<CandidacyItem> = {}): CandidacyItem => ({
+		id: 'c1',
+		personId: OTHER,
+		firstName: 'chris',
+		lastName: 'lewis',
+		party: 'Independent',
+		...c,
+	});
+	const personsById = (person: PersonItem) => new Map([[OTHER.toLowerCase(), person]]);
+
+	// The candidacy feed carries no pledge field, so the flag can only arrive via
+	// the batched person lookup `loadOtherCandidates` adds.
+	test('carries the pledge flag from the resolved person', () => {
+		const cards = buildOtherCandidateCards(
+			[candidacy()],
+			personsById(makePerson({ id: OTHER, isPledged: true })),
+			PID,
+		);
+		expect(cards.map((c) => c.isPledged)).toEqual([true]);
+	});
+
+	test('is not pledged when the person lookup found nothing', () => {
+		const cards = buildOtherCandidateCards([candidacy()], new Map(), PID);
+		expect(cards).toHaveLength(1);
+		expect(cards.map((c) => c.isPledged)).toEqual([false]);
+	});
+
+	test('a major-party candidate is not pledged even when the flag says so', () => {
+		const cards = buildOtherCandidateCards(
+			[candidacy({ party: 'Republican' })],
+			personsById(makePerson({ id: OTHER, isPledged: true })),
+			PID,
+		);
+		expect(cards.map((c) => c.isPledged)).toEqual([false]);
+	});
+
+	test('excludes the subject of the profile', () => {
+		expect(buildOtherCandidateCards([candidacy({ personId: PID })], new Map(), PID)).toEqual([]);
 	});
 });

--- a/src/lib/peopleProfile.test.ts
+++ b/src/lib/peopleProfile.test.ts
@@ -966,7 +966,7 @@ describe('buildNearbyOfficialCards', () => {
 	// the same persons for their names — and the builder simply never read it.
 	test('carries the spine pledge flag through', () => {
 		const cards = buildNearbyOfficialCards(
-			[makeOffice({ personId: OTHER, officeTitle: 'mayor' })],
+			[makeOffice({ personId: OTHER, officeTitle: 'mayor', partyNames: ['Independent'] })],
 			personsById(makePerson({ id: OTHER, fullName: 'chris lewis', isPledged: true })),
 			PID,
 		);
@@ -975,7 +975,7 @@ describe('buildNearbyOfficialCards', () => {
 
 	test('is not pledged when the spine says nothing', () => {
 		const cards = buildNearbyOfficialCards(
-			[makeOffice({ personId: OTHER, officeTitle: 'mayor' })],
+			[makeOffice({ personId: OTHER, officeTitle: 'mayor', partyNames: ['Independent'] })],
 			personsById(makePerson({ id: OTHER, fullName: 'chris lewis' })),
 			PID,
 		);
@@ -996,6 +996,36 @@ describe('buildNearbyOfficialCards', () => {
 		const cards = buildNearbyOfficialCards(
 			[makeOffice({ personId: OTHER, officeTitle: 'mayor', partyNames: ['Democratic'] })],
 			personsById(makePerson({ id: OTHER, fullName: 'chris lewis', isPledged: true })),
+			PID,
+		);
+		expect(cards.map((c) => c.isPledged)).toEqual([false]);
+	});
+
+	// An officeholder row carries no party at all far more often than it carries a
+	// wrong one. Unknown has to read as "do not assert", or the card claims a
+	// pledge for someone whose own profile may call them ineligible.
+	test('an unknown party is not enough to claim the pledge', () => {
+		const cards = buildNearbyOfficialCards(
+			[makeOffice({ personId: OTHER, officeTitle: 'mayor', partyNames: [] })],
+			personsById(makePerson({ id: OTHER, fullName: 'chris lewis', isPledged: true })),
+			PID,
+		);
+		expect(cards.map((c) => c.isPledged)).toEqual([false]);
+	});
+
+	// The hero would read the major-party candidacy and call them ineligible, so
+	// an Independent office row on its own must not outvote it.
+	test('a major-party signal elsewhere on the person disqualifies', () => {
+		const cards = buildNearbyOfficialCards(
+			[makeOffice({ personId: OTHER, officeTitle: 'mayor', partyNames: ['Independent'] })],
+			personsById(
+				makePerson({
+					id: OTHER,
+					fullName: 'chris lewis',
+					isPledged: true,
+					Candidacies: [{ id: 'c1', party: 'Republican' }],
+				}),
+			),
 			PID,
 		);
 		expect(cards.map((c) => c.isPledged)).toEqual([false]);
@@ -1035,6 +1065,33 @@ describe('buildOtherCandidateCards', () => {
 		const cards = buildOtherCandidateCards(
 			[candidacy({ party: 'Republican' })],
 			personsById(makePerson({ id: OTHER, isPledged: true })),
+			PID,
+		);
+		expect(cards.map((c) => c.isPledged)).toEqual([false]);
+	});
+
+	test('an unknown party is not enough to claim the pledge', () => {
+		const cards = buildOtherCandidateCards(
+			[candidacy({ party: undefined })],
+			personsById(makePerson({ id: OTHER, isPledged: true })),
+			PID,
+		);
+		expect(cards.map((c) => c.isPledged)).toEqual([false]);
+	});
+
+	// The hero resolves party office-first, so a partisan office outranks this
+	// Independent race. The card sees the office only when the batched person
+	// payload carries it — when it does, it must not contradict the profile.
+	test('a major-party office on the person disqualifies an Independent run', () => {
+		const cards = buildOtherCandidateCards(
+			[candidacy({ party: 'Independent' })],
+			personsById(
+				makePerson({
+					id: OTHER,
+					isPledged: true,
+					OfficeHolders: [makeOffice({ partyNames: ['Democratic'] })],
+				}),
+			),
 			PID,
 		);
 		expect(cards.map((c) => c.isPledged)).toEqual([false]);

--- a/src/lib/peopleProfile.ts
+++ b/src/lib/peopleProfile.ts
@@ -119,6 +119,14 @@ export interface RelatedPersonCard {
 	subtitle: string | null;
 	href: string | null;
 	isEmpowered: boolean;
+	/**
+	 * The same ETL-maintained spine flag the hero reads (`Person.isPledged`), so
+	 * a card and the profile it links to can never disagree. Major-party people
+	 * are false regardless of the flag, matching the hero's precedence: party
+	 * decides eligibility, and a stale pledge from a past run under another party
+	 * must not override it.
+	 */
+	isPledged: boolean;
 	avatarUrl: string | null;
 }
 
@@ -613,9 +621,25 @@ function nameOf(first?: string | null, last?: string | null, fallback = ''): str
 	return formatPersonName([first, last].filter(Boolean).join(' ')) ?? fallback;
 }
 
-/** Maps candidacies sharing a position into "Other Candidates" cards, excluding the subject. */
+/**
+ * True only when we have looked the person up and the spine says they pledged.
+ * Party wins, exactly as it does for the hero (`pledgeAttribution`): a
+ * Republican or Democrat is ineligible rather than unpledged, so a stale flag
+ * from a past run under another party cannot make a card claim otherwise.
+ */
+function pledgedFromSpine(person: PersonItem | undefined, ...rawParties: Array<string | null | undefined>): boolean {
+	if (person?.isPledged !== true) return false;
+	return !isMajorParty(classifyPartyFrom(...rawParties));
+}
+
+/**
+ * Maps candidacies sharing a position into "Other Candidates" cards, excluding
+ * the subject. `personsById` supplies the pledge flag, which the candidacy feed
+ * does not carry — see {@link loadOtherCandidates}.
+ */
 export function buildOtherCandidateCards(
 	candidacies: CandidacyItem[],
+	personsById: Map<string, PersonItem>,
 	excludePersonId: string,
 ): RelatedPersonCard[] {
 	const cards: RelatedPersonCard[] = [];
@@ -637,6 +661,7 @@ export function buildOtherCandidateCards(
 			subtitle: c.party ?? null,
 			href,
 			isEmpowered: false,
+			isPledged: pledgedFromSpine(c.personId ? personsById.get(c.personId.toLowerCase()) : undefined, c.party),
 			avatarUrl: c.image ?? null,
 		});
 		if (cards.length >= 6) break;
@@ -682,6 +707,7 @@ export function buildNearbyOfficialCards(
 			subtitle: oh.officeTitle ?? oh.Position?.name ?? oh.positionName ?? null,
 			href,
 			isEmpowered: false,
+			isPledged: pledgedFromSpine(person, oh.partyNames?.[0]),
 			avatarUrl: person?.headshotUrl ?? null,
 		});
 		if (cards.length >= 6) break;
@@ -951,14 +977,28 @@ async function loadPrimaryCandidacy(
 	return getCandidateBySlug({ slug, includeStances: false, includeRace: true });
 }
 
-/** Fetches "Other Candidates for [Position]" cards for a resolved position. */
+/**
+ * Fetches "Other Candidates for [Position]" cards for a resolved position.
+ *
+ * The candidacy feed carries no pledge flag, so the persons are resolved in a
+ * second batched call — the same shape {@link loadNearbyOfficials} already uses,
+ * and preferred over a candidacy-level flag because it reads the very
+ * `Person.isPledged` the hero reads, so a card cannot contradict the profile it
+ * links to. `getPersonsByIds` dedupes, caps at 500 and is cached, and returns
+ * without a request when the position has no linked people.
+ */
 async function loadOtherCandidates(
 	positionId: string | null,
 	excludePersonId: string,
 ): Promise<RelatedPersonCard[]> {
 	if (!positionId) return [];
 	const candidacies = await getCandidacies({ positionId });
-	return buildOtherCandidateCards(candidacies, excludePersonId);
+	const ids = candidacies
+		.map((c) => c.personId)
+		.filter((id): id is string => Boolean(id) && id!.toLowerCase() !== excludePersonId.toLowerCase());
+	const persons = await getPersonsByIds(ids);
+	const byId = new Map(persons.map((p) => [p.id.toLowerCase(), p]));
+	return buildOtherCandidateCards(candidacies, byId, excludePersonId);
 }
 
 /** Fetches "Nearby Officials" cards for a resolved geo id. */

--- a/src/lib/peopleProfile.ts
+++ b/src/lib/peopleProfile.ts
@@ -15,7 +15,7 @@ import {
 	buildElectionPositionHrefFromRaceSlug,
 	getStateName,
 } from '~/lib/electionsHelpers';
-import { classifyPartyFrom, isMajorParty, type PartyClass } from '~/lib/party';
+import { classifyParty, classifyPartyFrom, isMajorParty, type PartyClass } from '~/lib/party';
 import { formatPersonName } from '~/lib/personName';
 import type { CandidacyItem } from '~/types/elections';
 import type {
@@ -121,10 +121,9 @@ export interface RelatedPersonCard {
 	isEmpowered: boolean;
 	/**
 	 * The same ETL-maintained spine flag the hero reads (`Person.isPledged`), so
-	 * a card and the profile it links to can never disagree. Major-party people
-	 * are false regardless of the flag, matching the hero's precedence: party
-	 * decides eligibility, and a stale pledge from a past run under another party
-	 * must not override it.
+	 * a card and the profile it links to read one source. Gated on party
+	 * eligibility by {@link pledgedFromSpine}, which is stricter than the hero
+	 * because a card sees less of the person than their own profile does.
 	 */
 	isPledged: boolean;
 	avatarUrl: string | null;
@@ -622,14 +621,36 @@ function nameOf(first?: string | null, last?: string | null, fallback = ''): str
 }
 
 /**
- * True only when we have looked the person up and the spine says they pledged.
- * Party wins, exactly as it does for the hero (`pledgeAttribution`): a
- * Republican or Democrat is ineligible rather than unpledged, so a stale flag
- * from a past run under another party cannot make a card claim otherwise.
+ * True only when the spine affirms the pledge AND the party evidence within
+ * reach affirms eligibility. Party wins, as it does for the hero
+ * (`pledgeAttribution`): a Republican or Democrat is ineligible rather than
+ * unpledged, so a stale flag from a past run under another party must not make
+ * a card claim otherwise.
+ *
+ * Deliberately STRICTER than the hero rather than merely different. The hero
+ * resolves party office-first then current candidacy across the person's whole
+ * record; a card has only the row it was built from, plus whatever the batched
+ * person payload happens to carry. So an unknown party suppresses the line, and
+ * a major-party signal anywhere in reach suppresses it, instead of the hero's
+ * "most specific class wins". The failure we can afford is a pledged person
+ * whose card stays quiet. The one we cannot is a card asserting a pledge that
+ * the profile it links to calls impossible.
+ *
+ * Residual, and unclosable from here: if the batch payload carries no nested
+ * offices or candidacies and the row's own party disagrees with the office the
+ * hero would read, the two can still differ. Closing it needs the current
+ * office party on the person feed, not more logic here.
  */
-function pledgedFromSpine(person: PersonItem | undefined, ...rawParties: Array<string | null | undefined>): boolean {
+function pledgedFromSpine(person: PersonItem | undefined, ...rowParties: Array<string | null | undefined>): boolean {
 	if (person?.isPledged !== true) return false;
-	return !isMajorParty(classifyPartyFrom(...rawParties));
+	const evidence = [
+		...rowParties,
+		...(person.OfficeHolders ?? []).flatMap((o) => o.partyNames ?? []),
+		...(person.Candidacies ?? []).map((c) => c.party),
+	];
+	const classes = evidence.map(classifyParty).filter((cls): cls is PartyClass => cls !== null);
+	if (classes.length === 0) return false;
+	return !classes.some(isMajorParty);
 }
 
 /**
@@ -707,7 +728,7 @@ export function buildNearbyOfficialCards(
 			subtitle: oh.officeTitle ?? oh.Position?.name ?? oh.positionName ?? null,
 			href,
 			isEmpowered: false,
-			isPledged: pledgedFromSpine(person, oh.partyNames?.[0]),
+			isPledged: pledgedFromSpine(person, ...(oh.partyNames ?? [])),
 			avatarUrl: person?.headshotUrl ?? null,
 		});
 		if (cards.length >= 6) break;

--- a/src/ui/CandidatesCard.mdx
+++ b/src/ui/CandidatesCard.mdx
@@ -69,11 +69,21 @@ Flag indicating this is a GoodParty-empowered candidate. When `true`, the card d
 - Yellow border (`border-bright-yellow-600`)
 - Yellow hover background (`hover:bg-bright-yellow-50`)
 - GoodParty logo badge overlay on avatar
-- "Empowered by GoodParty.org" text in gray
+- "Empowered by GoodParty.org" text in gray, unless `attribution` says otherwise
 
 **Type:** `boolean`
 
 **Default:** `false`
+
+#### `attribution` (optional)
+
+The line under the party affiliation. Independent of `isGoodPartyCandidate`, which carries the mark and the yellow frame: the mark says whose candidate this is, the line asserts a fact about the person, and on `/people` those come from different sources (claim vs pledge).
+
+The `/people` person profiles pass `'pledged'` for anyone the spine says has taken the pledge and `'none'` for everyone else. They never pass the negative or ineligible lines the hero carries — see `relatedCardAttribution` for why.
+
+**Type:** `'empowered' | 'pledged' | 'none'`
+
+**Default:** `'empowered'` when `isGoodPartyCandidate`, else `'none'`
 
 #### `className` (optional)
 
@@ -118,7 +128,7 @@ Internal key used by CandidatesBlock for React list rendering.
 - Border: `border-bright-yellow-600` (yellow)
 - Hover: Shadow and yellow background (`hover:shadow-md hover:bg-bright-yellow-50`)
 - Badge: GoodParty logo positioned `absolute -bottom-0.5 -right-0.5` on avatar
-- "Empowered by GoodParty.org": Displayed in `text-neutral-500` (gray), `caption` styleType
+- Attribution line: Displayed in `text-neutral-500` (gray), `caption` styleType. Wraps above the "View profile" link on narrow cards, so the longer pledge wording fits without pushing the link off. Wording comes from `_lib/attributionCopy.ts`, shared with `ProfileHero` so the two cannot drift.
 
 ## Avatar Fallback
 

--- a/src/ui/CandidatesCard.stories.tsx
+++ b/src/ui/CandidatesCard.stories.tsx
@@ -75,6 +75,50 @@ export const GoodPartyWithInitials: Story = {
 	},
 };
 
+/** How a pledged person's card renders on a `/people` profile. */
+export const Pledged: Story = {
+	args: {
+		name: 'Firstname Lastname',
+		partyAffiliation: 'Independent',
+		href: '/people/firstname-lastname',
+		attribution: 'pledged',
+	},
+};
+
+/** Pledged AND a GoodParty candidate — the pledge is the more specific fact. */
+export const PledgedGoodParty: Story = {
+	args: {
+		name: 'Firstname Lastname',
+		partyAffiliation: 'Independent',
+		href: '/people/firstname-lastname',
+		isGoodPartyCandidate: true,
+		attribution: 'pledged',
+	},
+};
+
+/** A GoodParty candidate who has not pledged — badge and frame, no line. */
+export const GoodPartyNoAttribution: Story = {
+	args: {
+		name: 'Firstname Lastname',
+		partyAffiliation: 'Independent',
+		href: '/people/firstname-lastname',
+		isGoodPartyCandidate: true,
+		attribution: 'none',
+	},
+};
+
+/** The longest line the card can carry, next to the longest name and party. */
+export const PledgedLongName: Story = {
+	args: {
+		name: 'Alexandria Martinez',
+		partyAffiliation: 'Independent Party of Delaware',
+		avatar: imageJpg(),
+		href: '/people/alexandria-martinez',
+		isGoodPartyCandidate: true,
+		attribution: 'pledged',
+	},
+};
+
 export const LongPartyName: Story = {
 	args: {
 		name: 'Alexandria Martinez',

--- a/src/ui/CandidatesCard.tsx
+++ b/src/ui/CandidatesCard.tsx
@@ -1,5 +1,6 @@
 import { memo } from 'react';
 import { cn, tv } from './_lib/utils.ts';
+import { ATTRIBUTION_COPY, type AttributionMode } from './_lib/attributionCopy.ts';
 import type { SanityImage } from './types.ts';
 import { Avatar } from './Avatar.tsx';
 import { Text } from './Text.tsx';
@@ -22,12 +23,23 @@ const styles = tv({
 		contentWrapper: 'flex flex-col gap-1',
 		content: 'flex flex-col gap-1',
 		name: 'whitespace-nowrap md:whitespace-normal',
-		empowered: 'text-neutral-500 min-w-0',
+		attributionLine: 'text-neutral-500 min-w-0',
 		footerWrapper: 'flex flex-col w-full gap-2 md:w-full md:flex-row md:flex-wrap md:items-center md:justify-between md:gap-4',
 		link: 'flex items-center gap-2 text-nowrap shrink-0',
 		badge: 'absolute -bottom-0.5 -right-0.5 w-[50px] h-[35px] flex items-center justify-center',
 	},
 });
+
+/**
+ * What the card may state about GoodParty.org's relationship to the person.
+ *
+ * Only the affirmative lines, and deliberately: `ATTRIBUTION_COPY` also carries
+ * "Has Not Taken…" and "Ineligible…", which the hero renders but a card must not
+ * (see `relatedCardAttribution`). Narrowing the union here is what makes that a
+ * type error rather than a judgement call at each call site — and widening it is
+ * the whole of the change when the pledge data lands.
+ */
+export type CardAttributionMode = Extract<AttributionMode, 'empowered' | 'pledged' | 'none'>;
 
 export type CandidatesCardProps = {
 	className?: string;
@@ -36,12 +48,26 @@ export type CandidatesCardProps = {
 	partyAffiliation: string;
 	href: string;
 	isGoodPartyCandidate?: boolean;
+	/**
+	 * The line under the party affiliation. Separate from `isGoodPartyCandidate`,
+	 * which carries the mark and the yellow frame — the same split ProfileHero
+	 * draws between `showBrandMark` and `attribution`: the mark says this is one
+	 * of our candidates, the line asserts a fact about the person. They come from
+	 * different inputs on `/people` (claim vs pledge), so a pledged person who is
+	 * not a GoodParty candidate still gets their line.
+	 *
+	 * Defaults to the legacy behaviour — `isGoodPartyCandidate` implies
+	 * "Empowered by GoodParty.org" — which is what the Sanity claim block's
+	 * example card and `/candidate/[...slug]` still mean by it.
+	 */
+	attribution?: CardAttributionMode;
 	_key?: string;
 };
 
 export const CandidatesCard = memo(function CandidatesCard(props: CandidatesCardProps) {
 	const isGoodParty = props.isGoodPartyCandidate === true;
-	const { base, baseStandard, baseGoodParty, avatarWrapper, rightColumn, contentWrapper, content, name, empowered, footerWrapper, link, badge } = styles();
+	const attributionMode: CardAttributionMode = props.attribution ?? (isGoodParty ? 'empowered' : 'none');
+	const { base, baseStandard, baseGoodParty, avatarWrapper, rightColumn, contentWrapper, content, name, attributionLine, footerWrapper, link, badge } = styles();
 
 	// Generate initials from name if no avatar
 	const initials = props.avatar ? undefined : getInitials(props.name);
@@ -79,9 +105,9 @@ export const CandidatesCard = memo(function CandidatesCard(props: CandidatesCard
 				</div>
 
 				<div className={footerWrapper()}>
-					{isGoodParty ? (
-						<Text as='p' styleType='caption' className={empowered()}>
-							Empowered by GoodParty.org
+					{attributionMode !== 'none' ? (
+						<Text as='p' styleType='caption' className={attributionLine()}>
+							{ATTRIBUTION_COPY[attributionMode]}
 						</Text>
 					) : (
 						<div />

--- a/src/ui/ProfileHero.mdx
+++ b/src/ui/ProfileHero.mdx
@@ -60,11 +60,31 @@ The candidate's profile image as a hosted URL. Used on dynamic candidate profile
 
 #### `isEmpowered` (optional)
 
-When true, shows the GoodParty logo badge on the avatar and the "Empowered by GoodParty.org" attribution. Set from claimed campaign lookup on candidate profile pages.
+When true, shows the GoodParty logo badge on the avatar and the "Empowered by GoodParty.org" attribution. Set from claimed campaign lookup on candidate profile pages. This is the legacy fallback, used only where `attribution` is not passed — today that is `/candidate/[...slug]`.
 
 **Type:** `boolean`
 
 **Default:** `false`
+
+#### `attribution` (optional)
+
+The line under the office. Overrides `isEmpowered` when passed.
+
+The `/people` person profiles pass one of the three pledge values: marketing replaced the claim-keyed "Empowered by GoodParty.org" / "Not Endorsed by GoodParty.org" pair there on 2026-08-17 with statements about the GoodParty.org pledge. `personSectionOverrides.pledgeAttribution` decides which; `pledgeAttributionCopy.test.tsx` pins the wording.
+
+The sentences themselves live in `~/ui/_lib/attributionCopy`, shared with the related-person cards. Take the wording from there rather than restating it — the cards went on publishing the retired sentence precisely because they held their own copy of it.
+
+**Type:** `AttributionMode` — `'empowered' | 'pledged' | 'notPledged' | 'pledgeIneligible' | 'none'`
+
+**Default:** derived from `isEmpowered`
+
+#### `showBrandMark` (optional)
+
+Whether the GoodParty.org mark paints, on the portrait and beside the attribution. Separate from `attribution` because the mark says the page is a GoodParty.org profile while the line asserts a fact about the person — on `/people` those come from different inputs (claimed vs pledged).
+
+**Type:** `boolean`
+
+**Default:** `attribution === 'empowered'`
 
 #### `backgroundColor` (optional)
 
@@ -96,7 +116,7 @@ When a profile image is provided (`profileImageUrl` or `profileImage`):
 
 ## Attribution
 
-When `isEmpowered` is true, the component displays "Empowered by GoodParty.org" with the GoodParty logo below the office title. Text color adapts to the background variant (white on midnight, dark on cream).
+The line under the office title comes from `attribution`, falling back to `isEmpowered` ("Empowered by GoodParty.org"). Affirmative lines get the semibold Figma treatment beside the GoodParty logo; the negative and ineligible pledge lines get the grey disclaimer style, so a sentence saying someone has *not* done something cannot read as a badge. Text color adapts to the background variant (white on midnight, dark on cream).
 
 ## Image Fallback
 

--- a/src/ui/ProfileHero.tsx
+++ b/src/ui/ProfileHero.tsx
@@ -6,6 +6,7 @@ import { Text } from './Text.tsx';
 import { ResponsiveImage } from './ResponsiveImage.tsx';
 import type { SanityImage } from './types.ts';
 import type { backgroundTypeValues } from './_lib/designTypesStore.ts';
+import { ATTRIBUTION_COPY, type AttributionMode } from './_lib/attributionCopy.ts';
 import { Logo } from '~/sanity/utils/Logo.tsx';
 
 const styles = tv({
@@ -133,15 +134,6 @@ export type ProfileHeroProps = {
 	 * framing, which is what the /candidate pages mean by it.
 	 */
 	showBrandMark?: boolean;
-};
-
-type AttributionMode = 'empowered' | 'pledged' | 'notPledged' | 'pledgeIneligible' | 'none';
-
-const ATTRIBUTION_COPY: Record<Exclude<AttributionMode, 'none'>, string> = {
-	empowered: 'Empowered by GoodParty.org',
-	pledged: 'Has Taken the GoodParty.org Pledge',
-	notPledged: 'Has Not Taken the GoodParty.org Pledge',
-	pledgeIneligible: 'Ineligible for the GoodParty.org Pledge Due to Partisan Affiliation',
 };
 
 /**

--- a/src/ui/_lib/attributionCopy.ts
+++ b/src/ui/_lib/attributionCopy.ts
@@ -1,0 +1,25 @@
+/**
+ * The sentences GoodParty.org publishes about a named person, shared by every
+ * surface that makes one.
+ *
+ * Marketing replaced the claim-keyed "Empowered by GoodParty.org" framing on the
+ * `/people` profiles with the three pledge statements on 2026-08-17 (approved by
+ * Emily and Jack; `pledgeAttributionCopy.test.tsx` pins the wording). The hero
+ * was rewritten and the related-person cards on the same page were missed, so
+ * the retired sentence went on being published about six other named people per
+ * profile. These live in one place now: a surface can only fall behind a copy
+ * decision if it holds its own copy.
+ */
+export type AttributionMode =
+	| 'empowered'
+	| 'pledged'
+	| 'notPledged'
+	| 'pledgeIneligible'
+	| 'none';
+
+export const ATTRIBUTION_COPY: Record<Exclude<AttributionMode, 'none'>, string> = {
+	empowered: 'Empowered by GoodParty.org',
+	pledged: 'Has Taken the GoodParty.org Pledge',
+	notPledged: 'Has Not Taken the GoodParty.org Pledge',
+	pledgeIneligible: 'Ineligible for the GoodParty.org Pledge Due to Partisan Affiliation',
+};


### PR DESCRIPTION
The **Other Candidates** and **Nearby Officials** cards on a person profile still read "Empowered by GoodParty.org" — the line marketing retired on this surface on 2026-08-17 ([#239](https://github.com/thegoodparty/gp-marketing/pull/239)) — because neither card builder read a pledge flag. Both now read `Person.isPledged`, the same field the profile hero reads, and render "Has Taken the GoodParty.org Pledge".

**Only the affirmative line renders.** No "Has Not Taken…", no "Ineligible…". The ETL has never written `is_pledged` — 0 true across 69,385 sampled production rows (`docs/person-spine-pledge-and-claim-linkage-handoff.md`), and 40 live profiles sampled today rendered "Has Taken…" zero times — so the negative line would publish a statement we cannot stand behind about six more named people per page. An affirmative-only rule cannot be false when it renders, and it lights up on its own when the backfill lands. Turning the other two on is then widening `CardAttributionMode` and the return in `relatedCardAttribution`.

**The fetch.** Nearby Officials needed no new request; `loadNearbyOfficials` already resolves those persons for their names. Other Candidates gains one batched `getPersonsByIds` over the candidacy `personId`s (deduped, capped, cached, no request when there are none) — preferred over a candidacy-level flag so both rails and the hero read one field. It stays inside the existing `Promise.all` and adds a second round trip to that branch only.

**Party gating is stricter on a card than on the hero, on purpose.** The hero resolves party office-first then current candidacy across the person's whole record; a card has only the row it was built from. So an unknown party suppresses the line and a major-party signal anywhere in reach disqualifies, rather than the hero's "most specific class wins" — a card that stays quiet about a pledged person is a cost we can pay, one that asserts a pledge the linked profile calls impossible is not. The residual gap is documented at `pledgedFromSpine`.

The badge and yellow frame are untouched — branding, not an assertion. The longer sentence wraps above "View profile" in the footer's existing `flex-wrap`; the `/people` rail is a full-width column, so it fits on one line there. The narrow `CandidatesBlock` grid keeps the default `'empowered'` and is unchanged.

**This supersedes [#244](https://github.com/thegoodparty/gp-marketing/pull/244)**, which suppressed the line entirely on the grounds that the cards had no pledge field to read. This gets them the field, and preserves #244's outcome exactly for everyone who has not pledged. It should be closed rather than merged first. I carried over its `.gitignore` fix; its `ProfileHero.mdx` correction is not carried here and is still worth landing.

One deviation from scope: the four attribution sentences moved to `src/ui/_lib/attributionCopy.ts`, shared by the card and the hero. Pure extraction, no behaviour change — this bug exists because the hero was rewritten while a second surface held its own copy of the same sentence.

```
npm run typecheck  → clean
npm test           → 861 pass, 0 fail   (baseline on develop: 841)
```

`npm run lint` does not resolve `@typescript-eslint` through this worktree's symlinked `node_modules`. Environmental; not chased.
