### PR TITLE
fix(people): resolve a spelled-out state to the code the routes expect

### DIFF
--- a/docs/person-state-normalization-handoff.md
+++ b/docs/person-state-normalization-handoff.md
@@ -1,0 +1,134 @@
+# Handoff: `Person.state` is not always a state code
+
+**Ask:** normalize `state` to the two-letter USPS code in the Person mart
+(`m_election_api__person.sql`), so every row spells it the way BallotReady-sourced
+rows already do.
+
+**Status:** the marketing site has shipped defensive workarounds for both known
+symptoms ([gp-marketing#256](https://github.com/thegoodparty/gp-marketing/pull/256),
+[#257](https://github.com/thegoodparty/gp-marketing/pull/257)). Nothing is on fire.
+This is the root-cause fix that makes those a no-op safety net and stops the next
+consumer from hitting it.
+
+## What we found
+
+`election-api.Person.state` holds two different formats:
+
+| shape | rows |
+| --- | --- |
+| two-letter code (`MN`) | 551,372 |
+| spelled out (`Minnesota`) | **24,619** |
+| null | 20,636 |
+
+The spelled-out rows are not random. They are almost exactly the cohort the ETL
+creates from a gp-api account rather than from BallotReady:
+
+| of the 24,619 spelled-out rows | count |
+| --- | --- |
+| linked to a gp-api user (`gp_api_user_id` set) | 24,385 (99%) |
+| `is_pledged` | 18,893 |
+| with any `Candidacy` or `OfficeHolder` row | **0** |
+
+The working theory is that this path passes gp-api's own state format straight
+through, while the BallotReady path carries codes. Worth confirming on your side —
+if that is right, the fix is one normalization at the point those rows are built.
+
+## Why it matters
+
+Every consumer treats this column as a code. In gp-marketing the variable is
+literally named `stateCode`.
+
+**1. A 404 breadcrumb on all 24,619 pages.** The profile breadcrumb builds
+`/elections/${state.toLowerCase()}`:
+
+| URL | status |
+| --- | --- |
+| `/elections/mn`, `/elections/ok` | 200 |
+| `/elections/minnesota`, `/elections/california`, `/elections/texas` | **404** |
+
+This was invisible for a while because the label helper falls back to echoing its
+input, so the crumb *reads* "California" and simply goes nowhere. It affects the
+published, indexable profiles too — the crumbs a crawler actually follows.
+
+**2. These people can never enter the sitemap.** The sitemap enumerates by
+sweeping `v1/persons?state=<code>` across the 51 codes, and election-api filters
+with exact equality (`...(state && { state })`). A `Minnesota` row is returned by
+no sweep. Normally the candidacy/officeholder feeds recover such rows, but this
+cohort has zero civics rows, so there is nothing to recover them with.
+
+While they are unpublished this is harmless — they are thin and correctly
+excluded. But four of them have already published, which makes their pages
+indexable, and all four were missing from the production sitemap:
+
+| published profile | state | in sitemap |
+| --- | --- | --- |
+| `sean-matteson-d1d88988` | `NC` | yes |
+| `matthew-janson-e2f25d7b` | `MT` | yes |
+| `david-patterson-65b96bee` | `California` | **no** |
+| `valentin-pena-1b1555a1` | `Oklahoma` | **no** |
+| `james-macon-03ba19fc` | `Tennessee` | **no** |
+| `kasen-hampton-623ac0fe` | `Florida` | **no** |
+
+## Queries to reproduce
+
+Run against the election-api database.
+
+```sql
+-- 1. How is state spelled?
+select case
+         when state is null then '(null)'
+         when length(btrim(state)) = 2 then 'two-letter code'
+         else 'spelled out'
+       end as shape,
+       count(*)::int as persons
+  from "Person"
+ group by 1
+ order by 2 desc;
+
+-- 2. Who are the spelled-out rows?
+select count(*)::int                                              as spelled_out,
+       count(*) filter (where gp_api_user_id is not null)::int    as gp_api_users,
+       count(*) filter (where is_pledged)::int                    as pledged,
+       count(*) filter (
+         where exists (select 1 from "Candidacy"    c where c.person_id = p.id)
+            or exists (select 1 from "OfficeHolder" o where o.person_id = p.id)
+       )::int                                                     as with_civics
+  from "Person" p
+ where state is not null and length(btrim(state)) <> 2;
+
+-- 3. Most common spellings.
+select state, count(*)::int as persons
+  from "Person"
+ where state is not null and length(btrim(state)) <> 2
+ group by state
+ order by 2 desc
+ limit 12;
+```
+
+Figures above were measured 2026-08-25.
+
+## Suggested fix
+
+Map the full name to the USPS code wherever these rows are built, so `state` is a
+code for every row regardless of source. Two things to decide:
+
+- **Values that are neither.** `Puerto Rico` and similar appear upstream and have
+  no `/elections` page. gp-marketing now resolves those to `null` rather than
+  passing them through. A null is easy to handle; a value that only *looks* like a
+  code is what caused this.
+- **Null states.** 20,636 rows have no state at all. Out of scope here, but they
+  are unreachable by the same sweep, so worth knowing whether that is expected.
+
+## Separately, and probably more important
+
+While investigating we found two things that are not about state at all, and are
+worth their own conversation:
+
+1. **Duplicate Person rows.** 1,775 name pairs where one row is a real product
+   user and its twin is a completely empty shell; 1,419 of those have the pledge
+   on the row nobody is looking at. This produces public pages that tell visitors
+   someone has *not* taken a pledge they did take.
+2. **Product data never reaches the public profile.** `PersonProfile` in gp-api is
+   populated only by the profile editor — there is no sync from `Campaign` in
+   either direction. A candidate who completed Win onboarding has to retype all of
+   it to get anything on their public page.

--- a/src/constants/usStateCodes.ts
+++ b/src/constants/usStateCodes.ts
@@ -24,7 +24,7 @@ export function isValidStateCode(code: string | null | undefined): code is USSta
 
 /** Full state name (lowercased) → code, for normalizing a spelled-out state. */
 const CODE_BY_STATE_NAME = new Map<string, USStateCode>(
-	US_STATES_TUPLES.map(([code, name]) => [name.toLowerCase(), code as USStateCode]),
+	US_STATES_TUPLES.map(([code, name]): [string, USStateCode] => [name.toLowerCase(), code]),
 );
 
 /**

--- a/src/constants/usStateCodes.ts
+++ b/src/constants/usStateCodes.ts
@@ -21,3 +21,29 @@ export function isValidStateCode(code: string | null | undefined): code is USSta
 	}
 	return US_STATE_CODES.includes(code.toUpperCase() as USStateCode);
 }
+
+/** Full state name (lowercased) → code, for normalizing a spelled-out state. */
+const CODE_BY_STATE_NAME = new Map<string, USStateCode>(
+	US_STATES_TUPLES.map(([code, name]) => [name.toLowerCase(), code as USStateCode]),
+);
+
+/**
+ * Coerces a state to its two-letter code, accepting either spelling.
+ *
+ * `Person.state` is treated as a code everywhere downstream — it builds
+ * `/elections/<code>` and fills schema.org `addressRegion` — but the mart does
+ * not guarantee one. Rows sourced from BallotReady carry `MN`; rows the ETL
+ * creates from a gp-api account carry `Minnesota`, which is gp-api's own
+ * format passed straight through. Lowercasing that second shape produced
+ * `/elections/minnesota`, which 404s.
+ *
+ * Returns null for anything that is neither, so a caller can tell "no state"
+ * from "a state I cannot place" rather than propagating a value that only
+ * looks like a code.
+ */
+export function normalizeStateCode(value: string | null | undefined): USStateCode | null {
+	if (!value || typeof value !== 'string') return null;
+	const trimmed = value.trim();
+	if (isValidStateCode(trimmed)) return trimmed.toUpperCase() as USStateCode;
+	return CODE_BY_STATE_NAME.get(trimmed.toLowerCase()) ?? null;
+}

--- a/src/lib/peopleProfile.test.ts
+++ b/src/lib/peopleProfile.test.ts
@@ -838,6 +838,21 @@ describe('composeView issues, links, labels', () => {
 		expect(view.stateLabel).toBe('CA');
 	});
 
+	test('a spelled-out state becomes the code the routes and schema.org expect', () => {
+		// The mart sends `Minnesota` rather than `MN` for rows it created from a
+		// gp-api account instead of from BallotReady — 24,619 of them. stateLabel
+		// fills schema.org `addressRegion` and mirrors the breadcrumb, both of
+		// which are codes, so the full name has to be resolved here and not
+		// passed through.
+		const view = composeView(PID, makePerson({ fullName: 'DeVelle Jackson', state: 'Minnesota' }), null);
+		expect(view.stateLabel).toBe('MN');
+	});
+
+	test('a state that maps to no code is dropped rather than passed through', () => {
+		const view = composeView(PID, makePerson({ fullName: 'Ana Ruiz', state: 'Puerto Rico' }), null);
+		expect(view.stateLabel).toBeNull();
+	});
+
 	test('canonicalSlug uses the spine base slug + id8 suffix, not the overlay display name', () => {
 		const view = composeView(
 			PID,

--- a/src/lib/peopleProfile.ts
+++ b/src/lib/peopleProfile.ts
@@ -11,6 +11,7 @@ import {
 	getVoterDensityForDistrict,
 } from '~/lib/electionsApi';
 import { US_STATES_TUPLES } from '~/constants/usStates';
+import { normalizeStateCode } from '~/constants/usStateCodes';
 import {
 	buildElectionPositionHrefFromRaceSlug,
 	getStateName,
@@ -893,8 +894,11 @@ export function composeView(
 	const party = rawParty ?? (partyClass ? PARTY_LABELS[partyClass] : null);
 	const districtLabel = office?.subAreaValue ?? office?.subAreaName ?? null;
 	// Mirror the loader's stateCode (which includes the candidacy fallback) so a
-	// candidate-only person's sidebar label matches their breadcrumb.
-	const stateLabel = extras.stateCode ?? office?.state ?? person?.state ?? null;
+	// candidate-only person's sidebar label matches their breadcrumb. Normalized
+	// for the same reason the loader normalizes: this is a code by contract (it
+	// fills schema.org `addressRegion`) and the feed does not always send one.
+	const stateLabel =
+		extras.stateCode ?? normalizeStateCode(office?.state ?? person?.state) ?? null;
 	// `positionHref` was resolved from whichever candidacy selectPrimaryCandidacy
 	// picked, so Recent Experience has to key off that same candidacy — matching
 	// on anything looser would hang the breadcrumb's position link on a different
@@ -1213,7 +1217,10 @@ export async function loadPersonProfile(personId: string): Promise<PersonProfile
 			slug: raceSlug ?? undefined,
 			positionLevel: positionLevel ?? undefined,
 		}) ?? null;
-	const stateCode = office?.state ?? person?.state ?? candidacy?.state ?? null;
+	// A code by contract — it builds `/elections/<code>` in the breadcrumb — but
+	// the mart sends `Minnesota` for rows it created from a gp-api account
+	// rather than from BallotReady, which lowercased to a 404 crumb.
+	const stateCode = normalizeStateCode(office?.state ?? person?.state ?? candidacy?.state);
 
 	const composedName = [person?.firstName, person?.lastName].filter(Boolean).join(' ');
 	const displayName =

--- a/src/lib/personStateNormalization.test.ts
+++ b/src/lib/personStateNormalization.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from 'bun:test';
+import { normalizeStateCode } from '~/constants/usStateCodes';
+import { US_STATES_TUPLES } from '~/constants/usStates';
+import { buildBreadcrumbTrail } from '~/lib/peopleProfile';
+
+/**
+ * `Person.state` is a two-letter code by contract — the breadcrumb lowercases it
+ * into `/elections/<code>` and the profile's JSON-LD uses it for schema.org
+ * `addressRegion` — but the mart does not guarantee one.
+ *
+ * Rows sourced from BallotReady carry `MN`. Rows the ETL creates from a gp-api
+ * account carry `Minnesota`, gp-api's own format passed through: 24,619 rows on
+ * 2026-08-25, of which 24,385 are gp-api users, 18,893 took the pledge, and
+ * zero have any candidacy or office term. Every one of those pages linked to
+ * `/elections/minnesota` (or /california, /texas...), which 404s, while
+ * `/elections/mn` serves 200 — including on the published, indexable profiles.
+ */
+
+describe('a spelled-out state normalizes to the code the routes expect', () => {
+	test('every state resolves from its full name as well as its code', () => {
+		for (const [code, name] of US_STATES_TUPLES) {
+			expect([name, normalizeStateCode(name)]).toEqual([name, code]);
+			expect([code, normalizeStateCode(code)]).toEqual([code, code]);
+		}
+	});
+
+	test('spelling and padding do not matter', () => {
+		expect(normalizeStateCode('minnesota')).toBe('MN');
+		expect(normalizeStateCode('  Minnesota  ')).toBe('MN');
+		expect(normalizeStateCode('mn')).toBe('MN');
+		// Multi-word names are the ones most likely to be typo'd upstream.
+		expect(normalizeStateCode('north carolina')).toBe('NC');
+		expect(normalizeStateCode('District of Columbia')).toBe('DC');
+	});
+
+	test('an unplaceable value is null, not something that looks like a code', () => {
+		// Returning the input would put the 404 back: the caller cannot tell a
+		// real code from a passthrough, which is exactly how `Minnesota` shipped.
+		expect(normalizeStateCode('Puerto Rico')).toBeNull();
+		expect(normalizeStateCode('XX')).toBeNull();
+		expect(normalizeStateCode('')).toBeNull();
+		expect(normalizeStateCode(null)).toBeNull();
+		expect(normalizeStateCode(undefined)).toBeNull();
+	});
+});
+
+describe('the breadcrumb links somewhere that exists', () => {
+	const crumbs = (stateCode: string | null) =>
+		buildBreadcrumbTrail({
+			displayName: 'DeVelle Jackson',
+			stateCode,
+			raceSlug: null,
+			positionLevel: null,
+			positionName: null,
+		});
+
+	test('a code-spelled state builds the state URL', () => {
+		expect(crumbs('MN')[1]).toEqual({ href: '/elections/mn', label: 'Minnesota' });
+	});
+
+	test('a normalized full name builds the same URL, not /elections/minnesota', () => {
+		// The regression: `Minnesota`.toLowerCase() is a 404. Callers normalize
+		// before handing the value over, so the trail only ever sees a code.
+		const state = normalizeStateCode('Minnesota');
+		expect(state).toBe('MN');
+		expect(crumbs(state)[1]).toEqual({ href: '/elections/mn', label: 'Minnesota' });
+	});
+
+	test('no state at all drops the crumb rather than linking nowhere', () => {
+		const trail = crumbs(normalizeStateCode('Puerto Rico'));
+		expect(trail.map((c) => c.label)).toEqual(['Elections', 'DeVelle Jackson']);
+	});
+});


### PR DESCRIPTION
## What's wrong

Every `/people` profile in one large cohort links to a breadcrumb URL that 404s.

| URL | status |
| --- | --- |
| `/elections/mn`, `/elections/ok` | 200 |
| `/elections/minnesota`, `/elections/california`, `/elections/texas` | **404** |

## Why

`Person.state` is a two-letter code *by contract* — `buildBreadcrumbTrail` does `/elections/${stateCode.toLowerCase()}`, and `stateLabel` fills schema.org `addressRegion` — but the mart does not guarantee one.

Rows sourced from BallotReady carry `MN`. Rows the ETL creates from a gp-api account carry `Minnesota`, which is gp-api's own format passed straight through.

Measured on the election-api spine, 2026-08-25:

| | rows |
| --- | --- |
| `Person` rows whose state is not a 2-letter code | **24,619** |
| ...of those, linked to a gp-api user | 24,385 |
| ...of those, `is_pledged` | 18,893 |
| ...of those, with any candidacy or office term | **0** |

The spelling is effectively a fingerprint of the product-created cohort.

`getStateName` hid this in the UI, because it falls back to echoing its input — so the crumb *reads* "California" and just doesn't go anywhere. It is visible on the published, indexable profiles too, e.g. [david-patterson-65b96bee](https://goodparty.org/people/david-patterson-65b96bee) emits `/elections/california`. Those are the crumbs a crawler actually follows.

## The fix

`normalizeStateCode()` accepts either spelling and returns the code, built from the existing `US_STATES_TUPLES` (no new data). Applied at the two points the view derives a state.

Anything that resolves to neither returns `null`, so the crumb is **dropped** rather than pointed at a guess — passing the input through is precisely what shipped the 404. `Puerto Rico` is the realistic case: it appears upstream and has no `/elections` page.

## Verification

- `personStateNormalization.test.ts` round-trips all 51 codes and names, pins the trimming/casing, pins that unplaceable values are null, and pins the built URL.
- Two assertions in `peopleProfile.test.ts` pin the call sites through `composeView`. Confirmed non-vacuous: both fail when the call-site change is reverted while the helper stays.
- `typecheck` clean; 822 logic + 57 DOM tests pass.

## Not in scope

The durable fix is normalizing `state` in the dbt mart (`m_election_api__person.sql`), which would make this a no-op safety net. Filed separately with the data team — this is defensive normalization at the consumer so the 404s stop now.

There is a second symptom from the same root cause: the sitemap enumerates people by sweeping `v1/persons?state=<code>` over the 51 codes, so this cohort is unreachable and a published profile among them can never be listed. Four already are in that state. That needs its own change to the enumeration and is not addressed here.

Made with [Cursor](https://cursor.com)