### PR TITLE
Release: put the stored-lead id on the notify event

### DIFF
--- a/src/app/api/people/claim-request/route.test.ts
+++ b/src/app/api/people/claim-request/route.test.ts
@@ -21,13 +21,25 @@ const { POST } = await import('./route');
 
 let calls: Array<{ url: string; body: Record<string, unknown> }>;
 let originalFetch: typeof globalThis.fetch;
+/** gp-api's response body; `null` stands for a 2xx that cannot be parsed. */
+let upstreamBody: Record<string, unknown> | null;
+
+const CLAIM_REQUEST_ID = 'clr_01HZY8QK5M';
 
 beforeEach(() => {
 	calls = [];
+	upstreamBody = { id: CLAIM_REQUEST_ID, personId: PERSON_ID, createdAt: '2026-08-24T00:00:00.000Z' };
 	originalFetch = globalThis.fetch;
 	globalThis.fetch = (async (url: string, init?: { body?: string }) => {
 		calls.push({ url: String(url), body: JSON.parse(init?.body ?? '{}') as Record<string, unknown> });
-		return { ok: true, status: 200 } as Response;
+		return {
+			ok: true,
+			status: 200,
+			json: async () => {
+				if (upstreamBody === null) throw new Error('unreadable body');
+				return upstreamBody;
+			},
+		} as Response;
 	}) as unknown as typeof globalThis.fetch;
 });
 
@@ -88,6 +100,41 @@ describe('POST /api/people/claim-request', () => {
 		await post({ personId: PERSON_ID, email: EMAIL, source: 'owner' });
 
 		expect(calls[0]?.body['marketingConsent']).toBe(false);
+	});
+
+	/**
+	 * The client needs the stored-lead id to put on the success event, and this
+	 * route is the only place it can come from: the browser never talks to gp-api
+	 * directly. Returning a bare `{ ok: true }` — as this did before — leaves the
+	 * event with nothing to tie it to the row it came from.
+	 */
+	test('hands back the stored-lead id so the success event can carry it', async () => {
+		const res = await post({ personId: PERSON_ID, email: EMAIL, source: 'notify' });
+
+		expect(res.status).toBe(200);
+		expect(await res.json()).toEqual({ ok: true, claimRequestId: CLAIM_REQUEST_ID });
+	});
+
+	/**
+	 * By this point gp-api has committed the lead, so an unreadable body costs the
+	 * analytics join and nothing else. Failing here would turn a stored lead into
+	 * an error on the visitor's screen.
+	 */
+	test('still succeeds when the upstream body cannot be parsed', async () => {
+		upstreamBody = null;
+
+		const res = await post({ personId: PERSON_ID, email: EMAIL, source: 'notify' });
+
+		expect(res.status).toBe(200);
+		expect(await res.json()).toEqual({ ok: true, claimRequestId: null });
+	});
+
+	test('omits an id that is not a usable string', async () => {
+		upstreamBody = { id: '', personId: PERSON_ID };
+
+		const res = await post({ personId: PERSON_ID, email: EMAIL, source: 'notify' });
+
+		expect(await res.json()).toEqual({ ok: true, claimRequestId: null });
 	});
 
 	test('rejects a bad personId before calling gp-api', async () => {

--- a/src/app/api/people/claim-request/route.ts
+++ b/src/app/api/people/claim-request/route.ts
@@ -66,7 +66,17 @@ export async function POST(request: NextRequest) {
 			const isClientError = res.status >= 400 && res.status < 500;
 			return NextResponse.json({ error: 'Claim request failed' }, { status: isClientError ? res.status : 502 });
 		}
-		return NextResponse.json({ ok: true });
+		// gp-api's stored-lead id, forwarded so the success event can carry it.
+		// Never fail the submission over it: the lead is already committed at this
+		// point, so a body we cannot read costs the analytics join, not the lead.
+		let claimRequestId: string | null = null;
+		try {
+			const payload = (await res.json()) as { id?: unknown };
+			if (typeof payload.id === 'string' && payload.id !== '') claimRequestId = payload.id;
+		} catch {
+			claimRequestId = null;
+		}
+		return NextResponse.json({ ok: true, claimRequestId });
 	} catch {
 		return NextResponse.json({ error: 'Claim request failed' }, { status: 502 });
 	}

--- a/src/components/people/ClaimProfileModal.tsx
+++ b/src/components/people/ClaimProfileModal.tsx
@@ -80,11 +80,20 @@ export function NotifyForm({
 				}),
 			});
 			if (!res.ok) throw new Error('Submission failed');
+			// The lead is stored by now, so reading the id back must not be able to
+			// fail the submission — hence the fallback rather than a rethrow.
+			let claimRequestId: string | null = null;
+			try {
+				const payload = (await res.json()) as { claimRequestId?: string | null };
+				claimRequestId = payload.claimRequestId ?? null;
+			} catch {
+				claimRequestId = null;
+			}
 			// After the 201, so the count means completed asks. This is the signal
 			// marketing automates on: gp-api's HubSpot counter only ever sees the
 			// subjects that resolve to a single CRM contact — see
 			// trackPersonProfileNotifySubmitted.
-			trackPersonProfileNotifySubmitted({ personId });
+			trackPersonProfileNotifySubmitted({ personId, claimRequestId });
 			setIsSuccess(true);
 		} catch {
 			setError('root', { message: 'Something went wrong. Please try again.' });

--- a/src/components/people/claimFlow.test.tsx
+++ b/src/components/people/claimFlow.test.tsx
@@ -51,6 +51,7 @@ let segmentEvents: { name: string; props?: Record<string, unknown> }[];
 let dataLayer: Record<string, unknown>[];
 let fetchCalls: { url: string; body: Record<string, unknown> }[];
 let fetchOk: boolean;
+let fetchBody: Record<string, unknown> | null;
 
 beforeEach(() => {
 	dom = new JSDOM('<!DOCTYPE html><html><body><div id="root"></div></body></html>', {
@@ -74,6 +75,7 @@ beforeEach(() => {
 	dataLayer = [];
 	fetchCalls = [];
 	fetchOk = true;
+	fetchBody = { ok: true, claimRequestId: CLAIM_REQUEST_ID };
 
 	// JSDOM ships no scrollIntoView at all, so the component would silently skip
 	// the optional call. Standing one up is what makes the scroll observable.
@@ -108,7 +110,15 @@ beforeEach(() => {
 
 	globalThis.fetch = (async (url: string, init?: { body?: string }) => {
 		fetchCalls.push({ url: String(url), body: JSON.parse(init?.body ?? '{}') as Record<string, unknown> });
-		return { ok: fetchOk } as Response;
+		// `fetchBody === null` stands for a 2xx whose body cannot be read, which is
+		// the case that must still report the submission.
+		return {
+			ok: fetchOk,
+			json: async () => {
+				if (fetchBody === null) throw new Error('unreadable body');
+				return fetchBody;
+			},
+		} as Response;
 	}) as unknown as typeof fetch;
 
 	// `window.location` is unforgeable in JSDOM — it cannot be reassigned or
@@ -175,6 +185,8 @@ function setInputValue(input: HTMLInputElement, value: string) {
 
 const personId = '11111111-1111-4111-8111-111111111111';
 const displayName = 'Example Person';
+/** gp-api's stored-lead id, echoed back through the proxy. */
+const CLAIM_REQUEST_ID = 'clr_01HZY8QK5M';
 
 async function renderProfileClaimSurfaces() {
 	const [{ ClaimProfileModal }, { PersonClaimCTABand }] = await Promise.all([import('./ClaimProfileModal'), import('./PersonClaimCTABand')]);
@@ -318,7 +330,37 @@ describe('a completed notify submission is reported to marketing', () => {
 
 		expect(fetchCalls).toHaveLength(1);
 		expect(segmentEvents).toEqual([
-			{ name: NOTIFY_EVENT, props: { personId, page_path: '/people/example-person' } },
+			{
+				name: NOTIFY_EVENT,
+				props: { personId, claimRequestId: CLAIM_REQUEST_ID, page_path: '/people/example-person' },
+			},
+		]);
+	});
+
+	/**
+	 * `personId` is the join key marketing resolves to the subject's HubSpot
+	 * contact (`mart_civics.people.gp_person_id` → `hs_contact_id`), so it has to
+	 * survive on the event even though the contact id itself is never fetched
+	 * here. Losing it would leave the event with nothing to join on.
+	 */
+	test('carries the subject id the CRM join needs', async () => {
+		await submitNotifyForm();
+
+		expect(segmentEvents[0]?.props?.['personId']).toBe(personId);
+	});
+
+	/**
+	 * The id is a convenience for tying an event back to its row, never a
+	 * precondition for reporting the ask. A 2xx we cannot parse still means the
+	 * lead was stored, so the event must fire with a null rather than vanish.
+	 */
+	test('still reports the ask when the id cannot be read back', async () => {
+		fetchBody = null;
+
+		await submitNotifyForm();
+
+		expect(segmentEvents).toEqual([
+			{ name: NOTIFY_EVENT, props: { personId, claimRequestId: null, page_path: '/people/example-person' } },
 		]);
 	});
 
@@ -331,7 +373,10 @@ describe('a completed notify submission is reported to marketing', () => {
 		await submitNotifyForm();
 
 		expect(trackedEvents.filter(e => e.name === NOTIFY_EVENT)).toEqual([
-			{ name: NOTIFY_EVENT, props: { personId, page_path: '/people/example-person' } },
+			{
+				name: NOTIFY_EVENT,
+				props: { personId, claimRequestId: CLAIM_REQUEST_ID, page_path: '/people/example-person' },
+			},
 		]);
 	});
 

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -56,10 +56,30 @@ export function trackClickToCallPhoneSubmitted(props: { page_path: string | null
  * this module attaches it, and Segment's snippet puts the path in event
  * *context* rather than in properties, so a property-keyed audience would not
  * find it otherwise.
+ *
+ * `personId` is the join key to the subject's HubSpot record: it is the same
+ * value as `mart_civics.people.gp_person_id`, whose `hs_contact_id` column is
+ * the contact gp-api writes `candidate_profile_requests` to. The contact id is
+ * deliberately NOT resolved here — that lookup is a warehouse query gp-api runs
+ * off the request path, and it yields null for most of the spine, so putting it
+ * on the event would both slow a public form submit and read as "no contact"
+ * far more often than it read as a real id.
+ *
+ * `claimRequestId` is gp-api's stored-lead id, echoed back through the proxy so
+ * a Segment event can be tied to the exact row that produced it. Null when the
+ * lead was accepted but the id could not be read back; the event still fires,
+ * because a completed ask is the thing being counted.
  */
-export function trackPersonProfileNotifySubmitted(props: { personId: string }): void {
+export function trackPersonProfileNotifySubmitted(props: {
+	personId: string;
+	claimRequestId?: string | null;
+}): void {
 	const pagePath = typeof window !== 'undefined' ? window.location.pathname : null;
-	const properties = { personId: props.personId, page_path: pagePath ?? null };
+	const properties = {
+		personId: props.personId,
+		claimRequestId: props.claimRequestId ?? null,
+		page_path: pagePath ?? null,
+	};
 
 	trackEvent('Person Profile Notify Submitted', properties);
 	trackSegmentEvent('Person Profile Notify Submitted', properties);


### PR DESCRIPTION
Promotes `develop` to production.

Contains one change since the last release (#247):

- **#248** — the `Person Profile Notify Submitted` Segment/Amplitude event now carries a `claimRequestId`, gp-api's id for the stored lead, so an event can be tied back to the exact row that produced it. Getting it to the browser required the `/api/people/claim-request` proxy route to stop discarding gp-api's response body and return a bare `{ ok: true }`; it now forwards the id alongside it.

Both the proxy and the modal fall back to `claimRequestId: null` when the upstream body cannot be parsed. By that point the lead is already committed, so an unreadable body costs the analytics join and nothing else — it must never surface as an error to the visitor, and the event still fires so the completed ask is still counted.

The change also pins down `personId` as the key marketing joins to the subject's HubSpot contact in the warehouse (`mart_civics.people.gp_person_id` → `hs_contact_id`). The contact id itself is deliberately not resolved on the request path.

Merge with a **merge commit**, not a squash, so `develop` and `master` do not diverge.

Made with [Cursor](https://cursor.com)