### PR TITLE
Release: send "View Position" to the position page

### DIFF
--- a/src/lib/peopleProfile.test.ts
+++ b/src/lib/peopleProfile.test.ts
@@ -156,6 +156,112 @@ describe('composeView recent experience', () => {
 	});
 });
 
+/**
+ * "View Position" is the row's only link, and its label promises the
+ * `/elections` position page — the same destination the breadcrumb's position
+ * crumb carries. It shipped pointing at `/candidate/<slug>` instead, so the
+ * button took voters to the candidate's own page rather than the seat.
+ */
+describe('Recent Experience links to the position page, not the candidate page', () => {
+	const POSITION_HREF = '/elections/al/lee/auburn/position/city-council-ward-5';
+	const CANDIDACY_SLUG = 'toshiro-jackson/auburn-city-council-ward-5';
+
+	const runningFor = (over: Record<string, unknown> = {}) =>
+		makePerson({
+			state: 'AL',
+			Candidacies: [
+				{
+					id: 'c1',
+					slug: CANDIDACY_SLUG,
+					positionName: 'Auburn City Council - Ward 5',
+					state: 'AL',
+					Race: { electionDate: '2026-11-03' },
+					...over,
+				},
+			],
+		});
+
+	test('the row for the resolved race points at that position page', () => {
+		const view = composeView(PID, runningFor(), null, { positionHref: POSITION_HREF });
+
+		expect(view.recentExperience[0]?.href).toBe(POSITION_HREF);
+	});
+
+	/**
+	 * The reported bug, pinned by destination rather than by absence: any href
+	 * under `/candidate/` here is the old wrong link, whatever its slug.
+	 */
+	test('never points at the candidate page', () => {
+		const view = composeView(PID, runningFor(), null, { positionHref: POSITION_HREF });
+
+		for (const row of view.recentExperience) {
+			expect(row.href ?? '').not.toStartWith('/candidate/');
+		}
+	});
+
+	/**
+	 * The position href is resolved from whichever candidacy the loader fetched
+	 * in full, so it describes that race alone. A second candidacy carries no
+	 * race slug of its own (election-api nests only `Race.electionDate`), and
+	 * hanging this href on it would point at the wrong seat.
+	 */
+	test('a candidacy the position href does not describe stays unlinked', () => {
+		const person = makePerson({
+			state: 'AL',
+			Candidacies: [
+				{
+					id: 'c1',
+					slug: CANDIDACY_SLUG,
+					positionName: 'Auburn City Council - Ward 5',
+					state: 'AL',
+					Race: { electionDate: '2026-11-03' },
+				},
+				{
+					id: 'c2',
+					slug: 'toshiro-jackson/lee-county-commission',
+					positionName: 'Lee County Commission',
+					state: 'AL',
+					Race: { electionDate: '2022-11-08' },
+				},
+			],
+		});
+
+		const view = composeView(PID, person, null, { positionHref: POSITION_HREF });
+		const byTitle = new Map(view.recentExperience.map((r) => [r.title, r.href]));
+
+		expect(byTitle.get('Candidate for Auburn City Council - Ward 5')).toBe(POSITION_HREF);
+		expect(byTitle.get('Candidate for Lee County Commission')).toBeNull();
+	});
+
+	/**
+	 * The requirement is parity with the breadcrumb, so assert against what the
+	 * trail actually builds rather than against a hand-written path: if the
+	 * elections route shape changes, both move together or this fails.
+	 */
+	test('matches the destination the breadcrumb position crumb uses', () => {
+		const raceSlug = 'al/lee/auburn/city-council-ward-5';
+		const trail = buildBreadcrumbTrail({
+			displayName: 'Toshiro Jackson',
+			stateCode: 'AL',
+			raceSlug,
+			positionLevel: 'CITY',
+			positionName: 'Auburn City Council - Ward 5',
+		});
+		const crumbHref = trail.find((c) => c.label === 'Auburn City Council - Ward 5')?.href ?? null;
+
+		const view = composeView(PID, runningFor(), null, { positionHref: crumbHref });
+
+		expect(crumbHref).not.toBeNull();
+		expect(view.recentExperience[0]?.href).toBe(crumbHref);
+	});
+
+	test('renders no link when no position page resolves', () => {
+		const view = composeView(PID, runningFor(), null, {});
+
+		expect(view.recentExperience[0]?.href).toBeNull();
+	});
+});
+
 describe('extractPersonId', () => {
 	test('extracts the trailing UUID from a slug', () => {
 		expect(extractPersonId(`jane-doe-${PID}`)).toBe(PID);

--- a/src/lib/peopleProfile.ts
+++ b/src/lib/peopleProfile.ts
@@ -561,7 +561,10 @@ function buildLinks(
  * term (and vice versa). Entries without a date sort last.
  * Claimed profiles override this with the owner-authored list (see composeView).
  */
-function buildRecentExperience(person: PersonItem | null): ExperienceItem[] {
+function buildRecentExperience(
+	person: PersonItem | null,
+	positionLink: { candidacySlug: string | null; href: string } | null = null,
+): ExperienceItem[] {
 	const offices = (person?.OfficeHolders ?? []).map((o) => ({
 		sortKey: o.startAt ?? '',
 		item: {
@@ -585,7 +588,16 @@ function buildRecentExperience(person: PersonItem | null): ExperienceItem[] {
 					organization: c.state ?? null,
 					term: formatYear(electionDate),
 					status: 'Candidate',
-					href: c.slug ? `/candidate/${c.slug}` : null,
+					// "View Position" means the /elections position page the breadcrumb
+					// already points at, not the candidate's own page. Only the primary
+					// candidacy resolves to one: the person payload nests just
+					// `Race.electionDate` (see election-api CANDIDACY_INCLUDE), so a race
+					// slug exists only for the candidacy the loader fetched in full. The
+					// rest render unlinked rather than pointing somewhere else.
+					href:
+						positionLink && c.slug && c.slug === positionLink.candidacySlug
+							? positionLink.href
+							: null,
 				},
 			};
 		});
@@ -883,6 +895,16 @@ export function composeView(
 	// Mirror the loader's stateCode (which includes the candidacy fallback) so a
 	// candidate-only person's sidebar label matches their breadcrumb.
 	const stateLabel = extras.stateCode ?? office?.state ?? person?.state ?? null;
+	// `positionHref` was resolved from whichever candidacy selectPrimaryCandidacy
+	// picked, so Recent Experience has to key off that same candidacy — matching
+	// on anything looser would hang the breadcrumb's position link on a different
+	// race than the one it describes.
+	const positionLink = extras.positionHref
+		? {
+				candidacySlug: selectPrimaryCandidacy(person, office?.isCurrent === true)?.slug ?? null,
+				href: extras.positionHref,
+			}
+		: null;
 
 	// Removal strips photo + authored content; keep only the civics spine.
 	const avatarUrl = removed ? null : (overlay?.avatarUrl ?? person?.headshotUrl ?? null);
@@ -951,7 +973,9 @@ export function composeView(
 		// to the public-record spine. Unclaimed pages get the spine list too.
 		recentExperience:
 			extras.recentExperience ??
-			(removed ? buildRecentExperience(person) : (authoredExperience(overlay) ?? buildRecentExperience(person))),
+			(removed
+				? buildRecentExperience(person, positionLink)
+				: (authoredExperience(overlay) ?? buildRecentExperience(person, positionLink))),
 		otherCandidates: extras.otherCandidates ?? [],
 		nearbyOfficials: extras.nearbyOfficials ?? [],
 		breadcrumb: extras.breadcrumb ?? [{ href: '/elections', label: 'Elections' }, { label: displayName }],


### PR DESCRIPTION
Promotes `develop` to production.

Contains one change since the last release (#249):

- **#250** — under **Recent Experience**, the "View Position" button linked to `/candidate/<slug>`, the candidate's own profile, instead of the `/elections` position page its label promises and its breadcrumb already points at. Reported case resolved to `goodparty.org/candidate/toshiro-jackson/auburn-city-council-ward-5`. It now reuses the position href the breadcrumb resolves, keyed to the same candidacy so the row and the crumb can't describe different races.

Not a regression — the href has pointed at `/candidate/` since the section shipped in #161, and no test pinned it.

One scope limit: election-api nests only `Race.electionDate` under a person's candidacies, so only the primary candidacy (the one fetched in full for the breadcrumb) can resolve a position page. A second, older candidacy row now renders unlinked rather than keeping the wrong link. Widening that select so every row links is queued as a follow-up.

## Test plan

- [x] 5 tests added, each verified to fail against the old code
- [x] Parity test asserts against `buildBreadcrumbTrail` output, so the row and crumb move together if elections routes change
- [x] Full suite green; 3 pre-existing failures unchanged from `develop`
- [ ] Spot-check a candidate profile on production after deploy

Made with [Cursor](https://cursor.com)