### PR TITLE
feat(people): link every Recent Experience row to its own position page

### DIFF
--- a/src/lib/peopleProfile.test.ts
+++ b/src/lib/peopleProfile.test.ts
@@ -345,6 +345,47 @@ describe('Recent Experience links every row it has a race slug for', () => {
 	});
 
 	/**
+	 * A CITY slug carrying no county segment resolves to a county-depth URL that
+	 * 308s to the canonical four-level path (redirectCityRaceToFourLevelUrl), so
+	 * it is a working link, not a broken one.
+	 *
+	 * The sitemap deliberately suppresses these (`skipUnmappedCity`) because a
+	 * sitemap should advertise canonical URLs rather than redirects. An in-page
+	 * link is the opposite case: the breadcrumb's position crumb builds this very
+	 * href from the same helper, so suppressing it here would leave the row
+	 * unlinked while the crumb directly above it still worked — the exact
+	 * inconsistency this whole change set exists to remove.
+	 */
+	test('a city slug with no county segment links, matching the breadcrumb', () => {
+		const slug = 'ca/beverly-hills/city-legislature';
+		const person = makePerson({
+			state: 'CA',
+			Candidacies: [
+				{
+					id: 'c1',
+					slug: 'jane-doe-city-council',
+					positionName: 'City Council',
+					state: 'CA',
+					Race: { electionDate: '2026-11-03', slug, positionLevel: 'CITY' },
+				},
+			],
+		});
+
+		const crumbHref = buildBreadcrumbTrail({
+			displayName: 'Jane Doe',
+			stateCode: 'CA',
+			raceSlug: slug,
+			positionLevel: 'CITY',
+			positionName: 'City Council',
+		}).find((c) => c.label === 'City Council')?.href;
+
+		const view = composeView(PID, person, null, {});
+
+		expect(crumbHref).toBe('/elections/ca/beverly-hills/position/city-legislature');
+		expect(view.recentExperience[0]?.href).toBe(crumbHref);
+	});
+
+	/**
 	 * Slugs come from a dbt macro and can be too short to place. Linking anyway
 	 * would point "View Position" at a 404, which is worse than no link.
 	 */

--- a/src/lib/peopleProfile.test.ts
+++ b/src/lib/peopleProfile.test.ts
@@ -13,6 +13,7 @@ import {
 	resolveProfileState,
 	type PersonPersona,
 } from './peopleProfile';
+import { buildElectionPositionHrefFromRaceSlug } from './electionsHelpers';
 import { classifyParty, isMajorParty } from './party';
 
 const PID = '11111111-1111-1111-1111-111111111111';
@@ -258,6 +259,112 @@ describe('Recent Experience links to the position page, not the candidate page',
 	test('renders no link when no position page resolves', () => {
 		const view = composeView(PID, runningFor(), null, {});
 
+		expect(view.recentExperience[0]?.href).toBeNull();
+	});
+});
+
+/**
+ * Once election-api nests each candidacy's own race slug (omni#1425) and
+ * flattens the office's onto each term, every row can reach its own position
+ * page — not just the one candidacy the loader fetched in full.
+ */
+describe('Recent Experience links every row it has a race slug for', () => {
+	/** The canonical builder, so these assert parity rather than a hand-written path. */
+	const expectedHref = (slug: string, positionLevel: string) =>
+		buildElectionPositionHrefFromRaceSlug({ slug, positionLevel });
+
+	test('each candidacy links to its own race, not to the primary one', () => {
+		const current = 'al/lee/auburn/city-council-ward-5';
+		const older = 'al/lee/lee-county-commission';
+		const person = makePerson({
+			state: 'AL',
+			Candidacies: [
+				{
+					id: 'c1',
+					slug: 'toshiro-jackson/auburn-city-council-ward-5',
+					positionName: 'Auburn City Council - Ward 5',
+					state: 'AL',
+					Race: { electionDate: '2026-11-03', slug: current, positionLevel: 'CITY' },
+				},
+				{
+					id: 'c2',
+					slug: 'toshiro-jackson/lee-county-commission',
+					positionName: 'Lee County Commission',
+					state: 'AL',
+					Race: { electionDate: '2022-11-08', slug: older, positionLevel: 'COUNTY' },
+				},
+			],
+		});
+
+		const view = composeView(PID, person, null, {});
+		const byTitle = new Map(view.recentExperience.map((r) => [r.title, r.href]));
+
+		expect(byTitle.get('Candidate for Auburn City Council - Ward 5')).toBe(
+			expectedHref(current, 'CITY'),
+		);
+		expect(byTitle.get('Candidate for Lee County Commission')).toBe(expectedHref(older, 'COUNTY'));
+		// Distinct races must not collapse onto one destination.
+		expect(byTitle.get('Candidate for Auburn City Council - Ward 5')).not.toBe(
+			byTitle.get('Candidate for Lee County Commission'),
+		);
+	});
+
+	/**
+	 * A pure officeholder has no candidacy to borrow a slug from, so the term's
+	 * own `positionSlug` is the only route to their seat's page.
+	 */
+	test('an office term links through the slug flattened onto it', () => {
+		const slug = 'ca/los-angeles/mayor';
+		const person = makePerson({
+			state: 'CA',
+			OfficeHolders: [
+				makeOffice({
+					officeTitle: 'Mayor',
+					state: 'CA',
+					startAt: '2022-01-01',
+					isCurrent: true,
+					positionSlug: slug,
+					positionLevel: 'CITY',
+				}),
+			],
+		});
+
+		const view = composeView(PID, person, null, {});
+
+		expect(view.recentExperience[0]?.href).toBe(expectedHref(slug, 'CITY'));
+	});
+
+	test('an office term with no race stays unlinked', () => {
+		const person = makePerson({
+			OfficeHolders: [makeOffice({ officeTitle: 'Mayor', state: 'CA', startAt: '2022-01-01' })],
+		});
+
+		const view = composeView(PID, person, null, {});
+
+		expect(view.recentExperience[0]?.href).toBeNull();
+	});
+
+	/**
+	 * Slugs come from a dbt macro and can be too short to place. Linking anyway
+	 * would point "View Position" at a 404, which is worse than no link.
+	 */
+	test('a slug that resolves to no page renders unlinked, not a 404', () => {
+		const person = makePerson({
+			state: 'CA',
+			Candidacies: [
+				{
+					id: 'c1',
+					slug: 'jane-doe-mayor',
+					positionName: 'Mayor',
+					state: 'CA',
+					Race: { electionDate: '2026-11-03', slug: 'ca', positionLevel: 'CITY' },
+				},
+			],
+		});
+
+		const view = composeView(PID, person, null, {});
+
+		expect(expectedHref('ca', 'CITY')).toBeUndefined();
 		expect(view.recentExperience[0]?.href).toBeNull();
 	});
 });

--- a/src/lib/peopleProfile.ts
+++ b/src/lib/peopleProfile.ts
@@ -561,6 +561,26 @@ function buildLinks(
  * term (and vice versa). Entries without a date sort last.
  * Claimed profiles override this with the owner-authored list (see composeView).
  */
+/**
+ * The `/elections` position page for a race slug, or null when none resolves —
+ * the destination "View Position" promises and the breadcrumb's position crumb
+ * already uses. Every hop is optional upstream (a term need not reach a race,
+ * and a slug can be too short to place), so an unresolvable row renders as
+ * plain text rather than a link that 404s.
+ */
+function positionHrefFor(
+	slug: string | null | undefined,
+	positionLevel: string | null | undefined,
+): string | null {
+	if (!slug) return null;
+	return (
+		buildElectionPositionHrefFromRaceSlug({
+			slug,
+			positionLevel: positionLevel ?? undefined,
+		}) ?? null
+	);
+}
+
 function buildRecentExperience(
 	person: PersonItem | null,
 	positionLink: { candidacySlug: string | null; href: string } | null = null,
@@ -573,7 +593,10 @@ function buildRecentExperience(
 			term: formatTerm(o),
 			// Current terms read as "Incumbent"; past terms let the year range speak.
 			status: o.isCurrent === true ? 'Incumbent' : null,
-			href: null,
+			// The term's own race slug, flattened onto it by election-api. Prefer the
+			// race's level: Position.level is nullable, and the parser needs a level
+			// to route CITY/LOCAL offices to the right elections depth.
+			href: positionHrefFor(o.positionSlug, o.positionLevel ?? o.Position?.level),
 		},
 	}));
 
@@ -589,15 +612,15 @@ function buildRecentExperience(
 					term: formatYear(electionDate),
 					status: 'Candidate',
 					// "View Position" means the /elections position page the breadcrumb
-					// already points at, not the candidate's own page. Only the primary
-					// candidacy resolves to one: the person payload nests just
-					// `Race.electionDate` (see election-api CANDIDACY_INCLUDE), so a race
-					// slug exists only for the candidacy the loader fetched in full. The
-					// rest render unlinked rather than pointing somewhere else.
+					// already points at, not the candidate's own page. The row's own race
+					// slug is the accurate source; `positionLink` only covers the one
+					// candidacy the loader fetched in full, and stays as a fallback for
+					// payloads predating omni#1425 (which added slug to the nested Race).
 					href:
-						positionLink && c.slug && c.slug === positionLink.candidacySlug
+						positionHrefFor(c.Race?.slug, c.Race?.positionLevel) ??
+						(positionLink && c.slug && c.slug === positionLink.candidacySlug
 							? positionLink.href
-							: null,
+							: null),
 				},
 			};
 		});

--- a/src/lib/peopleProfile.ts
+++ b/src/lib/peopleProfile.ts
@@ -594,8 +594,12 @@ function buildRecentExperience(
 			// Current terms read as "Incumbent"; past terms let the year range speak.
 			status: o.isCurrent === true ? 'Incumbent' : null,
 			// The term's own race slug, flattened onto it by election-api. Prefer the
-			// race's level: Position.level is nullable, and the parser needs a level
-			// to route CITY/LOCAL offices to the right elections depth.
+			// race's level, which is non-null where Position.level is nullable.
+			// The level only changes routing once a citySlugToCountySlug map is in
+			// play (see resolveElectionPositionFromRaceSlug); without one every slug
+			// falls through to the generic segment-count branch, so passing it is
+			// inert today. Kept so this call reads like the breadcrumb's, and so it
+			// stays correct if a county map is ever threaded through.
 			href: positionHrefFor(o.positionSlug, o.positionLevel ?? o.Position?.level),
 		},
 	}));

--- a/src/types/people.ts
+++ b/src/types/people.ts
@@ -29,6 +29,13 @@ export interface PersonOfficeHolder {
 	officeEmail: string | null;
 	mailingCity: string | null;
 	mailingState: string | null;
+	/**
+	 * The office's own most recent race, flattened onto the term by election-api's
+	 * attachOfficeContext. This is the only route to a position page for a pure
+	 * officeholder, who has no candidacy to borrow a race slug from.
+	 */
+	positionSlug?: string | null;
+	positionLevel?: string | null;
 	/** Present when the officeholders feed is fetched with includePosition. */
 	Position?: {
 		id: string;
@@ -49,9 +56,15 @@ export interface PersonCandidacySummary {
 	positionId?: string | null;
 	/**
 	 * The candidacy's race, nested by election-api's persons endpoint (narrow,
-	 * non-PII select). Lets "Recent Experience" date a run without a second fetch.
+	 * non-PII select). Lets "Recent Experience" date a run and link it to its
+	 * position page without a second fetch. `slug`/`positionLevel` arrived after
+	 * `electionDate` (omni#1425), so treat them as absent on older payloads.
 	 */
-	Race?: { electionDate?: string | null } | null;
+	Race?: {
+		electionDate?: string | null;
+		slug?: string | null;
+		positionLevel?: string | null;
+	} | null;
 }
 
 export interface PersonItem {


### PR DESCRIPTION
## Summary

Follow-up to #250, which pointed "View Position" at the `/elections` position page instead of `/candidate/<slug>`. That fix could only resolve **one** destination: the person payload carried a race slug for just the candidacy the loader fetches in full, so a second run rendered unlinked and office terms never linked at all.

Now each row builds its href from its own race:

- **Candidacies** use the race slug [omni#1425](https://github.com/thegoodparty/omni/pull/1425) adds to the nested `Race` select.
- **Office terms** use the `positionSlug` election-api already flattens onto each term via `attachOfficeContext` — data that has been on the wire for a while but was never typed on the marketing side, which is why office rows had no link.

## Deploy ordering

Safe in either order. The per-candidacy href falls back to #250's primary-candidacy link when `Race.slug` is absent, so this is inert on today's payloads and lights up when omni#1425 ships.

## Behavior guards

A slug that resolves to no page renders unlinked rather than linking to a 404 — slugs come from a dbt macro and can be too short to place.

## Test plan

- [x] 4 tests added; the two behavior-changing ones verified to **fail** against `develop`, and the two guard tests correctly hold in both states
- [x] Asserts parity against `buildElectionPositionHrefFromRaceSlug` rather than hand-written paths, and pins that two distinct races don't collapse onto one destination
- [x] Full suite: 875 pass, 3 pre-existing failures unchanged from `develop`
- [x] `typecheck` and lint clean

## Still open after this

A pure officeholder still gets no `positionHref` and a collapsed breadcrumb (`Elections > State > Name`), because `loadPersonProfile` derives the race slug only from a candidacy. The office's `positionSlug` could now supply it, but that changes breadcrumbs and JSON-LD `BreadcrumbList` on every officeholder page, so it belongs in its own reviewable change rather than bundled here.

Made with [Cursor](https://cursor.com)