### PR TITLE
fix(sitemap): enumerate published people by id, not by state sweep

### DIFF
--- a/src/lib/sitemap-entries.test.ts
+++ b/src/lib/sitemap-entries.test.ts
@@ -458,6 +458,78 @@ describe('fetchPeopleSitemapEntries', () => {
 		]);
 	});
 
+	/**
+	 * The cohort behind that exemption is exactly the one no sweep can see.
+	 *
+	 * `Person.state` holds a spelled-out `Minnesota` for rows the ETL creates
+	 * from a gp-api account rather than from BallotReady — 24,619 of them, and
+	 * none with a candidacy or office term. So `?state=MN` misses them and the
+	 * linked-feed union has nothing to recover them with. Unpublished that is
+	 * correct; published it silently dropped the page, which is the one
+	 * direction this band is not allowed to take. Four live profiles were in
+	 * that state when this was written.
+	 */
+	test('lists a published person no state sweep and no civics feed can reach', async () => {
+		mockUpstream({
+			persons: [{ id: aliceId, slug: 'alice-smith', state: 'Minnesota' }],
+			published: [{ personId: aliceId, updatedAt: '2026-01-15T00:00:00.000Z' }],
+		});
+
+		expect((await fetchPeopleSitemapEntries(base, 'a')).map((e) => e.url)).toEqual([
+			`${base}/people/alice-smith-aaaaaaaa`,
+		]);
+	});
+
+	test('resolves the seeded published ids through the batch filter, not one call each', async () => {
+		const urls = mockUpstream({
+			persons: [
+				{ id: bobId, slug: 'bob-jones', state: 'Oklahoma' },
+				{ id: carolId, slug: 'carol-diaz', state: 'Tennessee' },
+			],
+			published: [{ personId: bobId }, { personId: carolId }],
+		});
+
+		await fetchPeopleSitemapEntries(base, 'b');
+
+		const idCalls = urls.filter((u) => u.includes('ids='));
+		expect(idCalls).toHaveLength(1);
+		expect(decodeURIComponent(idCalls[0]!)).toContain(`${bobId},${carolId}`);
+	});
+
+	test('does not re-request a published person the sweep already returned', async () => {
+		const urls = mockUpstream({
+			persons: [{ id: aliceId, slug: 'alice-smith', state: 'WY' }],
+			published: [{ personId: aliceId }],
+		});
+
+		await fetchPeopleSitemapEntries(base, 'a');
+
+		expect(urls.filter((u) => u.includes('ids='))).toEqual([]);
+	});
+
+	// Seeding cannot invent a page: gp-api can hold a profile for a personId the
+	// spine has no row for, and without a slug there is no URL to advertise.
+	test('ignores a published id the spine does not know', async () => {
+		mockUpstream({
+			persons: [],
+			published: [{ personId: aliceId }],
+		});
+
+		expect(await fetchPeopleSitemapEntries(base, 'a')).toEqual([]);
+	});
+
+	// Seeding must not outrank the exclusion list: publish-then-request-removal
+	// would otherwise advertise a page the owner asked us to take down.
+	test('still omits a seeded person who is also unlisted', async () => {
+		mockUpstream({
+			persons: [{ id: aliceId, slug: 'alice-smith', state: 'Minnesota' }],
+			published: [{ personId: aliceId }],
+			unlisted: [{ personId: aliceId }],
+		});
+
+		expect(await fetchPeopleSitemapEntries(base, 'a')).toEqual([]);
+	});
+
 	test('skips a person with no slug, since there is no URL to point at', async () => {
 		mockUpstream({
 			persons: [{ id: aliceId, slug: '', state: 'WY' }],

--- a/src/lib/sitemap-entries.ts
+++ b/src/lib/sitemap-entries.ts
@@ -717,11 +717,19 @@ async function mapWithConcurrency<T, R>(
  * unreachable through it (~8% of the corpus, 17k of 216k when this was written)
  * because there is no way to ask for `state IS NULL`.
  *
- * The upstream mart defines the Person table as "people with a candidacy or
- * office term", so the candidacy and officeholder feeds between them name every
- * person that exists — and both DO carry a usable state. Unioning their
+ * The upstream mart used to define the Person table as "people with a candidacy
+ * or office term", which made the candidacy and officeholder feeds — both of
+ * which DO carry a usable state — name every person that exists. Unioning their
  * personIds and resolving anything the sweep missed back through the 500-id
- * batch filter closes the gap exactly, rather than approximately.
+ * batch filter closed the gap exactly.
+ *
+ * That invariant no longer holds: 132,015 Person rows have neither, most of
+ * them created from a gp-api account rather than from BallotReady. They are
+ * unreachable by every filter here, since the sweep cannot see them (their
+ * `state` is often spelled out, and there is no way to ask for `state IS NULL`)
+ * and they appear in no linked feed. Unpublished that is harmless — they are
+ * thin and belong out of the sitemap — so the gap is closed only where it
+ * matters, by seeding the id batch with the published ids (`seedPersonIds`).
  *
  * If election-api ever grows a cursor or a dedicated enumeration feed, this
  * whole dance collapses into a single paged read.
@@ -733,7 +741,9 @@ async function mapWithConcurrency<T, R>(
  * it" for the whole corpus at the cost of one extra projected column — rather
  * than 216k profile loads.
  */
-async function fetchAllPersons(): Promise<PersonEnumeration> {
+async function fetchAllPersons(
+	seedPersonIds: readonly string[] = [],
+): Promise<PersonEnumeration> {
 	const tags = [PEOPLE_SITEMAP_CACHE_TAG];
 	const states = [...US_STATE_CODES];
 	const byId = new Map<string, PeopleSitemapPerson>();
@@ -786,6 +796,25 @@ async function fetchAllPersons(): Promise<PersonEnumeration> {
 		}
 	}
 
+	// Published people are resolved by id rather than trusted to the sweeps.
+	//
+	// Both the state sweep and the linked feeds filter on `state`, and neither
+	// reaches this cohort: `Person.state` holds a spelled-out `Minnesota` for
+	// rows the ETL creates from a gp-api account (24,619 of them, none with a
+	// candidacy or office term), so no `?state=<code>` sweep returns them, and
+	// having no civics rows there is nothing in the linked feeds to rescue them
+	// with. Unpublished, that is the right answer — they are thin and belong out
+	// of the sitemap. Published, it is not: the page renders `index`, and
+	// dropping it here is the one direction this band is not allowed to take.
+	// Four published profiles were already missing when this was written.
+	//
+	// Seeding by id sidesteps the spelling entirely, so this stays correct even
+	// if the mart never normalizes. An id with no spine row simply resolves to
+	// nothing, exactly as an unmatched linked-feed id does today.
+	for (const id of seedPersonIds) {
+		if (!byId.has(id)) unseen.add(id);
+	}
+
 	const batches = await mapWithConcurrency(
 		chunkArray([...unseen], PERSON_ID_BATCH),
 		ENUMERATION_CONCURRENCY,
@@ -825,7 +854,10 @@ export function clearPeopleSitemapCache(): void {
 async function getCachedPeopleSitemapData(): Promise<PeopleSitemapData> {
 	if (!cachedPeopleSitemapData) {
 		const load = (async (): Promise<PeopleSitemapData> => {
-			const [published, unlisted, enumeration] = await Promise.all([
+			// The two gp-api feeds are one small request each and settle long before
+			// the 153-request enumeration would; awaiting them first costs a round
+			// trip and buys the published ids, which the enumeration needs as seeds.
+			const [published, unlisted] = await Promise.all([
 				fetchGpApiJsonOrThrow<{ personId?: string; updatedAt?: string }>(
 					'v1/public-person-profiles/published',
 					[PEOPLE_SITEMAP_CACHE_TAG],
@@ -833,13 +865,14 @@ async function getCachedPeopleSitemapData(): Promise<PeopleSitemapData> {
 				fetchGpApiJsonOrThrow<{ personId?: string }>('v1/public-person-profiles/unlisted', [
 					PEOPLE_SITEMAP_CACHE_TAG,
 				]),
-				fetchAllPersons(),
 			]);
 
 			const updatedByPersonId = new Map<string, string | undefined>();
 			for (const row of published) {
 				if (row.personId) updatedByPersonId.set(row.personId.toLowerCase(), row.updatedAt);
 			}
+
+			const enumeration = await fetchAllPersons([...updatedByPersonId.keys()]);
 
 			// Two different reasons, one consequence: a person with a privacy removal
 			// on record renders noindex, and a person whose owner deleted their


### PR DESCRIPTION
## What's wrong

Four published, indexable `/people` profiles are missing from the production sitemap. Verified against the live shards:

| published profile | `Person.state` | civics data | in sitemap |
| --- | --- | --- | --- |
| `sean-matteson-d1d88988` | `NC` | yes | yes |
| `matthew-janson-e2f25d7b` | `MT` | yes | yes |
| `david-patterson-65b96bee` | `California` | no | **no** |
| `valentin-pena-1b1555a1` | `Oklahoma` | no | **no** |
| `james-macon-03ba19fc` | `Tennessee` | no | **no** |
| `kasen-hampton-623ac0fe` | `Florida` | no | **no** |

All four render with no robots tag — they are indexable — and nothing advertises them.

## Why

The band enumerates by sweeping `v1/persons?state=<code>` over the 51 codes, then recovers anyone the sweep missed via the candidacy/officeholder feeds. `fetchAllPersons`'s own comment justifies that as complete because *"the upstream mart defines the Person table as people with a candidacy or office term."*

**That invariant no longer holds.** 132,015 rows have neither. And 24,619 of them carry a spelled-out state, because the ETL creates them from a gp-api account and passes gp-api's own format through:

| | rows |
| --- | --- |
| `Person` rows whose state is not a 2-letter code | 24,619 |
| ...linked to a gp-api user | 24,385 |
| ...`is_pledged` | 18,893 |
| ...with any candidacy or office term | **0** |

election-api filters with `...(state && { state })` — exact equality, no normalization — so `?state=MN` never returns a `Minnesota` row, and with no civics rows the linked-feed union has nothing to recover them with. They are invisible to every filter in this function.

Unpublished, that is the **right** answer: they are thin, they render `noindex`, and they belong out of the sitemap. Published, it is not — and per this file's own reasoning, dropping a URL that renders `index` is the one direction the band is not allowed to take.

## The fix

Seed the existing `?ids=` batch with the published `personId`s. That sidesteps the state spelling entirely, so it stays correct whether or not the mart is ever normalized, and it costs nothing for the ~24.6k unpublished rows, which remain correctly excluded.

Ordering changes slightly: the two gp-api feeds are one small request each and are now awaited before the 153-request enumeration, which needs their ids. One round trip.

Also corrects the stale invariant in the doc comment, which is what made a state sweep look like complete coverage.

## Verification

Five new tests: the unreachable published person is listed; seeded ids go through the batch rather than one call each; a person the sweep already returned is not re-requested; a published id with no spine row is ignored rather than inventing a URL; and a seeded person who is also unlisted stays omitted, so seeding cannot outrank a takedown.

Confirmed non-vacuous — the first two fail when the seed argument is dropped. `typecheck` clean; 819 logic + 57 DOM tests pass.

## Related

[#256](https://github.com/thegoodparty/gp-marketing/pull/256) fixes the other symptom of the same root cause: those pages also emit a breadcrumb to `/elections/minnesota`, which 404s. Independent files, no conflict.

The durable fix is normalizing `state` in the dbt mart; this change is deliberately independent of it.

Made with [Cursor](https://cursor.com)