### PR TITLE
fix(people): stop the hero portrait landing on the first card

### DIFF
--- a/src/ui/ProfileContentBlock.tsx
+++ b/src/ui/ProfileContentBlock.tsx
@@ -31,6 +31,14 @@ const styles = tv({
 		// children are individual white cards; the cream page shows through the
 		// 24px gaps between them.
 		separatedColumn: 'flex min-w-0 w-full flex-col gap-6',
+		// The portrait overflows into the FIRST grid column. Normally that column is
+		// the <aside>, which clears it; with no sidebar the content column lands
+		// there instead — squeezed into the 280-400px track AND under the photo.
+		// From `lg` the two-column grid exists, so move content to the wide second
+		// column, which is beside the portrait and needs no clearance. Below `lg`
+		// the grid is a single stacked column, so clear the overflow the same way
+		// the sidebar does (`md` 104px; under `md` the portrait does not overflow).
+		columnWithoutSidebar: 'md:mt-[104px] lg:col-start-2 lg:mt-0',
 		// Figma card: 16px radius (--radius-lg) white fill; the inner sections
 		// carry their own 24px padding (ProfileContentCard), so the card itself
 		// only adds the 16px outer inset the frame shows.
@@ -67,10 +75,13 @@ export type ProfileContentBlockProps = {
 
 export function ProfileContentBlock(props: ProfileContentBlockProps) {
 	const backgroundColor = props.backgroundColor ?? 'cream';
-	const { base, well, grid, sidebar, sidebarStandalone, content, separatedColumn, separatedCard, title: titleSlot } =
+	const { base, well, grid, sidebar, sidebarStandalone, content, separatedColumn, separatedCard, columnWithoutSidebar, title: titleSlot } =
 		styles({ backgroundColor });
 	const hasContentCards = props.contentCards.length > 0;
 	const separated = props.cardLayout === 'separated';
+	// Without an <aside> the cards become the grid's first child, so they inherit
+	// the slot the hero portrait overflows into. See the slot's comment.
+	const contentColumn = props.sidebar ? undefined : columnWithoutSidebar();
 
 	return (
 		<article className={cn(base(), props.className)} data-component='ProfileContentBlock'>
@@ -83,7 +94,7 @@ export function ProfileContentBlock(props: ProfileContentBlockProps) {
 					)}
 					{hasContentCards &&
 						(separated ? (
-							<div className={cn(separatedColumn())}>
+							<div className={cn(separatedColumn(), contentColumn)}>
 								{chunkCardGroups(props.contentCards).map((group, gi) =>
 									group[0]?.raw ? (
 										group.map((card, ci) => <ProfileContentCard key={`${gi}-${ci}`} {...card} />)
@@ -102,7 +113,7 @@ export function ProfileContentBlock(props: ProfileContentBlockProps) {
 								)}
 							</div>
 						) : (
-							<div className={cn(content())}>
+							<div className={cn(content(), contentColumn)}>
 								{props.title && (
 									<Text as='h2' styleType='heading-sm' className={titleSlot()}>
 										{props.title}

--- a/src/ui/profileContentColumn.test.tsx
+++ b/src/ui/profileContentColumn.test.tsx
@@ -1,0 +1,85 @@
+import { describe, expect, test } from 'bun:test';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { ProfileContentBlock } from './ProfileContentBlock.tsx';
+
+/**
+ * The hero portrait is a circle that straddles the dark band: ProfileHero caps
+ * how much height it contributes with a negative bottom margin (`md` 104px,
+ * `lg` 216px), so the photo renders *past* the hero and lands in the first
+ * column of this block's grid.
+ *
+ * With a sidebar that first column is the <aside>, which offsets by the same
+ * amount to clear it. With no sidebar — a person whose civics feeds name no
+ * race, so there is nothing to put in an elections sidebar — the content column
+ * takes that slot instead and inherits neither the clearance nor the width it
+ * wants, so the photo sat on top of the first card. Measured on production
+ * before the fix: 168px of collision at 1512px wide, 73px at 900px, and a card
+ * squeezed to the 400px sidebar track while the wide column sat empty.
+ */
+
+const CARDS = [{ cardType: 'about-me' as const, heading: 'About Me', content: 'Body' }];
+
+const SIDEBAR = {
+	links: [],
+	aboutOffice: 'Body',
+	termLength: 'Body',
+	electionDate: 'Body',
+};
+
+/** Class list of the element holding the content cards. */
+function contentColumnClasses(html: string): string {
+	// The cards' column is the last direct child of the grid; grab every class
+	// attribute and take the one that owns the first card.
+	const marker = html.indexOf('About Me');
+	expect(marker).toBeGreaterThan(-1);
+	const before = html.slice(0, marker);
+	const classes = [...before.matchAll(/class="([^"]*)"/g)].map((m) => m[1] ?? '');
+	const column = classes.reverse().find((c) => c.includes('min-w-0') && c.includes('w-full'));
+	return column ?? '';
+}
+
+describe('the content column clears the hero portrait when there is no sidebar', () => {
+	for (const cardLayout of ['separated', 'joined'] as const) {
+		test(`${cardLayout}: moves to the wide second column from lg`, () => {
+			const html = renderToStaticMarkup(
+				<ProfileContentBlock cardLayout={cardLayout} contentCards={CARDS} />,
+			);
+			const column = contentColumnClasses(html);
+			// Beside the portrait, not under it — and in the 1fr track, not the
+			// 280-400px one the sidebar would have occupied.
+			expect(column).toContain('lg:col-start-2');
+		});
+
+		test(`${cardLayout}: clears the portrait in the stacked layout below lg`, () => {
+			const html = renderToStaticMarkup(
+				<ProfileContentBlock cardLayout={cardLayout} contentCards={CARDS} />,
+			);
+			const column = contentColumnClasses(html);
+			// Below `lg` the grid is a single column, so the card stacks directly
+			// under the photo and has to reserve its `md` overflow.
+			expect(column).toContain('md:mt-[104px]');
+			// ...but not at `lg`, where col-start-2 already moves it clear.
+			expect(column).toContain('lg:mt-0');
+		});
+
+		test(`${cardLayout}: leaves the column alone when a sidebar already clears it`, () => {
+			const html = renderToStaticMarkup(
+				<ProfileContentBlock cardLayout={cardLayout} contentCards={CARDS} sidebar={SIDEBAR} />,
+			);
+			const column = contentColumnClasses(html);
+			// The <aside> is the first grid child and carries the clearance, so the
+			// content column must stay in its natural second track.
+			expect(column).not.toContain('lg:col-start-2');
+			expect(column).not.toContain('md:mt-[104px]');
+		});
+	}
+
+	test('the sidebar still carries the clearance it always did', () => {
+		const html = renderToStaticMarkup(
+			<ProfileContentBlock cardLayout='separated' contentCards={CARDS} sidebar={SIDEBAR} />,
+		);
+		const aside = /<aside class="([^"]*)"/.exec(html)?.[1] ?? '';
+		expect(aside).toContain('md:mt-[104px]');
+		expect(aside).toContain('lg:mt-[216px]');
+	});
+});


### PR DESCRIPTION
## What's wrong

On a profile with no elections sidebar the hero portrait renders **on top of** the first content card, and the card is squeezed into the narrow sidebar track while the wide column sits empty.

Reported on [Develle Jackson](https://goodparty.org/people/develle-jackson-c788b673).

## Why

`ProfileHero` caps how much height the portrait contributes with a negative bottom margin (`md:-mb-[104px] lg:-mb-[216px]`) so the circle straddles the dark band and renders *past* the hero, into the first column of `ProfileContentBlock`'s grid. Both `sidebar` and `sidebarStandalone` offset by the same amount to clear it.

Nothing else does. When a person's civics feeds name no race there is no `<aside>`, so the content column becomes the grid's first child — it lands under the portrait *and* inside the `minmax(280px,400px)` track meant for the sidebar.

Measured on production before the fix:

| viewport | collision | card width |
| --- | --- | --- |
| 1512 | 168 x 400px | 400px |
| 1024 | 181 x 400px | 400px |
| 900 | 73 x 274px | 768px |
| 768 | 77 x 288px | 678px |
| 500 | none | 438px |

Profiles that *do* have a sidebar were never affected — their cards sit in the second track, beside the portrait.

## The fix

Give the content column the placement it only lacked because the `<aside>` was absent:

- `lg:col-start-2` — from `lg` the two-column grid exists, so put the cards in the wide track, beside the portrait rather than under it. This is where they already sit whenever a sidebar is present, so the two shapes now agree.
- `md:mt-[104px] lg:mt-0` — below `lg` the grid is a single stacked column, so reserve the `md` overflow the way the sidebar does. Under `md` the portrait has no negative margin and nothing is reserved.

## Verification

- `src/ui/profileContentColumn.test.tsx` pins the placement for both `separated` and `joined` layouts, and pins that a sidebar-bearing block is left alone. Confirmed non-vacuous: 4 of the 7 fail on `develop`.
- Geometry checked by applying the compiled CSS to the live page and re-measuring: collision clears at every breakpoint above, and the card widens from 400px to 752px at 1512.
- `typecheck` clean; 814 logic + 64 DOM tests pass.

## Not in scope

Two other things surfaced on that profile and need their own work:

1. It is one of **two** `Person` rows for the same human. The other, `develle-jackson-a7d370b4`, is the one carrying `is_pledged` and the gp-api user link — which is why this URL says "Has Not Taken the GoodParty.org Pledge" about someone who did.
2. That second row's gp-api overlay exists but is `unpublished` with every content field null, so it renders an almost empty page.

Made with [Cursor](https://cursor.com)